### PR TITLE
chore: add labeler, stale, dependabot, and release-drafter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - area:ci
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,62 @@
+# PR auto-labels by file paths touched.
+# See https://github.com/actions/labeler
+
+"area:ui":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Macterm/Views/**"
+          - "Macterm/Settings/**"
+
+"area:terminal":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Macterm/Views/Terminal/**"
+          - "Macterm/Ghostty/**"
+
+"area:palette":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Macterm/Palette/**"
+
+"area:state":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Macterm/App/AppState.swift"
+          - "Macterm/Model/**"
+          - "Macterm/Persistence/**"
+
+"area:hotkeys":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Macterm/App/Hotkeys.swift"
+          - "Macterm/App/KeyRouter.swift"
+          - "Macterm/App/Responders.swift"
+
+"area:config":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Macterm/Config/**"
+
+"area:tests":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "MactermTests/**"
+
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - "mise.toml"
+          - "scripts/**"
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+"area:release":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/release.yml"
+          - "Macterm/Info.plist"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,47 @@
+name-template: "Macterm v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "What's New"
+    labels:
+      - enhancement
+      - feature
+  - title: "Fixes"
+    labels:
+      - bug
+      - fix
+  - title: "Maintenance"
+    labels:
+      - chore
+      - dependencies
+      - documentation
+
+exclude-labels:
+  - skip-changelog
+
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - enhancement
+      - feature
+  patch:
+    labels:
+      - bug
+      - fix
+      - chore
+      - dependencies
+      - documentation
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,8 +17,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,45 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # daily at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues: 60 days idle -> stale, 14 more -> closed.
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been inactive for 60 days. It will be closed in 14
+            days if there's no further activity. Add a comment or remove the
+            `stale` label to keep it open.
+          close-issue-message: >
+            Closing due to inactivity. Reopen if this is still relevant.
+          exempt-issue-labels: "pinned,help wanted,good first issue"
+
+          # PRs: 30 days idle -> stale, 14 more -> closed.
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has been inactive for 30 days. It will be closed in 14
+            days if there's no further activity. Push a commit or comment to
+            keep it open.
+          close-pr-message: >
+            Closing due to inactivity. Reopen when you're ready to pick it
+            back up.
+          exempt-pr-labels: "pinned,blocked"
+
+          # Don't annoy people about issues that just got opened.
+          operations-per-run: 100
+          remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # Issues: 60 days idle -> stale, 14 more -> closed.
           days-before-issue-stale: 60


### PR DESCRIPTION
## Summary
- **actions/labeler** auto-applies `area:*` labels on PRs based on changed paths (config in `.github/labeler.yml`).
- **actions/stale** marks issues stale after 60d / closes after 14 more, PRs after 30d / closes after 14 more. `pinned`, `help wanted`, `good first issue` are exempt for issues; `pinned`, `blocked` for PRs.
- **dependabot** bumps GitHub Actions weekly, grouped into a single PR labeled `dependencies` + `area:ci`.
- **release-drafter** maintains a categorized draft GitHub release on every merge to main, sorting merged PRs into What's New / Fixes / Maintenance by label. Replaces the manual note-writing step in `/release` — you still tag and publish.

Created the supporting labels (`area:*`, `dependencies`, `chore`, `stale`, `pinned`, `blocked`, `breaking`, `skip-changelog`) via `gh label create`.

## Test plan
- [ ] Merge this PR; confirm the Labeler workflow runs against itself or the next opened PR and applies `area:ci` + `area:docs` (touches `.github/` only).
- [ ] Within a week, confirm Dependabot opens a PR if any action has an update available.
- [ ] After the next merged PR, confirm a draft release appears in the Releases tab with the PR title under the right category.
- [ ] Stale workflow runs daily at 08:00 UTC; trigger manually via `workflow_dispatch` once to confirm it runs cleanly with zero matches.