### PR TITLE
Fix font scaling when moving terminal between displays of different DPI

### DIFF
--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -34,7 +34,6 @@ final class GhosttyTerminalNSView: NSView {
     init(workingDirectory: String) {
         self.workingDirectory = workingDirectory
         super.init(frame: .zero)
-        wantsLayer = true
         setupTrackingArea()
         Self.liveViews.add(self)
     }
@@ -43,19 +42,6 @@ final class GhosttyTerminalNSView: NSView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")
     }
-
-    override func makeBackingLayer() -> CALayer {
-        let layer = CAMetalLayer()
-        layer.pixelFormat = .bgra8Unorm
-        layer.isOpaque = false
-        layer.framebufferOnly = false
-        layer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-        layer.needsDisplayOnBoundsChange = true
-        layer.presentsWithTransaction = false
-        return layer
-    }
-
-    override var wantsUpdateLayer: Bool { true }
 
     // MARK: - Surface lifecycle
 
@@ -80,7 +66,7 @@ final class GhosttyTerminalNSView: NSView {
         config.platform_tag = GHOSTTY_PLATFORM_MACOS
         config.platform = ghostty_platform_u(macos: ghostty_platform_macos_s(nsview: Unmanaged.passUnretained(self).toOpaque()))
         config.userdata = Unmanaged.passUnretained(self).toOpaque()
-        config.scale_factor = Double(window?.backingScaleFactor ?? 2.0)
+        config.scale_factor = Double(NSScreen.main?.backingScaleFactor ?? 2.0)
         config.context = GHOSTTY_SURFACE_CONTEXT_SPLIT
 
         workingDirectory.withCString { cwd in
@@ -88,10 +74,6 @@ final class GhosttyTerminalNSView: NSView {
             surface = ghostty_surface_new(app, &config)
         }
         guard let surface else { return }
-
-        let scale = Double(window?.backingScaleFactor ?? 2.0)
-        ghostty_surface_set_content_scale(surface, scale, scale)
-        ghostty_surface_set_size(surface, UInt32(backingSize.width), UInt32(backingSize.height))
 
         let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
@@ -187,10 +169,10 @@ final class GhosttyTerminalNSView: NSView {
         let scaledSize = convertToBacking(bounds).size
         guard scaledSize.width > 0, scaledSize.height > 0 else { return }
         let scale = Double(window?.backingScaleFactor ?? 2.0)
-        if let metalLayer = layer as? CAMetalLayer {
+        if let liveLayer = layer {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
-            metalLayer.contentsScale = CGFloat(scale)
+            liveLayer.contentsScale = CGFloat(scale)
             CATransaction.commit()
         }
         ghostty_surface_set_content_scale(surface, scale, scale)


### PR DESCRIPTION
## Summary

Fonts in Macterm's terminal surfaces previously rendered at the wrong logical size — and in some configurations pixelated — after a window was dragged between displays with different backing scale factors (e.g. Retina ↔ non-Retina). The official Ghostty.app does not have this bug. Investigation showed the divergence came from how Macterm's `GhosttyTerminalNSView` set up its Metal layer and how it talked to libghostty at surface-creation time.

## Root cause

Libghostty's Metal renderer (`src/renderer/Metal.zig`) explicitly puts the host NSView into **layer-hosting** mode using its own `IOSurfaceLayer`:

```zig
// On macOS we do this by making the view "layer-hosting"
// by assigning it to the view's `layer` property BEFORE
// setting `wantsLayer` to `true`.
info.view.setProperty("layer", layer.layer.value);
info.view.setProperty("wantsLayer", true);
```

But `GhosttyTerminalNSView.init` was pre-setting `wantsLayer = true` and providing a custom `CAMetalLayer` through `makeBackingLayer()`. By the time libghostty tried to install its `IOSurfaceLayer`, the view was already in **layer-backed** mode — so the layer-hosting pattern didn't apply cleanly, and the cached `layer as? CAMetalLayer` cast in `updateMetalLayerSize` was failing silently because the real installed layer was `IOSurfaceLayer`, not `CAMetalLayer`. That meant `contentsScale` was never refreshed on display switches, while libghostty's internal scale state was being set twice (once via `config.scale_factor`, again immediately via an extra `ghostty_surface_set_content_scale` + `ghostty_surface_set_size` call right after `ghostty_surface_new`).

## Changes

Mirror upstream Ghostty.app's surface initialization (`macos/Sources/Ghostty/Surface View/SurfaceView.swift` and `SurfaceView_AppKit.swift`):

1. Remove `wantsLayer = true` from `init` and remove the `makeBackingLayer` override — let libghostty's renderer install its `IOSurfaceLayer` in layer-hosting mode.
2. Initialize `config.scale_factor` from `NSScreen.main?.backingScaleFactor` rather than the (possibly nil) window's backing scale, matching `Ghostty.SurfaceConfiguration.withCValue`.
3. Stop calling `ghostty_surface_set_content_scale` and `ghostty_surface_set_size` immediately after `ghostty_surface_new`. The surface boots from `config.scale_factor`; size and scale updates flow through the regular `setFrameSize` and `viewDidChangeBackingProperties`/window-notification paths.
4. In `updateMetalLayerSize`, set `contentsScale` on whatever `CALayer` libghostty actually installed, not only on a `CAMetalLayer`.

## Test plan

- [ ] Open Macterm on a Retina display, type some text, drag the window onto a non-Retina display, drag back. Font visible size stays constant and glyphs are crisp on each display.
- [ ] Repeat with the quick terminal panel.
- [ ] Split panes still work and respond to resize on each display.
- [ ] Existing tests pass (`mise run test`).