### PR TITLE
ci: stand-in Checks workflow so path-filtered PRs aren't stuck on required contexts

### DIFF
--- a/.github/workflows/checks-skip.yml
+++ b/.github/workflows/checks-skip.yml
@@ -1,0 +1,41 @@
+name: Checks
+
+# Stand-in workflow that runs when the real Checks workflow's paths filter
+# excludes the PR (e.g. docs- or workflow-only changes). It registers the same
+# required check names (Format / Lint / Test) and immediately succeeds, so
+# branch protection's "Expected — Waiting for status to be reported" doesn't
+# block the merge forever.
+#
+# Triggered on the inverse path set of checks.yml. Both workflows share the
+# same `name:` so GitHub merges their check runs under one required context.
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.swift"
+      - "project.yml"
+      - "mise.toml"
+      - "scripts/**"
+      - ".swiftformat"
+      - ".swiftlint.yml"
+      - ".github/workflows/checks.yml"
+      - "Macterm/Info.plist"
+      - "Macterm/Macterm.entitlements"
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No Swift changes — skipping format."
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No Swift changes — skipping lint."
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No Swift changes — skipping tests."


### PR DESCRIPTION
## Problem
PR #21 (and any future docs- or workflow-only PR) sits forever showing:

```
Format    Expected — Waiting for status to be reported   Required
Lint      Expected — Waiting for status to be reported   Required
Test      Expected — Waiting for status to be reported   Required
```

`checks.yml` has a `paths:` filter so it only runs when Swift / build-config files change. When the filter excludes a PR, the workflow never starts, but branch protection still requires the contexts.

## Fix
Add a companion workflow `.github/workflows/checks-skip.yml` with:
- the same `name: Checks`,
- the same job names (`Format`, `Lint`, `Test`),
- the **inverse** path filter (`paths-ignore` set to the real workflow's `paths`).

It runs on `ubuntu-latest` and prints a no-op, satisfying the required contexts in ~5 seconds. Exactly one of the two workflows fires per PR.

## Test plan
- [ ] Merge this; rebase PR #21 onto main and confirm Format/Lint/Test report as passed.
- [ ] Open a Swift-only PR after merge and confirm the real `checks.yml` still runs (not the stand-in).