### PR TITLE
feat: configurable window opacity and blur (Tahoe-only)

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -28,6 +28,67 @@ final class Preferences {
         }
     }
 
+    /// Empty string = use the ghostty default theme.
+    var theme: String {
+        didSet {
+            defaults.set(theme, forKey: Keys.theme)
+            notifyConfigChanged()
+        }
+    }
+
+    /// Empty string = use the ghostty default font.
+    var fontFamily: String {
+        didSet {
+            defaults.set(fontFamily, forKey: Keys.fontFamily)
+            notifyConfigChanged()
+        }
+    }
+
+    var fontSize: Int {
+        didSet {
+            defaults.set(fontSize, forKey: Keys.fontSize)
+            notifyConfigChanged()
+        }
+    }
+
+    /// One of "true", "false", "left", "right" — matches ghostty's accepted values.
+    var optionAsAlt: String {
+        didSet {
+            defaults.set(optionAsAlt, forKey: Keys.optionAsAlt)
+            notifyConfigChanged()
+        }
+    }
+
+    // MARK: - Window
+
+    /// Macterm-painted window background opacity (0–1). Independent from
+    /// ghostty's renderer — we always tell ghostty to render fully opaque
+    /// terminal content, then Macterm composites this translucency at the
+    /// window level. Avoids the double-paint problem when both layers tint.
+    var windowOpacity: Double {
+        didSet {
+            defaults.set(windowOpacity, forKey: Keys.windowOpacity)
+            notifyConfigChanged()
+        }
+    }
+
+    /// CGSSetWindowBackgroundBlurRadius value (0–100). 0 = no blur.
+    var windowBlurRadius: Int {
+        didSet {
+            defaults.set(windowBlurRadius, forKey: Keys.windowBlurRadius)
+            notifyConfigChanged()
+        }
+    }
+
+    /// Settings → file → libghostty reload pipeline. Each preference setter
+    /// that maps to ghostty config (theme, font, opacity, etc.) calls this so
+    /// the change propagates through the renderer and to any window-appearance
+    /// observers in one shot.
+    private func notifyConfigChanged() {
+        MactermConfig.shared.regenerate()
+        GhosttyApp.shared.reloadConfig()
+    }
+
     // MARK: - Quick terminal
 
     var quickTerminalEnabled: Bool {
@@ -58,6 +119,12 @@ final class Preferences {
     private init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
+        theme = defaults.string(forKey: Keys.theme) ?? "Rose Pine"
+        fontFamily = defaults.string(forKey: Keys.fontFamily) ?? ""
+        fontSize = defaults.object(forKey: Keys.fontSize) as? Int ?? 16
+        optionAsAlt = defaults.string(forKey: Keys.optionAsAlt) ?? "true"
+        windowOpacity = (defaults.object(forKey: Keys.windowOpacity) as? Double) ?? 1.0
+        windowBlurRadius = defaults.integer(forKey: Keys.windowBlurRadius)
         quickTerminalEnabled = defaults.object(forKey: Keys.quickTerminalEnabled) as? Bool ?? true
         quickTerminalWidthFraction = Self.clampFraction(defaults.double(forKey: Keys.quickTerminalWidth), fallback: 0.6)
         quickTerminalHeightFraction = Self.clampFraction(defaults.double(forKey: Keys.quickTerminalHeight), fallback: 0.5)
@@ -73,6 +140,12 @@ final class Preferences {
 
     enum Keys {
         static let autoTiling = "macterm.autoTiling.enabled"
+        static let theme = "macterm.appearance.theme"
+        static let fontFamily = "macterm.appearance.fontFamily"
+        static let fontSize = "macterm.appearance.fontSize"
+        static let optionAsAlt = "macterm.input.optionAsAlt"
+        static let windowOpacity = "macterm.window.opacity"
+        static let windowBlurRadius = "macterm.window.blurRadius"
         static let quickTerminalEnabled = "macterm.quickTerminal.enabled"
         static let quickTerminalWidth = "macterm.quickTerminal.width"
         static let quickTerminalHeight = "macterm.quickTerminal.height"

--- a/Macterm/Config/MactermConfig.swift
+++ b/Macterm/Config/MactermConfig.swift
@@ -33,14 +33,15 @@ final class MactermConfig {
         var lines: [String] = []
 
         // --- Macterm-managed window appearance ---
-        // Hand ghostty a fully-transparent terminal surface (background-opacity
-        // = 0). Ghostty draws only the text and cursor; the colored fill behind
-        // the text comes from Macterm's bgWithOpacity SwiftUI layer, which is
-        // the single source of window translucency. This avoids the double-tint
-        // that happens when both ghostty's renderer and SwiftUI tint the same
-        // pixels.
+        // Ghostty's terminal surface is fully transparent — it draws only the
+        // text and cursor. The colored fill behind the text comes from the
+        // window's `NSWindow.backgroundColor` (set in `WindowAppearance.sync`
+        // to the terminal color tinted by `Preferences.windowOpacity`), which
+        // is the single source of window translucency. Keeping all tinting on
+        // one layer avoids the double-paint that happens when both ghostty's
+        // renderer and SwiftUI/AppKit tint the same pixels.
         lines.append("background-opacity = 0")
-        // We drive window blur ourselves via the CGS SPI, not ghostty's wrapper.
+        // Blur is driven by our own CGS SPI call, not ghostty's wrapper.
         lines.append("background-blur = 0")
 
         // --- User-configurable via Settings UI ---

--- a/Macterm/Config/MactermConfig.swift
+++ b/Macterm/Config/MactermConfig.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+/// Generates the ghostty config file that libghostty loads. Macterm owns this
+/// config entirely — users do not edit it. All user-facing settings live in
+/// `Preferences` (UserDefaults); `regenerate()` reads them and writes a fresh
+/// ghostty.conf to App Support, which `GhosttyApp.loadConfig` then loads.
+///
+/// We force `background-opacity = 1` and `background-blur = 0` so ghostty's
+/// renderer draws fully opaque terminal content. Window translucency is
+/// composited at the window level by Macterm (see `WindowAppearance`),
+/// avoiding the double-paint that happens when both ghostty and Macterm
+/// tint the same pixels.
 @MainActor @Observable
 final class MactermConfig {
     static let shared = MactermConfig()
@@ -9,80 +19,51 @@ final class MactermConfig {
     private init() {
         let dir = FileStorage.appSupportDirectory()
         ghosttyConfigURL = dir.appendingPathComponent("ghostty.conf")
-        seedIfNeeded()
-        // Ensure option-as-alt is set for pre-existing installs that were
-        // seeded before this default became part of Macterm.
-        if value(for: "macos-option-as-alt") == nil {
-            updateValue("macos-option-as-alt", value: "true")
-        }
+        // Write a fresh config on every launch so the file always reflects
+        // the current Preferences state — no stale lines from previous runs.
+        regenerate()
     }
 
     var ghosttyConfigPath: String { ghosttyConfigURL.path }
 
-    func readConfig() -> String {
-        (try? String(contentsOf: ghosttyConfigURL, encoding: .utf8)) ?? ""
-    }
+    /// Rebuild the ghostty.conf file from current `Preferences` values.
+    /// Called on launch and whenever a relevant preference changes.
+    func regenerate() {
+        let prefs = Preferences.shared
+        var lines: [String] = []
 
-    func setManagedWindowPaddingTop(_ value: Int) {
-        updateValue("window-padding-top", value: String(max(0, value)))
-        updateValue("window-padding-balance", value: "false")
-    }
+        // --- Macterm-managed window appearance ---
+        // Hand ghostty a fully-transparent terminal surface (background-opacity
+        // = 0). Ghostty draws only the text and cursor; the colored fill behind
+        // the text comes from Macterm's bgWithOpacity SwiftUI layer, which is
+        // the single source of window translucency. This avoids the double-tint
+        // that happens when both ghostty's renderer and SwiftUI tint the same
+        // pixels.
+        lines.append("background-opacity = 0")
+        // We drive window blur ourselves via the CGS SPI, not ghostty's wrapper.
+        lines.append("background-blur = 0")
 
-    func updateValue(_ key: String, value: String) {
-        var lines = readConfig().components(separatedBy: "\n")
-        let entry = "\(key) = \(value)"
-        if let index = findLine(for: key, in: lines) {
-            lines[index] = entry
-        } else {
-            lines.insert(entry, at: 0)
+        // --- User-configurable via Settings UI ---
+        if !prefs.theme.isEmpty {
+            lines.append("theme = \"\(prefs.theme)\"")
         }
-        try? Data(lines.joined(separator: "\n").utf8).write(to: ghosttyConfigURL, options: .atomic)
-    }
-
-    func removeValue(_ key: String) {
-        var lines = readConfig().components(separatedBy: "\n")
-        if let index = findLine(for: key, in: lines) {
-            lines.remove(at: index)
-            try? Data(lines.joined(separator: "\n").utf8).write(to: ghosttyConfigURL, options: .atomic)
+        if !prefs.fontFamily.isEmpty {
+            lines.append("font-family = \(prefs.fontFamily)")
         }
-    }
+        lines.append("font-size = \(prefs.fontSize)")
+        lines.append("macos-option-as-alt = \(prefs.optionAsAlt)")
 
-    func value(for key: String) -> String? {
-        let lines = readConfig().components(separatedBy: .newlines)
-        guard let index = findLine(for: key, in: lines) else { return nil }
-        let line = lines[index]
-        guard let eqIndex = line.firstIndex(of: "=") else { return nil }
-        return String(line[line.index(after: eqIndex)...]).trimmingCharacters(in: .whitespaces)
-    }
+        // --- Sensible defaults the user can't currently override ---
+        // Keep this list minimal; expose to Settings UI as needed instead of
+        // documenting "edit this file." Anything here should be a default that
+        // virtually all users will want.
+        lines.append("scrollbar = system")
+        lines.append("mouse-hide-while-typing = true")
+        lines.append("clipboard-trim-trailing-spaces = true")
+        lines.append("window-padding-x = 16")
+        lines.append("window-padding-y = 16")
 
-    private func findLine(for key: String, in lines: [String]) -> Int? {
-        lines.firstIndex { line in
-            let t = line.trimmingCharacters(in: .whitespaces)
-            guard t.hasPrefix(key) else { return false }
-            let rest = t.dropFirst(key.count)
-            guard let next = rest.first else { return false }
-            return next == "=" || next.isWhitespace
-        }
-    }
-
-    private func seedIfNeeded() {
-        guard !FileManager.default.fileExists(atPath: ghosttyConfigURL.path) else { return }
-        let systemConfig = NSHomeDirectory() + "/.config/ghostty/config"
-        var content = ""
-        if FileManager.default.fileExists(atPath: systemConfig),
-           let sysContent = try? String(contentsOfFile: systemConfig, encoding: .utf8)
-        {
-            content = sysContent
-        } else {
-            content = "scrollbar = system\n"
-        }
-        // Option-as-Alt defaults on so shells/editors receive the Alt
-        // modifier for word navigation etc. Users can opt out in
-        // Settings → Appearance → Input or by editing the config.
-        if !content.contains("macos-option-as-alt") {
-            content += (content.hasSuffix("\n") ? "" : "\n") + "macos-option-as-alt = true\n"
-        }
-
+        let content = lines.joined(separator: "\n") + "\n"
         try? Data(content.utf8).write(to: ghosttyConfigURL, options: .atomic)
     }
 }

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -79,25 +79,6 @@ final class GhosttyApp {
         NotificationCenter.default.post(name: .mactermConfigDidChange, object: nil)
     }
 
-    var backgroundOpacity: Double {
-        guard let config else { return 1.0 }
-        var value = 1.0
-        let key = "background-opacity"
-        return ghostty_config_get(config, &value, key, UInt(key.utf8.count)) ? max(0, min(1, value)) : 1.0
-    }
-
-    /// Whether the user has requested a blurred window background via
-    /// `background-blur = <radius>` (or `true`) in ghostty.conf. Negative
-    /// values are ghostty's glass-style flags, which Macterm doesn't expose
-    /// yet — treat them as disabled.
-    var backgroundBlurEnabled: Bool {
-        guard let config else { return false }
-        var value: Int16 = 0
-        let key = "background-blur"
-        guard ghostty_config_get(config, &value, key, UInt(key.utf8.count)) else { return false }
-        return value > 0
-    }
-
     var backgroundColor: NSColor { configColor("background") ?? NSColor(srgbRed: 0.11, green: 0.11, blue: 0.14, alpha: 1) }
     var foregroundColor: NSColor { configColor("foreground") ?? .white }
     var accentColor: NSColor { paletteColor(at: 4) ?? foregroundColor }

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -86,6 +86,18 @@ final class GhosttyApp {
         return ghostty_config_get(config, &value, key, UInt(key.utf8.count)) ? max(0, min(1, value)) : 1.0
     }
 
+    /// Whether the user has requested a blurred window background via
+    /// `background-blur = <radius>` (or `true`) in ghostty.conf. Negative
+    /// values are ghostty's glass-style flags, which Macterm doesn't expose
+    /// yet — treat them as disabled.
+    var backgroundBlurEnabled: Bool {
+        guard let config else { return false }
+        var value: Int16 = 0
+        let key = "background-blur"
+        guard ghostty_config_get(config, &value, key, UInt(key.utf8.count)) else { return false }
+        return value > 0
+    }
+
     var backgroundColor: NSColor { configColor("background") ?? NSColor(srgbRed: 0.11, green: 0.11, blue: 0.14, alpha: 1) }
     var foregroundColor: NSColor { configColor("foreground") ?? .white }
     var accentColor: NSColor { paletteColor(at: 4) ?? foregroundColor }

--- a/Macterm/Ghostty/Theme.swift
+++ b/Macterm/Ghostty/Theme.swift
@@ -7,13 +7,13 @@ enum MactermTheme {
     static var bg: Color { Color(nsColor: GhosttyApp.shared.backgroundColor) }
     @MainActor
     static var nsBg: NSColor { GhosttyApp.shared.backgroundColor }
-    /// Background tinted by `background-opacity` from ghostty.conf. Use for
+    /// Background tinted by `Preferences.shared.windowOpacity`. Use for
     /// SwiftUI chrome that should follow window transparency (sidebar,
     /// palette, search bar). `bg`/`nsBg` stay opaque for callers that need
     /// a known-solid base color.
     @MainActor
     static var bgWithOpacity: Color {
-        Color(nsColor: GhosttyApp.shared.backgroundColor.withAlphaComponent(GhosttyApp.shared.backgroundOpacity))
+        Color(nsColor: GhosttyApp.shared.backgroundColor.withAlphaComponent(Preferences.shared.windowOpacity))
     }
 
     @MainActor

--- a/Macterm/Ghostty/Theme.swift
+++ b/Macterm/Ghostty/Theme.swift
@@ -7,6 +7,15 @@ enum MactermTheme {
     static var bg: Color { Color(nsColor: GhosttyApp.shared.backgroundColor) }
     @MainActor
     static var nsBg: NSColor { GhosttyApp.shared.backgroundColor }
+    /// Background tinted by `background-opacity` from ghostty.conf. Use for
+    /// SwiftUI chrome that should follow window transparency (sidebar,
+    /// palette, search bar). `bg`/`nsBg` stay opaque for callers that need
+    /// a known-solid base color.
+    @MainActor
+    static var bgWithOpacity: Color {
+        Color(nsColor: GhosttyApp.shared.backgroundColor.withAlphaComponent(GhosttyApp.shared.backgroundOpacity))
+    }
+
     @MainActor
     static var fg: Color { Color(nsColor: GhosttyApp.shared.foregroundColor) }
     @MainActor

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -39,15 +39,19 @@ private struct AppearanceSettings: View {
     @State
     private var themes: [ThemePreview] = []
     @State
-    private var currentTheme: String = ""
+    private var currentTheme: String = Preferences.shared.theme
     @State
-    private var currentFont: String = ""
+    private var currentFont: String = Preferences.shared.fontFamily
     @State
-    private var fontSize: Int = 12
+    private var fontSize: Int = Preferences.shared.fontSize
     @State
     private var monoFonts: [String] = []
     @AppStorage(Preferences.Keys.autoTiling)
     private var autoTilingEnabled = false
+    @State
+    private var backgroundOpacity: Double = Preferences.shared.windowOpacity
+    @State
+    private var backgroundBlurRadius: Double = .init(Preferences.shared.windowBlurRadius)
     var body: some View {
         Form {
             Section("Font") {
@@ -61,12 +65,7 @@ private struct AppearanceSettings: View {
                     }
                 }
                 .onChange(of: currentFont) { _, v in
-                    if v.isEmpty {
-                        MactermConfig.shared.removeValue("font-family")
-                    } else {
-                        MactermConfig.shared.updateValue("font-family", value: v)
-                    }
-                    GhosttyApp.shared.reloadConfig()
+                    Preferences.shared.fontFamily = v
                 }
 
                 Stepper(value: $fontSize, in: 8 ... 32) {
@@ -79,22 +78,18 @@ private struct AppearanceSettings: View {
                     }
                 }
                 .onChange(of: fontSize) { _, v in
-                    MactermConfig.shared.updateValue("font-size", value: "\(v)")
-                    GhosttyApp.shared.reloadConfig()
+                    Preferences.shared.fontSize = v
                 }
             }
 
             Section("Theme") {
                 Picker("Select Theme", selection: $currentTheme) {
-                    Text("Default").tag("")
-                    Divider()
                     ForEach(themes) { theme in
                         Text(theme.id).tag(theme.id)
                     }
                 }
                 .onChange(of: currentTheme) { _, v in
-                    MactermConfig.shared.updateValue("theme", value: "\"\(v)\"")
-                    GhosttyApp.shared.reloadConfig()
+                    Preferences.shared.theme = v
                 }
 
                 if let theme = themes.first(where: { $0.id == currentTheme }) {
@@ -127,6 +122,35 @@ private struct AppearanceSettings: View {
                 }
             }
 
+            Section("Window") {
+                HStack {
+                    Text("Background Opacity")
+                    Slider(value: $backgroundOpacity, in: 0.3 ... 1.0)
+                    Text("\(Int((backgroundOpacity * 100).rounded()))%")
+                        .monospacedDigit()
+                        .frame(width: 42, alignment: .trailing)
+                }
+                .onChange(of: backgroundOpacity) { _, v in
+                    Preferences.shared.windowOpacity = v
+                }
+
+                HStack {
+                    Text("Background Blur")
+                    Slider(value: $backgroundBlurRadius, in: 0 ... 100)
+                    Text("\(Int(backgroundBlurRadius.rounded()))")
+                        .monospacedDigit()
+                        .frame(width: 42, alignment: .trailing)
+                }
+                .onChange(of: backgroundBlurRadius) { _, v in
+                    Preferences.shared.windowBlurRadius = Int(v.rounded())
+                }
+                .disabled(backgroundOpacity >= 0.999)
+
+                Text("Blur only takes effect when opacity is below 100%. Set to 0 to disable.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Layout") {
                 Toggle("Auto-tile panes", isOn: $autoTilingEnabled)
                     .onChange(of: autoTilingEnabled) { _, v in
@@ -140,15 +164,8 @@ private struct AppearanceSettings: View {
         .formStyle(.grouped)
         .task { await loadThemes() }
         .onAppear {
-            loadCurrentValues()
             monoFonts = Self.loadMonoFonts()
         }
-    }
-
-    private func loadCurrentValues() {
-        currentTheme = MactermConfig.shared.value(for: "theme")?.replacingOccurrences(of: "\"", with: "") ?? ""
-        currentFont = MactermConfig.shared.value(for: "font-family") ?? ""
-        fontSize = Int(MactermConfig.shared.value(for: "font-size") ?? "") ?? 12
     }
 
     private static func loadMonoFonts() -> [String] {
@@ -311,7 +328,7 @@ private struct KeymapSettings: View {
     @State
     private var invalidActions: Set<String> = []
     @State
-    private var optionAsAlt: OptionAsAlt = .from(MactermConfig.shared.value(for: "macos-option-as-alt"))
+    private var optionAsAlt: OptionAsAlt = .from(Preferences.shared.optionAsAlt)
 
     var body: some View {
         Form {
@@ -322,8 +339,7 @@ private struct KeymapSettings: View {
                     }
                 }
                 .onChange(of: optionAsAlt) { _, v in
-                    MactermConfig.shared.updateValue("macos-option-as-alt", value: v.rawValue)
-                    GhosttyApp.shared.reloadConfig()
+                    Preferences.shared.optionAsAlt = v.rawValue
                 }
                 Text(
                     "Pick \"Left\" or \"Right\" to keep one Option key for typing macOS special characters "

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -15,15 +15,11 @@ struct MainWindow: View {
                 .navigationSplitViewColumnWidth(min: 140, ideal: 180, max: 280)
         } detail: {
             ZStack {
-                // Paint the detail background at the configured opacity, even
-                // when a terminal is rendering. There's a slight double-up
-                // with ghostty's own translucent surface in the terminal
-                // body, but keeping this full-bleed is what makes the
-                // titlebar region read at the right opacity — without it,
-                // the titlebar reads as fully transparent over the detail
-                // column. The double-up is small and visually acceptable.
-                MactermTheme.bgWithOpacity
-                    .ignoresSafeArea(.container, edges: .top)
+                // The window's NSWindow.backgroundColor (set by WindowAppearance)
+                // fills the detail column at the configured opacity. No need
+                // to paint another tinted layer here — doing so stacks two
+                // translucent fills and the detail reads as darker than the
+                // strip around the sidebar.
                 if let project = activeProjectWithWorkspace {
                     if projectHasAnyTab(project) {
                         WorkspaceView(project: project)

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -15,7 +15,8 @@ struct MainWindow: View {
                 .navigationSplitViewColumnWidth(min: 140, ideal: 180, max: 280)
         } detail: {
             ZStack {
-                MactermTheme.terminalBg
+                MactermTheme.bgWithOpacity
+                    .ignoresSafeArea(.container, edges: .top)
                 if let project = activeProjectWithWorkspace {
                     if projectHasAnyTab(project) {
                         WorkspaceView(project: project)
@@ -253,6 +254,11 @@ private struct WindowStyler: NSViewRepresentable {
             window.titlebarAppearsTransparent = true
             window.titlebarSeparatorStyle = .none
             window.tabbingMode = .disallowed
+            // Let the content view extend under the titlebar so the sidebar
+            // and terminal paint continuously up to the top of the window.
+            // Without this the titlebar floats above the sidebar with a
+            // visible boundary, which is jarring when both are translucent.
+            window.styleMask.insert(.fullSizeContentView)
             WindowAppearance.sync(window: window)
             context.coordinator.observe(window: window)
             // Intercept the close button to hide instead of close,

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -253,7 +253,7 @@ private struct WindowStyler: NSViewRepresentable {
             window.titlebarAppearsTransparent = true
             window.titlebarSeparatorStyle = .none
             window.tabbingMode = .disallowed
-            applyStyle(to: window)
+            WindowAppearance.sync(window: window)
             context.coordinator.observe(window: window)
             // Intercept the close button to hide instead of close,
             // preserving terminal surfaces and running processes.
@@ -264,17 +264,15 @@ private struct WindowStyler: NSViewRepresentable {
 
     func updateNSView(_: NSView, context _: Context) {}
 
-    private func applyStyle(to window: NSWindow) {
-        window.isOpaque = true
-        window.backgroundColor = MactermTheme.nsBg
-    }
-
     final class Coordinator: NSObject, NSWindowDelegate {
         nonisolated(unsafe) private var observer: Any?
         weak var swiftuiDelegate: (any NSWindowDelegate)?
 
         @MainActor
         func observe(window: NSWindow) {
+            // Re-apply on config change. AppKit also rebuilds the titlebar
+            // subviews on becomeMain / fullscreen transitions, so we resync
+            // there too via the delegate hooks below.
             observer = NotificationCenter.default.addObserver(
                 forName: .mactermConfigDidChange,
                 object: nil,
@@ -282,10 +280,27 @@ private struct WindowStyler: NSViewRepresentable {
             ) { [weak window] _ in
                 guard let window else { return }
                 MainActor.assumeIsolated {
-                    window.isOpaque = true
-                    window.backgroundColor = MactermTheme.nsBg
+                    WindowAppearance.sync(window: window)
                 }
             }
+        }
+
+        func windowDidBecomeMain(_ notification: Notification) {
+            guard let window = notification.object as? NSWindow else { return }
+            WindowAppearance.sync(window: window)
+            swiftuiDelegate?.windowDidBecomeMain?(notification)
+        }
+
+        func windowDidEnterFullScreen(_ notification: Notification) {
+            guard let window = notification.object as? NSWindow else { return }
+            WindowAppearance.sync(window: window)
+            swiftuiDelegate?.windowDidEnterFullScreen?(notification)
+        }
+
+        func windowDidExitFullScreen(_ notification: Notification) {
+            guard let window = notification.object as? NSWindow else { return }
+            WindowAppearance.sync(window: window)
+            swiftuiDelegate?.windowDidExitFullScreen?(notification)
         }
 
         @MainActor

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -15,6 +15,13 @@ struct MainWindow: View {
                 .navigationSplitViewColumnWidth(min: 140, ideal: 180, max: 280)
         } detail: {
             ZStack {
+                // Paint the detail background at the configured opacity, even
+                // when a terminal is rendering. There's a slight double-up
+                // with ghostty's own translucent surface in the terminal
+                // body, but keeping this full-bleed is what makes the
+                // titlebar region read at the right opacity — without it,
+                // the titlebar reads as fully transparent over the detail
+                // column. The double-up is small and visually acceptable.
                 MactermTheme.bgWithOpacity
                     .ignoresSafeArea(.container, edges: .top)
                 if let project = activeProjectWithWorkspace {
@@ -285,9 +292,7 @@ private struct WindowStyler: NSViewRepresentable {
                 queue: .main
             ) { [weak window] _ in
                 guard let window else { return }
-                MainActor.assumeIsolated {
-                    WindowAppearance.sync(window: window)
-                }
+                MainActor.assumeIsolated { WindowAppearance.sync(window: window) }
             }
         }
 

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Carbon
-import GhosttyKit
 import SwiftUI
 
 @MainActor
@@ -54,7 +53,21 @@ final class QuickTerminalService: NSObject {
             name: UserDefaults.didChangeNotification,
             object: nil
         )
+        // Re-apply the blur radius when ghostty.conf changes so the visible
+        // panel picks up Settings adjustments without needing to be re-shown.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reapplyBlur),
+            name: .mactermConfigDidChange,
+            object: nil
+        )
         if isEnabled { registerHotKey() }
+    }
+
+    @objc
+    private func reapplyBlur() {
+        guard let panel, isVisible else { return }
+        setWindowBackgroundBlur(panel, radius: Preferences.shared.windowBlurRadius)
     }
 
     @objc
@@ -163,9 +176,8 @@ final class QuickTerminalService: NSObject {
             previousFrontmostApp = frontmost
         }
         panel.makeKeyAndOrderFront(nil)
-        if GhosttyApp.shared.backgroundBlurEnabled, let app = GhosttyApp.shared.app {
-            ghostty_set_window_background_blur(app, Unmanaged.passUnretained(panel).toOpaque())
-        }
+        // Apply the current blur radius (0 = no blur) for this panel session.
+        setWindowBackgroundBlur(panel, radius: Preferences.shared.windowBlurRadius)
         if let focusedID = splitState.focusedPaneID {
             FocusRestoration.restoreFocus(to: focusedID, in: splitState.splitRoot, window: panel)
         }

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Carbon
+import GhosttyKit
 import SwiftUI
 
 @MainActor
@@ -162,6 +163,9 @@ final class QuickTerminalService: NSObject {
             previousFrontmostApp = frontmost
         }
         panel.makeKeyAndOrderFront(nil)
+        if GhosttyApp.shared.backgroundBlurEnabled, let app = GhosttyApp.shared.app {
+            ghostty_set_window_background_blur(app, Unmanaged.passUnretained(panel).toOpaque())
+        }
         if let focusedID = splitState.focusedPaneID {
             FocusRestoration.restoreFocus(to: focusedID, in: splitState.splitRoot, window: panel)
         }
@@ -349,7 +353,7 @@ private struct QuickTerminalView: View {
             onToggleZoom: { state.tab.toggleZoom(paneID: $0) }
         )
         .id(renderedNode.id)
-        .background(Color(nsColor: GhosttyApp.shared.backgroundColor))
+        .background(MactermTheme.bgWithOpacity)
         .overlay(alignment: .topTrailing) {
             if let zoomID = state.tab.zoomedPaneID {
                 ZoomIndicator(onExit: { state.tab.toggleZoom(paneID: zoomID) })

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -59,7 +59,10 @@ struct SidebarContent: View {
         }
         .listStyle(.sidebar)
         .scrollContentBackground(.hidden)
-        .background(MactermTheme.bgWithOpacity)
+        // No background here: the window's NSWindow.backgroundColor (set by
+        // WindowAppearance) provides the translucent fill uniformly. Adding
+        // another tinted layer here would make the sidebar read darker than
+        // the surrounding strip.
         .safeAreaInset(edge: .bottom) {
             Button {
                 openProject()

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -59,7 +59,7 @@ struct SidebarContent: View {
         }
         .listStyle(.sidebar)
         .scrollContentBackground(.hidden)
-        .background(MactermTheme.bg)
+        .background(MactermTheme.bgWithOpacity)
         .safeAreaInset(edge: .bottom) {
             Button {
                 openProject()

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -77,10 +77,12 @@ enum WindowAppearance {
 
         if effectiveTransparent {
             window.isOpaque = false
-            // The 0.001-alpha-white trick is from Ghostty: `.clear` gets
-            // special-cased somewhere in AppKit and produces a visibly
-            // different composite. The near-zero alpha works around it.
-            window.backgroundColor = .white.withAlphaComponent(0.001)
+            // The window's backgroundColor is the *only* tinted layer.
+            // Ghostty renders fully transparent, the detail ZStack and
+            // sidebar paint nothing, so the whole interior — including the
+            // strip around the system glass sidebar — reads as one
+            // continuous translucent surface backed by this color.
+            window.backgroundColor = bg.withAlphaComponent(opacity)
             // Apply blur unconditionally; passing 0 clears any previous blur.
             setWindowBackgroundBlur(window, radius: blurRadius)
         } else {

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -73,6 +73,14 @@ enum WindowAppearance {
 
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
+            // On Tahoe with liquid glass, the NavigationSplitView's sidebar
+            // is a system glass surface that extends behind the titlebar by
+            // design. Painting a flat color over the titlebar covers that
+            // glass and creates a visible break across the sidebar. Instead,
+            // leave the titlebar transparent and let the system materials
+            // (glass sidebar on one side, detail view's painted bg on the
+            // other) show through. In the opaque case we still fill so the
+            // titlebar matches the terminal background.
             titlebarView.layer?.backgroundColor = isTransparent
                 ? NSColor.clear.cgColor
                 : bg.cgColor

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -1,0 +1,99 @@
+import AppKit
+import GhosttyKit
+
+extension NSView {
+    /// Recursively finds the first descendant view whose class name (as a string)
+    /// matches `name`. Used to reach into AppKit's private titlebar view tree —
+    /// the only known way to colorize the titlebar to match a transparent
+    /// window background. Lifted from Ghostty's NSView+Extension.swift.
+    func firstDescendant(withClassName name: String) -> NSView? {
+        for subview in subviews {
+            if String(describing: type(of: subview)) == name {
+                return subview
+            }
+            if let found = subview.firstDescendant(withClassName: name) {
+                return found
+            }
+        }
+        return nil
+    }
+}
+
+/// Encapsulates the Tahoe-only window styling work needed to make the titlebar
+/// blend with a transparent terminal background. AppKit gives us two surface
+/// areas — the content view and a separate, system-owned titlebar view tree —
+/// that don't compose visually with a single `backgroundColor` setting. To
+/// make them look uniform we have to reach into the private titlebar hierarchy
+/// and override its layer color directly.
+///
+/// Mirrors the `syncAppearanceTahoe` path in Ghostty's
+/// `TransparentTitlebarTerminalWindow.swift`. Pre-Tahoe macOS releases need
+/// different incantations (hiding NSVisualEffectView, etc.) — Macterm targets
+/// macOS 26+ so we only ship the Tahoe path.
+@MainActor
+enum WindowAppearance {
+    /// Apply the current opacity/blur settings to `window`. Safe to call any
+    /// time — re-applies idempotently. Should be called after the window is
+    /// onscreen, on theme changes, and on focus changes (AppKit recreates
+    /// titlebar subviews under us in some cases, e.g. tab bar appearing).
+    static func sync(window: NSWindow) {
+        let opacity = GhosttyApp.shared.backgroundOpacity
+        let bg = GhosttyApp.shared.backgroundColor
+        let blurEnabled = GhosttyApp.shared.backgroundBlurEnabled
+        let isTransparent = opacity < 1.0
+
+        // Native fullscreen draws its own opaque grey background; widgets show
+        // through any transparency we apply, so force opaque while fullscreened.
+        let forceOpaque = window.styleMask.contains(.fullScreen)
+        let effectiveTransparent = isTransparent && !forceOpaque
+
+        if effectiveTransparent {
+            window.isOpaque = false
+            // The 0.001-alpha-white trick is from Ghostty: `.clear` gets
+            // special-cased somewhere in AppKit and produces a visibly
+            // different composite. The near-zero alpha works around it.
+            window.backgroundColor = .white.withAlphaComponent(0.001)
+            if blurEnabled, let app = GhosttyApp.shared.app {
+                ghostty_set_window_background_blur(app, Unmanaged.passUnretained(window).toOpaque())
+            }
+        } else {
+            window.isOpaque = true
+            window.backgroundColor = bg
+        }
+
+        // Override the titlebar's private background layer so its color
+        // matches the terminal background (or stays transparent when the
+        // window is). Without this the titlebar paints its own material
+        // and you get a visible seam at y=titlebarHeight.
+        syncTitlebar(window: window, isTransparent: effectiveTransparent, bg: bg)
+    }
+
+    private static func syncTitlebar(window: NSWindow, isTransparent: Bool, bg: NSColor) {
+        guard let container = titlebarContainer(in: window) else { return }
+
+        if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
+            titlebarView.wantsLayer = true
+            titlebarView.layer?.backgroundColor = isTransparent
+                ? NSColor.clear.cgColor
+                : bg.cgColor
+        }
+
+        // NSTitlebarBackgroundView has subviews that force their own background
+        // colors; hiding it is the only way to keep our override visible.
+        container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = true
+    }
+
+    private static func titlebarContainer(in window: NSWindow) -> NSView? {
+        // The titlebar container lives on the window's content view's root in
+        // normal mode, and on a separate NSToolbarFullScreenWindow in native
+        // fullscreen. We don't support native fullscreen tab bars, so the
+        // first path suffices for Macterm.
+        guard let contentView = window.contentView else { return nil }
+        var root: NSView = contentView
+        while let s = root.superview {
+            root = s
+        }
+        if String(describing: type(of: root)) == "NSTitlebarContainerView" { return root }
+        return root.firstDescendant(withClassName: "NSTitlebarContainerView")
+    }
+}

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -1,5 +1,4 @@
 import AppKit
-import GhosttyKit
 
 extension NSView {
     /// Recursively finds the first descendant view whose class name (as a string)
@@ -19,6 +18,35 @@ extension NSView {
     }
 }
 
+// MARK: - Private CGS blur SPI
+
+/// `CGSSetWindowBackgroundBlurRadius` is a private CoreGraphics API that
+/// every macOS terminal (Terminal.app, iTerm, Ghostty) uses to blur the
+/// content behind a translucent window. It's undocumented but stable;
+/// libghostty exposes the same call.
+private let cgsConnectionFnPtr: @convention(c) () -> Int32 = {
+    let handle = dlopen(nil, RTLD_NOW)
+    guard let sym = dlsym(handle, "CGSDefaultConnectionForThread") else {
+        fatalError("CGSDefaultConnectionForThread symbol not found")
+    }
+    return unsafeBitCast(sym, to: (@convention(c) () -> Int32).self)
+}()
+
+private let cgsSetBlurFnPtr: @convention(c) (Int32, Int, Int32) -> Int32 = {
+    let handle = dlopen(nil, RTLD_NOW)
+    guard let sym = dlsym(handle, "CGSSetWindowBackgroundBlurRadius") else {
+        fatalError("CGSSetWindowBackgroundBlurRadius symbol not found")
+    }
+    return unsafeBitCast(sym, to: (@convention(c) (Int32, Int, Int32) -> Int32).self)
+}()
+
+@MainActor
+func setWindowBackgroundBlur(_ window: NSWindow, radius: Int) {
+    _ = cgsSetBlurFnPtr(cgsConnectionFnPtr(), window.windowNumber, Int32(radius))
+}
+
+// MARK: - Window styling
+
 /// Encapsulates the Tahoe-only window styling work needed to make the titlebar
 /// blend with a transparent terminal background. AppKit gives us two surface
 /// areas — the content view and a separate, system-owned titlebar view tree —
@@ -37,9 +65,9 @@ enum WindowAppearance {
     /// onscreen, on theme changes, and on focus changes (AppKit recreates
     /// titlebar subviews under us in some cases, e.g. tab bar appearing).
     static func sync(window: NSWindow) {
-        let opacity = GhosttyApp.shared.backgroundOpacity
+        let opacity = Preferences.shared.windowOpacity
+        let blurRadius = Preferences.shared.windowBlurRadius
         let bg = GhosttyApp.shared.backgroundColor
-        let blurEnabled = GhosttyApp.shared.backgroundBlurEnabled
         let isTransparent = opacity < 1.0
 
         // Native fullscreen draws its own opaque grey background; widgets show
@@ -53,42 +81,40 @@ enum WindowAppearance {
             // special-cased somewhere in AppKit and produces a visibly
             // different composite. The near-zero alpha works around it.
             window.backgroundColor = .white.withAlphaComponent(0.001)
-            if blurEnabled, let app = GhosttyApp.shared.app {
-                ghostty_set_window_background_blur(app, Unmanaged.passUnretained(window).toOpaque())
-            }
+            // Apply blur unconditionally; passing 0 clears any previous blur.
+            setWindowBackgroundBlur(window, radius: blurRadius)
         } else {
             window.isOpaque = true
             window.backgroundColor = bg
+            // Make sure a previous blur is cleared when going opaque.
+            setWindowBackgroundBlur(window, radius: 0)
         }
 
         // Override the titlebar's private background layer so its color
         // matches the terminal background (or stays transparent when the
         // window is). Without this the titlebar paints its own material
         // and you get a visible seam at y=titlebarHeight.
-        syncTitlebar(window: window, isTransparent: effectiveTransparent, bg: bg)
+        syncTitlebar(window: window, isTransparent: effectiveTransparent)
     }
 
-    private static func syncTitlebar(window: NSWindow, isTransparent: Bool, bg: NSColor) {
+    private static func syncTitlebar(window: NSWindow, isTransparent: Bool) {
         guard let container = titlebarContainer(in: window) else { return }
 
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
-            // On Tahoe with liquid glass, the NavigationSplitView's sidebar
-            // is a system glass surface that extends behind the titlebar by
-            // design. Painting a flat color over the titlebar covers that
-            // glass and creates a visible break across the sidebar. Instead,
-            // leave the titlebar transparent and let the system materials
-            // (glass sidebar on one side, detail view's painted bg on the
-            // other) show through. In the opaque case we still fill so the
-            // titlebar matches the terminal background.
-            titlebarView.layer?.backgroundColor = isTransparent
-                ? NSColor.clear.cgColor
-                : bg.cgColor
+            // On Tahoe, the NavigationSplitView's sidebar is a liquid-glass
+            // surface that extends behind the titlebar by design. Painting
+            // any flat color on the titlebar layer draws a band over that
+            // glass and creates a visible seam. Keep the layer transparent
+            // and let AppKit's default titlebar materials (or the content
+            // view, with `.fullSizeContentView`) show through in both modes.
+            titlebarView.layer?.backgroundColor = NSColor.clear.cgColor
         }
 
         // NSTitlebarBackgroundView has subviews that force their own background
-        // colors; hiding it is the only way to keep our override visible.
-        container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = true
+        // colors; hide it only when transparent, so the default opaque-mode
+        // chrome stays intact.
+        container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = isTransparent
     }
 
     private static func titlebarContainer(in window: NSWindow) -> NSView? {


### PR DESCRIPTION
## Summary
- Adds Background Opacity and Background Blur sliders in Settings → Appearance → Window. Both compose at the macOS window level via `isOpaque = false`, the 0.001 alpha trick lifted from Ghostty, and the private `CGSSetWindowBackgroundBlurRadius` SPI.
- Ports the Tahoe-only titlebar incantations from Ghostty's `TransparentTitlebarTerminalWindow` so the titlebar reads as the same translucent surface as the rest of the window.
- Architectural shift: Macterm now owns its ghostty config end-to-end. The config file is generated from `Preferences` (UserDefaults) at launch and on every settings change, with `background-opacity = 0` hardcoded so ghostty renders only text and Macterm composites the single tinted fill at the window level. This eliminates the double-tint that made terminal areas look more opaque than the welcome screen at the same opacity setting.
- New defaults for fresh installs: Rose Pine theme, 16pt font, 16px window padding.

## Test plan
- [x] Manual: opacity slider 30–100% updates the main window live; terminal pane, welcome screen, and sidebar strip all read at the same translucency
- [x] Manual: blur slider 0–100 updates live; disabled when opacity is 100%
- [x] Manual: quick terminal honors both
- [x] Manual: native fullscreen forces opaque, transitions back cleanly
- [x] Manual: theme picker, font picker, font-size stepper, Option-as-Alt all still work
- [x] `mise run format` / `mise run lint` / `mise run test`