### PR TITLE
fix: flip portal overlay coordinate system to match SwiftUI

### DIFF
--- a/Macterm/Ghostty/TerminalPortal.swift
+++ b/Macterm/Ghostty/TerminalPortal.swift
@@ -103,6 +103,8 @@ final class TerminalPortalHost {
 /// A transparent NSView that hosts all terminal views.
 /// Passes hit testing through to terminal subviews.
 final class TerminalOverlayView: NSView {
+    override var isFlipped: Bool { true }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = false


### PR DESCRIPTION
Clicking vertical split panes focused the wrong pane because the
overlay used bottom-left origin while SwiftUI uses top-left.

Closes #1 
