### PR TITLE
feat: load user's ghostty.conf as the source of truth

### DIFF
--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -120,6 +120,46 @@ final class AppState {
         return project
     }
 
+    /// Open the user's ghostty.conf in `$EDITOR` (default `vi`) inside a new
+    /// Macterm tab. Used by the "Edit" button in Settings → Appearance →
+    /// Ghostty Config. The tab lands in the currently active project; if no
+    /// project is active, we lazily create a "Home" project rooted at `$HOME`
+    /// so the tab belongs to a real project like every other tab.
+    func openGhosttyConfigEditor(projectStore: ProjectStore) {
+        let path = Preferences.shared.expandedUserGhosttyConfigPath
+        guard !path.isEmpty else { return }
+        let editor = ProcessInfo.processInfo.environment["EDITOR"] ?? "vi"
+        // Single-quote with embedded-quote escape so paths with spaces or
+        // apostrophes survive the shell that ghostty wraps the command in.
+        let escapedPath = path.replacingOccurrences(of: "'", with: "'\\''")
+        let cmd = "\(editor) '\(escapedPath)'"
+
+        let project: Project
+        if let activeID = activeProjectID,
+           let active = projectStore.projects.first(where: { $0.id == activeID })
+        {
+            project = active
+        } else {
+            project = ensureHomeProject(projectStore: projectStore)
+            selectProject(project)
+        }
+        createTab(projectID: project.id, projectPath: project.path, initialCommand: cmd)
+    }
+
+    /// Find or create the "Home" project pointing at `$HOME`. We match on path
+    /// rather than name so a user who already has a project at their home
+    /// directory under a different name doesn't get a duplicate.
+    private func ensureHomeProject(projectStore: ProjectStore) -> Project {
+        let homePath = NSHomeDirectory()
+        if let existing = projectStore.projects.first(where: { $0.path == homePath }) {
+            return existing
+        }
+        let project = Project(name: "Home", path: homePath, sortOrder: projectStore.projects.count)
+        projectStore.add(project)
+        ensureWorkspace(projectID: project.id, path: project.path)
+        return project
+    }
+
     func removeProject(_ projectID: UUID) {
         if let ws = workspaces[projectID] {
             for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {
@@ -133,9 +173,9 @@ final class AppState {
 
     // MARK: - Tabs
 
-    func createTab(projectID: UUID, projectPath: String) {
+    func createTab(projectID: UUID, projectPath: String, initialCommand: String? = nil) {
         guard let ws = workspaces[projectID] else { return }
-        ws.createTab(projectPath: projectPath)
+        ws.createTab(projectPath: projectPath, initialCommand: initialCommand)
         saveWorkspaces()
     }
 

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -64,6 +64,8 @@ struct MactermApp: App {
 
         Settings {
             SettingsView()
+                .environment(appState)
+                .environment(projectStore)
         }
     }
 }

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -4,16 +4,10 @@ import Observation
 
 /// Single observable source of truth for UserDefaults-backed preferences.
 ///
-/// Before: settings were scattered across `UserDefaults.standard.set/get`
-/// calls in SettingsView, ad-hoc wrappers like `AutoTilePreference`, and
-/// `@AppStorage` in views. Different views used different access patterns,
-/// and observers couldn't tell that a setting had changed without bespoke
-/// `NotificationCenter` glue.
-///
-/// Now: every call site reads/writes through `Preferences.shared.x`. Changes
-/// notify via Swift's Observation macro, and legacy `NotificationCenter`
-/// signals (e.g. `.autoTilingEnabledDidChange`) are still posted so older
-/// objects that observe them keep working.
+/// Macterm only stores app-shaped state here (window opacity/blur, quick
+/// terminal, hotkeys, etc.). Anything that's a ghostty config setting lives
+/// in the user's ghostty.conf instead — see `MactermConfig` for the wrapper
+/// files Macterm generates around it.
 @MainActor @Observable
 final class Preferences {
     static let shared = Preferences()
@@ -28,43 +22,13 @@ final class Preferences {
         }
     }
 
-    /// Empty string = use the ghostty default theme.
-    var theme: String {
-        didSet {
-            defaults.set(theme, forKey: Keys.theme)
-            notifyConfigChanged()
-        }
-    }
-
-    /// Empty string = use the ghostty default font.
-    var fontFamily: String {
-        didSet {
-            defaults.set(fontFamily, forKey: Keys.fontFamily)
-            notifyConfigChanged()
-        }
-    }
-
-    var fontSize: Int {
-        didSet {
-            defaults.set(fontSize, forKey: Keys.fontSize)
-            notifyConfigChanged()
-        }
-    }
-
-    /// One of "true", "false", "left", "right" — matches ghostty's accepted values.
-    var optionAsAlt: String {
-        didSet {
-            defaults.set(optionAsAlt, forKey: Keys.optionAsAlt)
-            notifyConfigChanged()
-        }
-    }
-
     // MARK: - Window
 
     /// Macterm-painted window background opacity (0–1). Independent from
-    /// ghostty's renderer — we always tell ghostty to render fully opaque
-    /// terminal content, then Macterm composites this translucency at the
-    /// window level. Avoids the double-paint problem when both layers tint.
+    /// ghostty's renderer — `macterm-overrides.conf` pins `background-opacity
+    /// = 0` so ghostty draws fully transparent, then Macterm composites this
+    /// translucency at the window level. Avoids the double-paint problem when
+    /// both layers tint.
     var windowOpacity: Double {
         didSet {
             defaults.set(windowOpacity, forKey: Keys.windowOpacity)
@@ -80,10 +44,31 @@ final class Preferences {
         }
     }
 
-    /// Settings → file → libghostty reload pipeline. Each preference setter
-    /// that maps to ghostty config (theme, font, opacity, etc.) calls this so
-    /// the change propagates through the renderer and to any window-appearance
-    /// observers in one shot.
+    // MARK: - Ghostty config
+
+    /// Path to the user's ghostty.conf. Empty string = don't load any user
+    /// config (Macterm-defaults only). Tilde-expand via
+    /// `expandedUserGhosttyConfigPath` at use sites.
+    ///
+    /// Note: this setter does NOT auto-reload, intentionally. Settings UI is
+    /// the only writer and it calls `GhosttyApp.shared.reloadConfig()`
+    /// directly so it can surface any errors (missing file, parse errors)
+    /// in an alert. Other reloads happen silently.
+    var userGhosttyConfigPath: String {
+        didSet {
+            defaults.set(userGhosttyConfigPath, forKey: Keys.userGhosttyConfigPath)
+        }
+    }
+
+    /// `userGhosttyConfigPath` with leading `~` expanded to the home dir.
+    /// Empty when the user has disabled loading by clearing the field.
+    var expandedUserGhosttyConfigPath: String {
+        guard !userGhosttyConfigPath.isEmpty else { return "" }
+        return (userGhosttyConfigPath as NSString).expandingTildeInPath
+    }
+
+    /// Window-level appearance + libghostty reload. Both happen on the same
+    /// notification so the renderer and the window chrome stay in sync.
     private func notifyConfigChanged() {
         MactermConfig.shared.regenerate()
         GhosttyApp.shared.reloadConfig()
@@ -119,16 +104,14 @@ final class Preferences {
     private init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
-        theme = defaults.string(forKey: Keys.theme) ?? "Rose Pine"
-        fontFamily = defaults.string(forKey: Keys.fontFamily) ?? ""
-        fontSize = defaults.object(forKey: Keys.fontSize) as? Int ?? 16
-        optionAsAlt = defaults.string(forKey: Keys.optionAsAlt) ?? "true"
         windowOpacity = (defaults.object(forKey: Keys.windowOpacity) as? Double) ?? 1.0
         windowBlurRadius = defaults.integer(forKey: Keys.windowBlurRadius)
+        userGhosttyConfigPath = defaults.string(forKey: Keys.userGhosttyConfigPath) ?? "~/.config/ghostty/config"
         quickTerminalEnabled = defaults.object(forKey: Keys.quickTerminalEnabled) as? Bool ?? true
         quickTerminalWidthFraction = Self.clampFraction(defaults.double(forKey: Keys.quickTerminalWidth), fallback: 0.6)
         quickTerminalHeightFraction = Self.clampFraction(defaults.double(forKey: Keys.quickTerminalHeight), fallback: 0.5)
         activeProjectID = (defaults.string(forKey: Keys.activeProjectID)).flatMap(UUID.init)
+        Self.runOneTimeMigrations(defaults: defaults)
     }
 
     private static func clampFraction(_ v: Double, fallback: Double) -> Double {
@@ -136,19 +119,31 @@ final class Preferences {
         return max(0.2, min(1.0, v))
     }
 
+    /// Pre-v2 builds stored theme/font/option-as-alt in UserDefaults. Those
+    /// settings now live entirely in the user's ghostty.conf, so the keys
+    /// are dead. Drop them so `defaults read com.thdxg.macterm` is clean
+    /// and there's no risk of resurrecting the old values if someone wires
+    /// them back up later.
+    private static func runOneTimeMigrations(defaults: UserDefaults) {
+        guard !defaults.bool(forKey: Keys.migrationV2GhosttyConfigOwned) else { return }
+        defaults.removeObject(forKey: "macterm.appearance.theme")
+        defaults.removeObject(forKey: "macterm.appearance.fontFamily")
+        defaults.removeObject(forKey: "macterm.appearance.fontSize")
+        defaults.removeObject(forKey: "macterm.input.optionAsAlt")
+        defaults.set(true, forKey: Keys.migrationV2GhosttyConfigOwned)
+    }
+
     // MARK: - UserDefaults keys
 
     enum Keys {
         static let autoTiling = "macterm.autoTiling.enabled"
-        static let theme = "macterm.appearance.theme"
-        static let fontFamily = "macterm.appearance.fontFamily"
-        static let fontSize = "macterm.appearance.fontSize"
-        static let optionAsAlt = "macterm.input.optionAsAlt"
         static let windowOpacity = "macterm.window.opacity"
         static let windowBlurRadius = "macterm.window.blurRadius"
+        static let userGhosttyConfigPath = "macterm.ghostty.userConfigPath"
         static let quickTerminalEnabled = "macterm.quickTerminal.enabled"
         static let quickTerminalWidth = "macterm.quickTerminal.width"
         static let quickTerminalHeight = "macterm.quickTerminal.height"
         static let activeProjectID = "macterm.activeProjectID"
+        static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"
     }
 }

--- a/Macterm/Config/MactermConfig.swift
+++ b/Macterm/Config/MactermConfig.swift
@@ -1,70 +1,62 @@
 import Foundation
 
-/// Generates the ghostty config file that libghostty loads. Macterm owns this
-/// config entirely — users do not edit it. All user-facing settings live in
-/// `Preferences` (UserDefaults); `regenerate()` reads them and writes a fresh
-/// ghostty.conf to App Support, which `GhosttyApp.loadConfig` then loads.
+/// Generates the two ghostty config files Macterm wraps around the user's
+/// own ghostty.conf. The user is the source of truth for every ghostty
+/// setting; Macterm provides first-launch defaults that the user overrides,
+/// and a minimal must-win overrides file for keys Macterm can't let the
+/// renderer control (currently: background-opacity, background-blur — both
+/// required for the window-level translucency in `WindowAppearance`).
 ///
-/// We force `background-opacity = 1` and `background-blur = 0` so ghostty's
-/// renderer draws fully opaque terminal content. Window translucency is
-/// composited at the window level by Macterm (see `WindowAppearance`),
-/// avoiding the double-paint that happens when both ghostty and Macterm
-/// tint the same pixels.
+/// `GhosttyApp.loadConfig` loads them in this order:
+///   defaults → user's ghostty.conf → overrides
+/// libghostty does last-wins merge, so the user wins over our defaults and
+/// our overrides win over the user.
+///
+/// See the README for the full list of ghostty.conf settings Macterm honors
+/// and the small set it ignores or overrides.
 @MainActor @Observable
 final class MactermConfig {
     static let shared = MactermConfig()
 
-    let ghosttyConfigURL: URL
+    let defaultsURL: URL
+    let overridesURL: URL
 
     private init() {
         let dir = FileStorage.appSupportDirectory()
-        ghosttyConfigURL = dir.appendingPathComponent("ghostty.conf")
-        // Write a fresh config on every launch so the file always reflects
-        // the current Preferences state — no stale lines from previous runs.
+        defaultsURL = dir.appendingPathComponent("macterm-defaults.conf")
+        overridesURL = dir.appendingPathComponent("macterm-overrides.conf")
         regenerate()
     }
 
-    var ghosttyConfigPath: String { ghosttyConfigURL.path }
+    var defaultsPath: String { defaultsURL.path }
+    var overridesPath: String { overridesURL.path }
 
-    /// Rebuild the ghostty.conf file from current `Preferences` values.
-    /// Called on launch and whenever a relevant preference changes.
+    /// Rewrite both wrapper config files. Cheap and idempotent; safe to call
+    /// on launch and whenever Macterm-side state changes that's reflected in
+    /// either file.
     func regenerate() {
-        let prefs = Preferences.shared
-        var lines: [String] = []
+        let defaults = [
+            // First-launch tasteful UX. User's ghostty.conf overrides any of
+            // these without needing to know they exist. Anything we'd set to
+            // ghostty's own default (e.g. scrollbar=system) isn't listed —
+            // libghostty already does the right thing.
+            "theme = \"Rose Pine\"",
+            "font-size = 16",
+            "macos-option-as-alt = true",
+            "window-padding-x = 16",
+            "window-padding-y = 16",
+        ].joined(separator: "\n") + "\n"
+        try? Data(defaults.utf8).write(to: defaultsURL, options: .atomic)
 
-        // --- Macterm-managed window appearance ---
-        // Ghostty's terminal surface is fully transparent — it draws only the
-        // text and cursor. The colored fill behind the text comes from the
-        // window's `NSWindow.backgroundColor` (set in `WindowAppearance.sync`
-        // to the terminal color tinted by `Preferences.windowOpacity`), which
-        // is the single source of window translucency. Keeping all tinting on
-        // one layer avoids the double-paint that happens when both ghostty's
-        // renderer and SwiftUI/AppKit tint the same pixels.
-        lines.append("background-opacity = 0")
-        // Blur is driven by our own CGS SPI call, not ghostty's wrapper.
-        lines.append("background-blur = 0")
-
-        // --- User-configurable via Settings UI ---
-        if !prefs.theme.isEmpty {
-            lines.append("theme = \"\(prefs.theme)\"")
-        }
-        if !prefs.fontFamily.isEmpty {
-            lines.append("font-family = \(prefs.fontFamily)")
-        }
-        lines.append("font-size = \(prefs.fontSize)")
-        lines.append("macos-option-as-alt = \(prefs.optionAsAlt)")
-
-        // --- Sensible defaults the user can't currently override ---
-        // Keep this list minimal; expose to Settings UI as needed instead of
-        // documenting "edit this file." Anything here should be a default that
-        // virtually all users will want.
-        lines.append("scrollbar = system")
-        lines.append("mouse-hide-while-typing = true")
-        lines.append("clipboard-trim-trailing-spaces = true")
-        lines.append("window-padding-x = 16")
-        lines.append("window-padding-y = 16")
-
-        let content = lines.joined(separator: "\n") + "\n"
-        try? Data(content.utf8).write(to: ghosttyConfigURL, options: .atomic)
+        let overrides = [
+            // Macterm composites window translucency at the AppKit level —
+            // ghostty must draw a fully transparent terminal or we'd double-
+            // tint. See WindowAppearance.swift.
+            "background-opacity = 0",
+            // We call CGSSetWindowBackgroundBlurRadius ourselves; ghostty's
+            // own blur would compose on top of it.
+            "background-blur = 0",
+        ].joined(separator: "\n") + "\n"
+        try? Data(overrides.utf8).write(to: overridesURL, options: .atomic)
     }
 }

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -25,7 +25,8 @@ final class GhosttyApp {
             logger.error("ghostty_init failed")
             return
         }
-        guard let cfg = loadConfig() else {
+        let (cfgOpt, _) = loadConfig()
+        guard let cfg = cfgOpt else {
             logger.error("ghostty_config_new failed")
             return
         }
@@ -64,8 +65,21 @@ final class GhosttyApp {
 
     // MARK: - Config
 
-    func reloadConfig() {
-        guard let app, let newConfig = loadConfig() else { return }
+    /// Result of a config (re)load. `missingUserConfigPath` is populated when
+    /// the user pointed to a path that doesn't exist on disk — useful to
+    /// surface from the Settings reload button. `diagnostics` are libghostty's
+    /// parse warnings/errors (unknown keys, bad values, etc.). Both are
+    /// empty/nil on a clean reload.
+    struct ReloadResult {
+        var missingUserConfigPath: String?
+        var diagnostics: [String]
+    }
+
+    @discardableResult
+    func reloadConfig() -> ReloadResult {
+        guard let app else { return ReloadResult(diagnostics: []) }
+        let (newConfig, result) = loadConfig()
+        guard let newConfig else { return result }
         ghostty_app_update_config(app, newConfig)
         // Also update each existing surface so changes take effect immediately
         for view in GhosttyTerminalNSView.allLiveViews() {
@@ -77,6 +91,7 @@ final class GhosttyApp {
         config = newConfig
         configVersion += 1
         NotificationCenter.default.post(name: .mactermConfigDidChange, object: nil)
+        return result
     }
 
     var backgroundColor: NSColor { configColor("background") ?? NSColor(srgbRed: 0.11, green: 0.11, blue: 0.14, alpha: 1) }
@@ -101,22 +116,48 @@ final class GhosttyApp {
         return NSColor(srgbRed: CGFloat(color.r) / 255, green: CGFloat(color.g) / 255, blue: CGFloat(color.b) / 255, alpha: 1)
     }
 
-    private func loadConfig() -> ghostty_config_t? {
-        guard let cfg = ghostty_config_new() else { return nil }
-        MactermConfig.shared.ghosttyConfigPath.withCString { ghostty_config_load_file(cfg, $0) }
+    private func loadConfig() -> (ghostty_config_t?, ReloadResult) {
+        var result = ReloadResult(diagnostics: [])
+        guard let cfg = ghostty_config_new() else { return (nil, result) }
+
+        // Three-layer ghostty config:
+        //   1. Macterm defaults — tasteful first-launch values.
+        //   2. User's ghostty.conf — overrides any default. Source of truth
+        //      for all ghostty-shaped settings (theme, font, palette, keybinds,
+        //      shell integration, etc.).
+        //   3. Macterm overrides — keys Macterm absolutely needs to control,
+        //      currently just background-opacity/blur for the window-level
+        //      translucency contract. Loaded last so it overrides the user.
+        // libghostty merges last-wins, so this ordering produces:
+        //   Macterm defaults < user's ghostty.conf < Macterm overrides
+        MactermConfig.shared.defaultsPath.withCString { ghostty_config_load_file(cfg, $0) }
+        let userPath = Preferences.shared.expandedUserGhosttyConfigPath
+        if !userPath.isEmpty {
+            if FileManager.default.fileExists(atPath: userPath) {
+                userPath.withCString { ghostty_config_load_file(cfg, $0) }
+            } else {
+                logger.info("user ghostty.conf not found at \(userPath, privacy: .public); skipping")
+                result.missingUserConfigPath = userPath
+            }
+        }
+        MactermConfig.shared.overridesPath.withCString { ghostty_config_load_file(cfg, $0) }
         ghostty_config_load_recursive_files(cfg)
         ghostty_config_finalize(cfg)
 
-        // Log config diagnostics as warnings
+        // Collect ghostty's diagnostics (parse errors, unknown keys, bad
+        // values). Log them and surface to the caller so the Settings reload
+        // button can show them in an alert.
         let diagCount = ghostty_config_diagnostics_count(cfg)
         for i in 0 ..< diagCount {
             let diag = ghostty_config_get_diagnostic(cfg, i)
             if let msg = diag.message {
-                logger.warning("config: \(String(cString: msg))")
+                let s = String(cString: msg)
+                logger.warning("config: \(s, privacy: .public)")
+                result.diagnostics.append(s)
             }
         }
 
-        return cfg
+        return (cfg, result)
     }
 
     private static let resourcePaths = [

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -9,6 +9,10 @@ enum SplitPosition { case first, second }
 final class Pane: Identifiable {
     let id = UUID()
     let projectPath: String
+    /// Optional command to run instead of the user's shell. Used for one-off
+    /// "open this in $EDITOR" tabs. When the command exits, the pane's
+    /// process-exit callback fires the same as a shell exit.
+    let initialCommand: String?
     var title: String = "Terminal"
     let searchState = TerminalSearchState()
 
@@ -23,7 +27,7 @@ final class Pane: Identifiable {
 
     func ensureNSView() -> GhosttyTerminalNSView {
         if let existing = _nsView { return existing }
-        let view = GhosttyTerminalNSView(workingDirectory: projectPath)
+        let view = GhosttyTerminalNSView(workingDirectory: projectPath, initialCommand: initialCommand)
         _nsView = view
         return view
     }
@@ -82,8 +86,9 @@ final class Pane: Identifiable {
         token.allSatisfy { !$0.isLetter && !$0.isNumber }
     }
 
-    init(projectPath: String) {
+    init(projectPath: String, initialCommand: String? = nil) {
         self.projectPath = projectPath
+        self.initialCommand = initialCommand
     }
 }
 

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -54,9 +54,9 @@ final class TerminalTab: Identifiable {
         return splitRoot.findPane(id: focusedPaneID)
     }
 
-    init(projectPath: String) {
+    init(projectPath: String, initialCommand: String? = nil) {
         id = UUID()
-        let pane = Pane(projectPath: projectPath)
+        let pane = Pane(projectPath: projectPath, initialCommand: initialCommand)
         splitRoot = .pane(pane)
         focusedPaneID = pane.id
     }
@@ -177,8 +177,8 @@ final class Workspace: Identifiable {
     }
 
     @discardableResult
-    func createTab(projectPath: String) -> TerminalTab {
-        let tab = TerminalTab(projectPath: projectPath)
+    func createTab(projectPath: String, initialCommand: String? = nil) -> TerminalTab {
+        let tab = TerminalTab(projectPath: projectPath, initialCommand: initialCommand)
         tabs.append(tab)
         if let current = activeTabID { tabHistory.push(current) }
         activeTabID = tab.id

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -20,106 +20,53 @@ struct SettingsView: View {
 
 // MARK: - Appearance
 
-private struct ThemePreview: Identifiable, Hashable {
-    let id: String
-    let background: NSColor
-    let foreground: NSColor
-    let palette: [NSColor]
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-
-    static func == (lhs: ThemePreview, rhs: ThemePreview) -> Bool {
-        lhs.id == rhs.id
-    }
-}
-
 private struct AppearanceSettings: View {
-    @State
-    private var themes: [ThemePreview] = []
-    @State
-    private var currentTheme: String = Preferences.shared.theme
-    @State
-    private var currentFont: String = Preferences.shared.fontFamily
-    @State
-    private var fontSize: Int = Preferences.shared.fontSize
-    @State
-    private var monoFonts: [String] = []
+    @Environment(AppState.self)
+    private var appState
+    @Environment(ProjectStore.self)
+    private var projectStore
     @AppStorage(Preferences.Keys.autoTiling)
     private var autoTilingEnabled = false
+    @State
+    private var ghosttyConfigPath: String = Preferences.shared.userGhosttyConfigPath
     @State
     private var backgroundOpacity: Double = Preferences.shared.windowOpacity
     @State
     private var backgroundBlurRadius: Double = .init(Preferences.shared.windowBlurRadius)
+
     var body: some View {
         Form {
-            Section("Font") {
-                Picker("Font Family", selection: $currentFont) {
-                    Text("Default").tag("")
-                    Divider()
-                    ForEach(monoFonts, id: \.self) { family in
-                        Text(family)
-                            .font(.custom(family, size: 13))
-                            .tag(family)
+            Section("Ghostty Config") {
+                HStack {
+                    TextField("Path", text: $ghosttyConfigPath, prompt: Text("~/.config/ghostty/config"))
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { commitPath() }
+                    Button("Browse…") { browse() }
+                    Button("Reset") {
+                        ghosttyConfigPath = "~/.config/ghostty/config"
+                        commitPath()
                     }
                 }
-                .onChange(of: currentFont) { _, v in
-                    Preferences.shared.fontFamily = v
-                }
-
-                Stepper(value: $fontSize, in: 8 ... 32) {
-                    HStack {
-                        Text("Font Size")
-                        Spacer()
-                        Text("\(fontSize)pt")
-                            .monospacedDigit()
-                            .foregroundStyle(.secondary)
+                HStack {
+                    Spacer()
+                    Button("Reload") {
+                        commitPath()
+                        reloadAndReport()
                     }
-                }
-                .onChange(of: fontSize) { _, v in
-                    Preferences.shared.fontSize = v
-                }
-            }
-
-            Section("Theme") {
-                Picker("Select Theme", selection: $currentTheme) {
-                    ForEach(themes) { theme in
-                        Text(theme.id).tag(theme.id)
+                    .help("Re-read your ghostty.conf. Click after saving external edits.")
+                    Button("Edit Ghostty Config") {
+                        commitPath()
+                        appState.openGhosttyConfigEditor(projectStore: projectStore)
                     }
+                    .disabled(ghosttyConfigPath.isEmpty)
                 }
-                .onChange(of: currentTheme) { _, v in
-                    Preferences.shared.theme = v
-                }
-
-                if let theme = themes.first(where: { $0.id == currentTheme }) {
-                    HStack(alignment: .top, spacing: 16) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("BG / FG")
-                                .font(.system(size: 10))
-                                .foregroundStyle(.secondary)
-                            HStack(spacing: 6) {
-                                colorChip(theme.background)
-                                colorChip(theme.foreground)
-                            }
-                        }
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Palette")
-                                .font(.system(size: 10))
-                                .foregroundStyle(.secondary)
-                            LazyVGrid(
-                                columns: Array(repeating: GridItem(.fixed(16), spacing: 4, alignment: .leading), count: 8),
-                                alignment: .leading,
-                                spacing: 4
-                            ) {
-                                ForEach(Array(theme.palette.enumerated()), id: \.offset) { _, color in
-                                    colorChip(color)
-                                }
-                            }
-                        }
-                    }
-                }
+                Text(
+                    "Your ghostty.conf controls theme, font, palette, keybinds, and most other terminal settings. "
+                        + "Macterm provides defaults; anything in your ghostty.conf overrides them. "
+                        + "Macterm does not auto-detect external edits — click Reload after saving."
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
             }
 
             Section("Window") {
@@ -162,92 +109,57 @@ private struct AppearanceSettings: View {
             }
         }
         .formStyle(.grouped)
-        .task { await loadThemes() }
-        .onAppear {
-            monoFonts = Self.loadMonoFonts()
+    }
+
+    /// Push the text-field's current value into Preferences and reload. We
+    /// don't bind directly because that would reload on every keystroke;
+    /// debouncing on submit/blur matches how the path is typically edited.
+    /// If the new path produces errors, the alert surfaces via the same
+    /// `reloadAndReport` path the Reload button uses.
+    private func commitPath() {
+        guard ghosttyConfigPath != Preferences.shared.userGhosttyConfigPath else { return }
+        Preferences.shared.userGhosttyConfigPath = ghosttyConfigPath
+        reloadAndReport()
+    }
+
+    /// Trigger a libghostty config reload and surface any user-visible errors
+    /// (missing file, parse errors) as a modal alert. Silent on success.
+    private func reloadAndReport() {
+        let result = GhosttyApp.shared.reloadConfig()
+        var lines: [String] = []
+        if let missing = result.missingUserConfigPath {
+            lines.append("File not found: \(missing)")
         }
-    }
-
-    private static func loadMonoFonts() -> [String] {
-        NSFontManager.shared
-            .availableFontFamilies
-            .filter { family in
-                guard let font = NSFont(name: family, size: 13) else { return false }
-                return font.isFixedPitch || font.fontDescriptor.symbolicTraits.contains(.monoSpace)
-            }
-            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
-    }
-
-    private func loadThemes() async {
-        let paths = [
-            "/Applications/Ghostty.app/Contents/Resources/ghostty/themes",
-            NSHomeDirectory() + "/Applications/Ghostty.app/Contents/Resources/ghostty/themes",
-            NSHomeDirectory() + "/.config/ghostty/themes",
-        ]
-        var result: [ThemePreview] = []
-        for dir in paths {
-            guard let files = try? FileManager.default.contentsOfDirectory(atPath: dir) else { continue }
-            for file in files.sorted() {
-                let path = (dir as NSString).appendingPathComponent(file)
-                guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
-                let bg = parseColor(from: content, key: "background") ?? NSColor(srgbRed: 0.1, green: 0.1, blue: 0.1, alpha: 1)
-                let fg = parseColor(from: content, key: "foreground") ?? .white
-                let palette = parsePalette(from: content)
-                result.append(ThemePreview(id: file, background: bg, foreground: fg, palette: palette))
-            }
+        if !result.diagnostics.isEmpty {
+            lines.append(contentsOf: result.diagnostics)
         }
-        var seen = Set<String>()
-        themes = result.filter { seen.insert($0.id).inserted }
+        guard !lines.isEmpty else { return }
+
+        let alert = NSAlert()
+        alert.messageText = result.missingUserConfigPath != nil
+            ? "Ghostty config not found"
+            : "Issues in your ghostty.conf"
+        alert.informativeText = lines.joined(separator: "\n\n")
+        alert.alertStyle = result.missingUserConfigPath != nil ? .warning : .informational
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
-    private static func colorFromHex(_ hex: String) -> NSColor? {
-        let cleaned = hex.replacingOccurrences(of: "#", with: "")
-        guard cleaned.count == 6, let val = UInt64(cleaned, radix: 16) else { return nil }
-        return NSColor(
-            srgbRed: CGFloat((val >> 16) & 0xFF) / 255,
-            green: CGFloat((val >> 8) & 0xFF) / 255,
-            blue: CGFloat(val & 0xFF) / 255,
-            alpha: 1
-        )
-    }
-
-    private func parseColor(from content: String, key: String) -> NSColor? {
-        for line in content.components(separatedBy: .newlines) {
-            let t = line.trimmingCharacters(in: .whitespaces)
-            guard t.hasPrefix(key),
-                  t.dropFirst(key.count).trimmingCharacters(in: .whitespaces).hasPrefix("="),
-                  let eq = t.firstIndex(of: "=")
-            else { continue }
-            let hex = t[t.index(after: eq)...].trimmingCharacters(in: .whitespaces)
-            return Self.colorFromHex(hex)
+    private func browse() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
+        // Default the panel to the user's currently configured path's
+        // directory so they don't always start from ~.
+        let current = Preferences.shared.expandedUserGhosttyConfigPath
+        if !current.isEmpty {
+            panel.directoryURL = URL(fileURLWithPath: current).deletingLastPathComponent()
         }
-        return nil
-    }
-
-    private func parsePalette(from content: String) -> [NSColor] {
-        let pattern = #"([0-9]{1,2})\s*=\s*#([0-9a-fA-F]{6})"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
-        let ns = content as NSString
-        let matches = regex.matches(in: content, range: NSRange(location: 0, length: ns.length))
-
-        var indexed: [Int: NSColor] = [:]
-        for match in matches {
-            guard match.numberOfRanges == 3 else { continue }
-            let iString = ns.substring(with: match.range(at: 1))
-            let hex = ns.substring(with: match.range(at: 2))
-            guard let idx = Int(iString), let color = Self.colorFromHex(hex) else { continue }
-            indexed[idx] = color
-        }
-
-        return indexed.keys.sorted().compactMap { indexed[$0] }
-    }
-
-    private func colorChip(_ color: NSColor) -> some View {
-        Rectangle()
-            .fill(Color(nsColor: color))
-            .frame(width: 16, height: 16)
-            .clipShape(RoundedRectangle(cornerRadius: 3))
-            .overlay(RoundedRectangle(cornerRadius: 3).strokeBorder(.quaternary))
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        ghosttyConfigPath = url.path(percentEncoded: false)
+        commitPath()
     }
 }
 
@@ -297,29 +209,6 @@ private struct QuickTerminalSettings: View {
 
 // MARK: - Keymaps
 
-private enum OptionAsAlt: String, CaseIterable, Identifiable {
-    case off = "false"
-    case both = "true"
-    case left
-    case right
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .off: "Off (compose æ, ø, å, etc.)"
-        case .both: "Both Option keys"
-        case .left: "Left Option only"
-        case .right: "Right Option only"
-        }
-    }
-
-    static func from(_ raw: String?) -> OptionAsAlt {
-        guard let raw else { return .both }
-        return OptionAsAlt(rawValue: raw.lowercased()) ?? .both
-    }
-}
-
 private struct KeymapSettings: View {
     @State
     private var values: [String: String] = [:]
@@ -327,28 +216,9 @@ private struct KeymapSettings: View {
     private var capturingActionID: String?
     @State
     private var invalidActions: Set<String> = []
-    @State
-    private var optionAsAlt: OptionAsAlt = .from(Preferences.shared.optionAsAlt)
 
     var body: some View {
         Form {
-            Section("Input") {
-                Picker("Option as Alt", selection: $optionAsAlt) {
-                    ForEach(OptionAsAlt.allCases) { mode in
-                        Text(mode.title).tag(mode)
-                    }
-                }
-                .onChange(of: optionAsAlt) { _, v in
-                    Preferences.shared.optionAsAlt = v.rawValue
-                }
-                Text(
-                    "Pick \"Left\" or \"Right\" to keep one Option key for typing macOS special characters "
-                        + "(æ, ø, å, …) while the other still sends Alt to terminal programs."
-                )
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-            }
-
             Section("Keyboard Shortcuts") {
                 ForEach(HotkeyAction.allCases) { action in
                     HStack {

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -13,6 +13,7 @@ final class GhosttyTerminalNSView: NSView {
 
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
     private let workingDirectory: String
+    private let initialCommand: String?
     var onTitleChange: ((String) -> Void)?
     var onFocus: (() -> Void)?
     var onProcessExit: (() -> Void)?
@@ -31,8 +32,9 @@ final class GhosttyTerminalNSView: NSView {
     private var keyTextAccumulator: [String] = []
     private var currentKeyEvent: NSEvent?
 
-    init(workingDirectory: String) {
+    init(workingDirectory: String, initialCommand: String? = nil) {
         self.workingDirectory = workingDirectory
+        self.initialCommand = initialCommand
         super.init(frame: .zero)
         wantsLayer = true
         setupTrackingArea()
@@ -83,9 +85,23 @@ final class GhosttyTerminalNSView: NSView {
         config.scale_factor = Double(window?.backingScaleFactor ?? 2.0)
         config.context = GHOSTTY_SURFACE_CONTEXT_SPLIT
 
+        // Nest withCString so both pointers stay valid through
+        // ghostty_surface_new. libghostty copies the strings before the call
+        // returns, so the nesting only matters during the call itself.
         workingDirectory.withCString { cwd in
             config.working_directory = cwd
-            surface = ghostty_surface_new(app, &config)
+            if let cmd = initialCommand {
+                // Wait for user input before closing the surface when the
+                // command exits — otherwise the tab vanishes the instant the
+                // editor quits, which is jarring.
+                config.wait_after_command = true
+                cmd.withCString { cmdPtr in
+                    config.command = cmdPtr
+                    surface = ghostty_surface_new(app, &config)
+                }
+            } else {
+                surface = ghostty_surface_new(app, &config)
+            }
         }
         guard let surface else { return }
 

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -322,10 +322,19 @@ final class GhosttyTerminalNSView: NSView {
         ke.consumed_mods = consumedMods(translationEvent.modifierFlags)
         ke.composing = hasMarkedText() || hadMarkedText
 
-        if !keyTextAccumulator.isEmpty, !ke.composing {
+        // Accumulator content is text the IME *committed* via `insertText`
+        // during interpretKeyEvents. Send it regardless of `composing` state:
+        // committing happens precisely when the IME finishes a syllable, which
+        // may overlap with a new composition starting (so `composing == true`
+        // here even though this specific text is finalized). Without this,
+        // Korean / Japanese / Chinese input drops every committed character.
+        // The text itself carries no composing flag since it's already final.
+        if !keyTextAccumulator.isEmpty {
+            var commitKE = ke
+            commitKE.composing = false
             for text in keyTextAccumulator {
-                text.withCString { ke.text = $0
-                    _ = ghostty_surface_key(surface, ke)
+                text.withCString { commitKE.text = $0
+                    _ = ghostty_surface_key(surface, commitKE)
                 }
             }
         } else if !hasMarkedText() {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Split Panes**: Unlimited horizontal and vertical splits, with optional auto-tiling.
 - **Persistence**: Projects, tabs, and panes are saved and restored automatically.
 - **Quick terminal**: Global terminal accessible from anywhere.
-- **Highly Configurable**: Configurable theme, font, and keymap with hot-reloading.
+- **Configurable via your ghostty.conf**: Macterm reads your existing `~/.config/ghostty/config`. Theme, font, palette, keybinds — all of it just works.
 - **Command Palette**: Versatile command palette to interact with multiplexing (open, delete, and search projects)
 
 ## Install
@@ -38,6 +38,40 @@ Since the app isn't signed with an Apple Developer certificate, macOS will block
 ```bash
 xattr -cr /Applications/Macterm.app
 ```
+
+## For Ghostty Users
+
+Macterm uses libghostty as its terminal engine and reads your existing `~/.config/ghostty/config` on launch. Themes, fonts, palettes, keybinds, scrollback, cursor style, shell integration, mouse behavior — everything ghostty supports works the same in Macterm.
+
+If your config lives somewhere else, point Macterm at it in **Settings → Appearance → Ghostty Config**. You can also click **Edit Ghostty Config** to open it in `$EDITOR` (default `vi`) inside a Macterm tab, and **Reload** to pick up external edits without restarting.
+
+### What's different from Ghostty.app
+
+A handful of settings either don't apply or are overridden, because Macterm renders some of the chrome itself instead of letting ghostty do it. If you have these in your ghostty.conf, they'll be parsed without errors but won't change anything in Macterm:
+
+| Setting                                                         | Status          | Why                                                                                                                              |
+| --------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `background-opacity`                                            | Overridden to 0 | Macterm composites window translucency at the AppKit level. Use **Settings → Appearance → Window → Background Opacity** instead. |
+| `background-blur`                                               | Overridden to 0 | Same reason. Use the **Background Blur** slider in Settings.                                                                     |
+| `unfocused-split-opacity`                                       | Ignored         | Macterm draws its own dim overlay on unfocused panes.                                                                            |
+| `split-divider-color`                                           | Ignored         | Divider color comes from the theme's foreground.                                                                                 |
+| `window-padding-color`                                          | Ignored         | Padding follows the SwiftUI background stack.                                                                                    |
+| `macos-titlebar-*`, `macos-window-buttons`, `window-decoration` | Ignored         | Macterm has its own titlebar implementation.                                                                                     |
+| `quick-terminal-*` family                                       | Ignored         | Macterm has its own quick terminal. Size lives in **Settings → Quick Terminal**.                                                 |
+
+Macterm-specific settings (window opacity/blur, quick terminal dimensions, hotkeys, auto-tile) live in **Macterm → Settings**. Everything else belongs in your ghostty.conf.
+
+### Keybinds
+
+Most of your `keybind = ...` lines in ghostty config work the same as in Ghostty.app. The one rule to know: **on conflict, Macterm wins.** If a keystroke matches one of Macterm's app-level shortcuts (new tab, splits, focus moves, command palette, etc.), Macterm handles it and ghostty never sees the event. If it doesn't conflict, the keystroke flows through to libghostty and your ghostty `keybind` fires normally — including ghostty's defaults like `cmd+shift+c` (copy) and `cmd+shift+v` (paste).
+
+Every conflicting combo is rebindable in **Settings → Keymaps**, so if you'd rather a particular shortcut belong to your ghostty config, clear or remap it there.
+
+One caveat: ghostty keybinds that drive *app-level* actions (`new_split`, `new_tab`, `goto_tab`, `goto_split`, etc.) currently do nothing in Macterm — Macterm only triggers those actions through its own keybinds in **Settings → Keymaps**. Terminal-level ghostty bindings (copy/paste, scroll, font size, etc.) work normally.
+
+### First-launch defaults
+
+If you don't have a `~/.config/ghostty/config`, Macterm starts with the Rose Pine theme at 16pt, 16px window padding, and `macos-option-as-alt = true` (so Option+letter sends Alt to your shell instead of typing special characters). Everything else falls through to ghostty's own defaults. Any of these can be overridden by adding the corresponding line to your ghostty.conf.
 
 ## Demos
 


### PR DESCRIPTION
## Summary
- Macterm now loads `~/.config/ghostty/config` (configurable in Settings). Three-layer config: Macterm defaults → user's ghostty.conf → Macterm must-win overrides (`background-opacity=0`, `background-blur=0`).
- New Settings UI: path field with Browse/Reset/Reload buttons and an Edit button that opens the config in `\$EDITOR` (default `vi`) inside a Macterm tab. Auto-creates a Home project if no project is active.
- Removes Theme picker, Font Family, Font Size, and Option-as-Alt controls from Settings — those live in ghostty.conf now. One-time migration silently clears the deprecated stored values.
- Errors (missing file, ghostty parse diagnostics) surface as a modal alert on user-initiated reloads.
- README: new "For Ghostty Users" section documenting what's honored, what's overridden, and the Macterm-wins keybind conflict rule.

## Test plan
- [x] `mise run format && mise run lint && mise run test` pass
- [ ] Manual: existing `~/.config/ghostty/config` with custom theme/font is honored on first launch after upgrade
- [ ] Manual: Edit button opens config in `\$EDITOR`; Reload picks up external edits without restart
- [ ] Manual: invalid path → error alert
- [ ] Manual: malformed ghostty.conf → diagnostics alert
- [ ] Manual: window opacity / blur sliders still work (overrides take effect)