### PR TITLE
feat: palette command to replace project path with current pane pwd

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -30,6 +30,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
     case openProject
     case renameProject
     case removeProject
+    case replaceProjectPathWithCurrentDir
     case nextProject
     case previousProject
     // Window
@@ -63,6 +64,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .openProject: "Open project"
         case .renameProject: "Rename current project"
         case .removeProject: "Remove current project"
+        case .replaceProjectPathWithCurrentDir: "Replace project path with current directory"
         case .nextProject: "Next project"
         case .previousProject: "Previous project"
         case .toggleSidebar: "Toggle sidebar"
@@ -95,6 +97,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .openProject,
              .renameProject,
              .removeProject,
+             .replaceProjectPathWithCurrentDir,
              .nextProject,
              .previousProject: .projects
         case .toggleSidebar,
@@ -135,7 +138,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .toggleQuickTerminal: .toggleQuickTerminal
         case .renameTab,
              .renameProject,
-             .removeProject: nil
+             .removeProject,
+             .replaceProjectPathWithCurrentDir: nil
         }
     }
 

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -120,6 +120,24 @@ final class AppState {
         return project
     }
 
+    /// Update the active project's path to wherever the focused pane currently
+    /// sits (via OSC 7 — `pane.nsView.currentPwd`). Useful when a project
+    /// started in one directory but the user has settled into a subdirectory
+    /// and wants new tabs / persisted state to start there.
+    ///
+    /// No-op when there's no active project or no resolvable pwd. We don't
+    /// touch open panes or workspaces — those keep their current cwd; only
+    /// future tabs created via `createTab(projectID:projects:)` (which reads
+    /// `project.path`) will land in the new directory.
+    func replaceProjectPathWithCurrentDir(projectStore: ProjectStore) {
+        guard let projectID = activeProjectID,
+              let pane = focusedPane(for: projectID),
+              let pwd = pane.nsView?.currentPwd,
+              !pwd.isEmpty
+        else { return }
+        projectStore.setPath(id: projectID, to: pwd)
+    }
+
     func removeProject(_ projectID: UUID) {
         if let ws = workspaces[projectID] {
             for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {

--- a/Macterm/Palette/CommandSource.swift
+++ b/Macterm/Palette/CommandSource.swift
@@ -120,6 +120,16 @@ struct CommandSource: PaletteSource {
                 ctx.appState.removeProject(projectID)
                 ctx.projectStore.remove(id: projectID)
             }
+        case .replaceProjectPathWithCurrentDir:
+            // Only meaningful when there's an active project AND the focused
+            // pane's pwd differs from the project's current path. Hiding the
+            // entry otherwise keeps the palette uncluttered.
+            guard let projectID,
+                  let pane = ctx.appState.focusedPane(for: projectID),
+                  let pwd = pane.nsView?.currentPwd, !pwd.isEmpty,
+                  current?.path != pwd
+            else { return nil }
+            action = { ctx.appState.replaceProjectPathWithCurrentDir(projectStore: ctx.projectStore) }
         case .nextProject:
             action = { ctx.appState.selectNextProject(projects: ctx.projectStore.projects) }
         case .previousProject:

--- a/Macterm/Persistence/ProjectStore.swift
+++ b/Macterm/Persistence/ProjectStore.swift
@@ -29,6 +29,13 @@ final class ProjectStore {
         save()
     }
 
+    func setPath(id: UUID, to newPath: String) {
+        guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
+        guard projects[index].path != newPath else { return }
+        projects[index].path = newPath
+        save()
+    }
+
     func reorder(fromOffsets source: IndexSet, toOffset destination: Int) {
         projects.move(fromOffsets: source, toOffset: destination)
         for i in projects.indices {


### PR DESCRIPTION
## Summary
Adds a new palette-only command **"Replace project path with current directory"** under the Projects category. It updates the active project's stored path to wherever the focused pane currently sits (read from libghostty's OSC 7 `currentPwd`), so future `Cmd+T` tabs land there. Open panes and existing tabs are left alone.

The entry only surfaces when:
- there's an active project, *and*
- the focused pane has a non-empty pwd, *and*
- that pwd differs from the project's current path

so it stays out of sight in the common case.

No hotkey by default; rebindable via Settings → Keymaps if a user wants one.

## Test plan
- [x] `mise run format && mise run lint && mise run test` pass
- [ ] Manual: open project at `/Users/x/dev`, `cd ~/dev/some-sub` in the focused pane, run the palette command → project sidebar still says the old name but `Cmd+T` opens in `~/dev/some-sub`.
- [ ] Manual: when pwd matches project path, command is hidden from palette.
- [ ] Manual: when no project is active, command is hidden.