### PR TITLE
feat: zoom split pane (Cmd+Shift+Enter)

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -16,6 +16,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
     // Panes
     case splitRight
     case splitDown
+    case zoomPane
     case focusLeft
     case focusRight
     case focusUp
@@ -45,6 +46,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .recentTab: "Recent tab"
         case .splitRight: "Split right"
         case .splitDown: "Split down"
+        case .zoomPane: "Zoom pane"
         case .focusLeft: "Focus left"
         case .focusRight: "Focus right"
         case .focusUp: "Focus up"
@@ -72,6 +74,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
              .recentTab: .tabs
         case .splitRight,
              .splitDown,
+             .zoomPane,
              .focusLeft,
              .focusRight,
              .focusUp,
@@ -101,6 +104,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .recentTab: .recentTab
         case .splitRight: .splitRight
         case .splitDown: .splitDown
+        case .zoomPane: .zoomPane
         case .focusLeft: .focusPaneLeft
         case .focusRight: .focusPaneRight
         case .focusUp: .focusPaneUp

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -232,6 +232,13 @@ final class AppState {
         saveWorkspaces()
     }
 
+    func toggleZoom(projectID: UUID) {
+        guard let tab = workspaces[projectID]?.activeTab,
+              let paneID = tab.focusedPaneID
+        else { return }
+        tab.toggleZoom(paneID: paneID)
+    }
+
     func closePane(_ paneID: UUID, projectID: UUID) {
         guard let ws = workspaces[projectID] else { return }
         // Find the tab that actually contains this pane (not just the active tab)

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -28,6 +28,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
     case resizePaneRight = "resize_pane_right"
     case closeWindow = "close_window"
     case openProject = "open_project"
+    case zoomPane = "zoom_pane"
 
     var id: String { rawValue }
 
@@ -59,6 +60,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .resizePaneRight: "cmd+shift+l"
         case .closeWindow: "cmd+shift+w"
         case .openProject: "cmd+o"
+        case .zoomPane: "cmd+shift+return"
         }
     }
 }

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -77,6 +77,11 @@ final class QuickTerminalResponder: KeyResponder {
             state.requestClosePane(paneID)
             return .handled
         }
+        if HotkeyRegistry.matches(event, action: .zoomPane) {
+            guard let paneID = state.focusedPaneID else { return .passThrough }
+            state.tab.toggleZoom(paneID: paneID)
+            return .handled
+        }
         if let (_, dir) = Self.focusActions.first(where: { HotkeyRegistry.matches(event, action: $0.0) }) {
             guard let focusedID = state.focusedPaneID else { return .passThrough }
             if let bestID = state.splitRoot.nearestPane(from: focusedID, direction: dir) {
@@ -174,6 +179,12 @@ final class MainAppResponder: KeyResponder {
         if HotkeyRegistry.matches(event, action: .splitDown) {
             guard let projectID = appState.activeProjectID else { return .passThrough }
             appState.splitPane(direction: .vertical, projectID: projectID)
+            return .handled
+        }
+
+        if HotkeyRegistry.matches(event, action: .zoomPane) {
+            guard let projectID = appState.activeProjectID else { return .passThrough }
+            appState.toggleZoom(projectID: projectID)
             return .handled
         }
 

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -7,6 +7,10 @@ final class TerminalTab: Identifiable {
     var customTitle: String?
     var splitRoot: SplitNode
     var focusedPaneID: UUID?
+    /// When set, the split tree renders only this pane (zoom). The tree
+    /// itself is untouched — clearing this restores the full layout.
+    /// Transient: not persisted across launches.
+    var zoomedPaneID: UUID?
     /// Most-recent-first stack of previously focused pane IDs
     /// (excludes the currently focused pane).
     @ObservationIgnored
@@ -71,6 +75,18 @@ final class TerminalTab: Identifiable {
     // need persistence (AppState) handle saveWorkspaces themselves after calling
     // these; the quick terminal doesn't persist.
 
+    /// Toggle zoom for `paneID`. While zoomed, the tab renders only that pane;
+    /// toggling off (or zooming a different pane) restores the full split view.
+    func toggleZoom(paneID: UUID) {
+        guard splitRoot.findPane(id: paneID) != nil else { return }
+        if zoomedPaneID == paneID {
+            zoomedPaneID = nil
+        } else {
+            zoomedPaneID = paneID
+            focusPane(paneID)
+        }
+    }
+
     /// Split the focused pane (or a specific pane) in `direction`, placing the
     /// new pane in the `.second` position. Returns the new pane ID if created.
     @discardableResult
@@ -82,6 +98,8 @@ final class TerminalTab: Identifiable {
             paneID: paneID, direction: direction, position: .second, projectPath: sourcePath
         )
         splitRoot = newRoot
+        // Splitting reveals a new pane — exit zoom so it's visible.
+        zoomedPaneID = nil
         if let newID { focusPane(newID) }
         if Preferences.shared.autoTilingEnabled { splitRoot.rebalanced() }
         return newID
@@ -106,6 +124,7 @@ final class TerminalTab: Identifiable {
         }
         guard let newRoot = splitRoot.removing(paneID: paneID) else { return .notFound }
         splitRoot = newRoot
+        if zoomedPaneID == paneID { zoomedPaneID = nil }
         paneFocusHistory.remove(paneID)
         if focusedPaneID == paneID {
             focusedPaneID = nextFocusAfterClose()

--- a/Macterm/Palette/CommandSource.swift
+++ b/Macterm/Palette/CommandSource.swift
@@ -64,6 +64,9 @@ struct CommandSource: PaletteSource {
         case .splitDown:
             guard let projectID else { return nil }
             action = { ctx.appState.splitPane(direction: .vertical, projectID: projectID) }
+        case .zoomPane:
+            guard let projectID else { return nil }
+            action = { ctx.appState.toggleZoom(projectID: projectID) }
         case .focusLeft:
             guard let projectID else { return nil }
             action = { ctx.appState.focusPaneInDirection(.left, projectID: projectID) }

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -206,7 +206,38 @@ struct WorkspaceView: View {
                 onClosePane: { appState.requestClosePane($0, projectID: project.id) }
             )
             .id(renderedNode.id)
+            .overlay(alignment: .topTrailing) {
+                if tab.zoomedPaneID != nil {
+                    ZoomIndicator()
+                        .padding(8)
+                        .transition(.opacity)
+                }
+            }
         }
+    }
+}
+
+/// Small badge shown in the corner of a tab while one of its panes is zoomed.
+/// Hidden when nothing is zoomed.
+struct ZoomIndicator: View {
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "arrow.up.left.and.arrow.down.right")
+            Text("Zoomed")
+        }
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(MactermTheme.fg)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(MactermTheme.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(MactermTheme.border, lineWidth: 1)
+                )
+        )
+        .allowsHitTesting(false)
     }
 }
 

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -196,6 +196,7 @@ struct WorkspaceView: View {
             SplitTreeView(
                 node: renderedNode,
                 focusedPaneID: tab.focusedPaneID,
+                zoomedPaneID: tab.zoomedPaneID,
                 isActiveProject: true,
                 projectID: project.id,
                 onFocusPane: { appState.focusPane($0, projectID: project.id) },
@@ -203,12 +204,13 @@ struct WorkspaceView: View {
                     tab.split(paneID: paneID, direction: dir)
                     appState.saveWorkspaces()
                 },
-                onClosePane: { appState.requestClosePane($0, projectID: project.id) }
+                onClosePane: { appState.requestClosePane($0, projectID: project.id) },
+                onToggleZoom: { tab.toggleZoom(paneID: $0) }
             )
             .id(renderedNode.id)
             .overlay(alignment: .topTrailing) {
                 if tab.zoomedPaneID != nil {
-                    ZoomIndicator()
+                    ZoomIndicator(onExit: { appState.toggleZoom(projectID: project.id) })
                         .padding(8)
                         .transition(.opacity)
                 }
@@ -218,26 +220,32 @@ struct WorkspaceView: View {
 }
 
 /// Small badge shown in the corner of a tab while one of its panes is zoomed.
-/// Hidden when nothing is zoomed.
+/// Clicking it exits zoom and restores the full split layout.
 struct ZoomIndicator: View {
+    let onExit: () -> Void
+
     var body: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "arrow.up.left.and.arrow.down.right")
-            Text("Zoomed")
+        Button(action: onExit) {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.down.right.and.arrow.up.left")
+                Text("Zoomed")
+            }
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(MactermTheme.fg)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(MactermTheme.surface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(MactermTheme.border, lineWidth: 1)
+                    )
+            )
+            .contentShape(Rectangle())
         }
-        .font(.system(size: 11, weight: .medium))
-        .foregroundStyle(MactermTheme.fg)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(MactermTheme.surface)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .stroke(MactermTheme.border, lineWidth: 1)
-                )
-        )
-        .allowsHitTesting(false)
+        .buttonStyle(.plain)
+        .help("Exit zoom")
     }
 }
 

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -187,8 +187,14 @@ struct WorkspaceView: View {
 
     var body: some View {
         if let ws = appState.workspaces[project.id], let tab = ws.activeTab {
+            let renderedNode: SplitNode = {
+                if let zoomID = tab.zoomedPaneID, let pane = tab.splitRoot.findPane(id: zoomID) {
+                    return .pane(pane)
+                }
+                return tab.splitRoot
+            }()
             SplitTreeView(
-                node: tab.splitRoot,
+                node: renderedNode,
                 focusedPaneID: tab.focusedPaneID,
                 isActiveProject: true,
                 projectID: project.id,
@@ -199,7 +205,7 @@ struct WorkspaceView: View {
                 },
                 onClosePane: { appState.requestClosePane($0, projectID: project.id) }
             )
-            .id(tab.splitRoot.id)
+            .id(renderedNode.id)
         }
     }
 }

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -348,5 +348,12 @@ private struct QuickTerminalView: View {
         )
         .id(renderedNode.id)
         .background(Color(nsColor: GhosttyApp.shared.backgroundColor))
+        .overlay(alignment: .topTrailing) {
+            if state.tab.zoomedPaneID != nil {
+                ZoomIndicator()
+                    .padding(8)
+                    .transition(.opacity)
+            }
+        }
     }
 }

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -340,17 +340,19 @@ private struct QuickTerminalView: View {
         SplitTreeView(
             node: renderedNode,
             focusedPaneID: state.focusedPaneID,
+            zoomedPaneID: state.tab.zoomedPaneID,
             isActiveProject: true,
             projectID: Self.projectID,
             onFocusPane: { state.focusPane($0) },
             onSplit: { paneID, dir in state.split(paneID: paneID, direction: dir) },
-            onClosePane: { state.closePane($0) }
+            onClosePane: { state.closePane($0) },
+            onToggleZoom: { state.tab.toggleZoom(paneID: $0) }
         )
         .id(renderedNode.id)
         .background(Color(nsColor: GhosttyApp.shared.backgroundColor))
         .overlay(alignment: .topTrailing) {
-            if state.tab.zoomedPaneID != nil {
-                ZoomIndicator()
+            if let zoomID = state.tab.zoomedPaneID {
+                ZoomIndicator(onExit: { state.tab.toggleZoom(paneID: zoomID) })
                     .padding(8)
                     .transition(.opacity)
             }

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -331,8 +331,14 @@ private struct QuickTerminalView: View {
     @Bindable var state: QuickTerminalSplitState
 
     var body: some View {
+        let renderedNode: SplitNode = {
+            if let zoomID = state.tab.zoomedPaneID, let pane = state.splitRoot.findPane(id: zoomID) {
+                return .pane(pane)
+            }
+            return state.splitRoot
+        }()
         SplitTreeView(
-            node: state.splitRoot,
+            node: renderedNode,
             focusedPaneID: state.focusedPaneID,
             isActiveProject: true,
             projectID: Self.projectID,
@@ -340,7 +346,7 @@ private struct QuickTerminalView: View {
             onSplit: { paneID, dir in state.split(paneID: paneID, direction: dir) },
             onClosePane: { state.closePane($0) }
         )
-        .id(state.splitRoot.id)
+        .id(renderedNode.id)
         .background(Color(nsColor: GhosttyApp.shared.backgroundColor))
     }
 }

--- a/Macterm/Views/SplitTreeView.swift
+++ b/Macterm/Views/SplitTreeView.swift
@@ -5,31 +5,37 @@ import SwiftUI
 struct SplitTreeView: View {
     let node: SplitNode
     let focusedPaneID: UUID?
+    let zoomedPaneID: UUID?
     let isActiveProject: Bool
     let projectID: UUID
     let isSplit: Bool
     let onFocusPane: (UUID) -> Void
     let onSplit: (UUID, SplitDirection) -> Void
     let onClosePane: (UUID) -> Void
+    let onToggleZoom: (UUID) -> Void
 
     init(
         node: SplitNode,
         focusedPaneID: UUID?,
+        zoomedPaneID: UUID? = nil,
         isActiveProject: Bool,
         projectID: UUID,
         isSplit: Bool = false,
         onFocusPane: @escaping (UUID) -> Void,
         onSplit: @escaping (UUID, SplitDirection) -> Void,
-        onClosePane: @escaping (UUID) -> Void
+        onClosePane: @escaping (UUID) -> Void,
+        onToggleZoom: @escaping (UUID) -> Void = { _ in }
     ) {
         self.node = node
         self.focusedPaneID = focusedPaneID
+        self.zoomedPaneID = zoomedPaneID
         self.isActiveProject = isActiveProject
         self.projectID = projectID
         self.isSplit = isSplit
         self.onFocusPane = onFocusPane
         self.onSplit = onSplit
         self.onClosePane = onClosePane
+        self.onToggleZoom = onToggleZoom
     }
 
     var body: some View {
@@ -39,9 +45,11 @@ struct SplitTreeView: View {
             TerminalPane(
                 pane: pane,
                 focused: isFocused,
+                isZoomed: zoomedPaneID == pane.id,
                 onFocus: { onFocusPane(pane.id) },
                 onProcessExit: { onClosePane(pane.id) },
-                onSplitRequest: { dir, _ in onSplit(pane.id, dir) }
+                onSplitRequest: { dir, _ in onSplit(pane.id, dir) },
+                onZoomRequest: { onToggleZoom(pane.id) }
             )
             .overlay {
                 if !isFocused, isSplit {
@@ -55,24 +63,28 @@ struct SplitTreeView: View {
                 SplitTreeView(
                     node: branch.first,
                     focusedPaneID: focusedPaneID,
+                    zoomedPaneID: zoomedPaneID,
                     isActiveProject: isActiveProject,
                     projectID: projectID,
                     isSplit: true,
                     onFocusPane: onFocusPane,
                     onSplit: onSplit,
-                    onClosePane: onClosePane
+                    onClosePane: onClosePane,
+                    onToggleZoom: onToggleZoom
                 )
                 .id(branch.first.id)
             } second: {
                 SplitTreeView(
                     node: branch.second,
                     focusedPaneID: focusedPaneID,
+                    zoomedPaneID: zoomedPaneID,
                     isActiveProject: isActiveProject,
                     projectID: projectID,
                     isSplit: true,
                     onFocusPane: onFocusPane,
                     onSplit: onSplit,
-                    onClosePane: onClosePane
+                    onClosePane: onClosePane,
+                    onToggleZoom: onToggleZoom
                 )
                 .id(branch.second.id)
             }

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -17,6 +17,8 @@ final class GhosttyTerminalNSView: NSView {
     var onFocus: (() -> Void)?
     var onProcessExit: (() -> Void)?
     var onSplitRequest: ((SplitDirection, SplitPosition) -> Void)?
+    var onZoomRequest: (() -> Void)?
+    var isZoomed: Bool = false
     var onSearchStart: ((String?) -> Void)?
     var onSearchEnd: (() -> Void)?
     var onSearchTotal: ((Int?) -> Void)?
@@ -455,7 +457,22 @@ final class GhosttyTerminalNSView: NSView {
         addSplitItem(menu, "Split Left", .horizontal, .first)
         addSplitItem(menu, "Split Down", .vertical, .second)
         addSplitItem(menu, "Split Up", .vertical, .first)
+        if onZoomRequest != nil {
+            menu.addItem(.separator())
+            let zoom = NSMenuItem(
+                title: isZoomed ? "Restore Pane" : "Zoom Pane",
+                action: #selector(handleZoom),
+                keyEquivalent: ""
+            )
+            zoom.target = self
+            menu.addItem(zoom)
+        }
         NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
+
+    @objc
+    private func handleZoom() {
+        onZoomRequest?()
     }
 
     private func addSplitItem(_ menu: NSMenu, _ title: String, _ dir: SplitDirection, _ pos: SplitPosition) {

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -4,9 +4,11 @@ import SwiftUI
 struct TerminalPane: View {
     let pane: Pane
     let focused: Bool
+    let isZoomed: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
+    let onZoomRequest: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -29,9 +31,11 @@ struct TerminalPane: View {
             TerminalSurface(
                 pane: pane,
                 focused: focused,
+                isZoomed: isZoomed,
                 onFocus: onFocus,
                 onProcessExit: onProcessExit,
-                onSplitRequest: onSplitRequest
+                onSplitRequest: onSplitRequest,
+                onZoomRequest: onZoomRequest
             )
         }
     }
@@ -44,9 +48,11 @@ struct TerminalPane: View {
 private struct TerminalSurface: NSViewRepresentable {
     let pane: Pane
     let focused: Bool
+    let isZoomed: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
+    let onZoomRequest: () -> Void
 
     final class Coordinator {
         var wasFocused = false
@@ -106,6 +112,8 @@ private struct TerminalSurface: NSViewRepresentable {
         view.onFocus = onFocus
         view.onProcessExit = onProcessExit
         view.onSplitRequest = onSplitRequest
+        view.onZoomRequest = onZoomRequest
+        view.isZoomed = isZoomed
         view.onTitleChange = { [weak pane] title in pane?.title = title }
         view.isFocused = focused
 

--- a/MactermTests/Model/TerminalTabTests.swift
+++ b/MactermTests/Model/TerminalTabTests.swift
@@ -136,6 +136,54 @@ struct TerminalTabTests {
         #expect(tab.splitRoot.allPanes().count == 2)
     }
 
+    // MARK: - toggleZoom
+
+    @Test
+    func toggleZoom_sets_and_clears_zoomedPaneID() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        let aID = try #require(ids["a"])
+        tab.toggleZoom(paneID: aID)
+        #expect(tab.zoomedPaneID == aID)
+        tab.toggleZoom(paneID: aID)
+        #expect(tab.zoomedPaneID == nil)
+    }
+
+    @Test
+    func toggleZoom_switches_focus_to_zoomed_pane() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        let bID = try #require(ids["b"])
+        tab.toggleZoom(paneID: bID)
+        #expect(tab.zoomedPaneID == bID)
+        #expect(tab.focusedPaneID == bID)
+    }
+
+    @Test
+    func toggleZoom_unknown_pane_is_noop() {
+        let (tab, _) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        tab.toggleZoom(paneID: UUID())
+        #expect(tab.zoomedPaneID == nil)
+    }
+
+    @Test
+    func split_while_zoomed_clears_zoom() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        let aID = try #require(ids["a"])
+        tab.toggleZoom(paneID: aID)
+        #expect(tab.zoomedPaneID == aID)
+        _ = tab.split(paneID: aID, direction: .horizontal)
+        #expect(tab.zoomedPaneID == nil)
+    }
+
+    @Test
+    func removing_zoomed_pane_clears_zoom() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        let bID = try #require(ids["b"])
+        tab.toggleZoom(paneID: bID)
+        #expect(tab.zoomedPaneID == bID)
+        #expect(try tab.removePane(bID) == .removed)
+        #expect(tab.zoomedPaneID == nil)
+    }
+
     @Test
     func removePane_prunes_history() throws {
         let (tab, ids) = makeTab(H(pane("a"), H(pane("b"), pane("c"))), focused: "a")


### PR DESCRIPTION
Closes #7

## Summary
- Adds a new `Zoom pane` action bound to `Cmd+Shift+Enter` (configurable in Settings) that toggles the focused pane to fill the tab, hiding all other splits until toggled off again.
- The split tree itself is untouched while zoomed — only the rendered view switches to a single pane — so toggling off restores the exact layout.
- Splitting while zoomed exits zoom so the new pane is visible; closing the zoomed pane clears the zoom state automatically.
- Wired into both the main window and the quick terminal, and exposed through the command palette.

## Test plan
- [x] Unit tests for `TerminalTab.toggleZoom`, split-while-zoomed, and close-zoomed-pane behavior
- [x] `mise run format` / `mise run lint` / `mise run test`
- [x] Manual: open multiple splits, press Cmd+Shift+Enter, verify focused pane fills the tab; press again to restore.
- [x] Manual: zoom one pane, split it (Cmd+D) — zoom should clear and both panes appear.
- [x] Manual: zoom a pane, close it (Cmd+W) — remaining panes render correctly with no stale zoom.
- [x] Manual: same flow in the quick terminal (Ctrl+\`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thdxg/codesmith/macterm/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->