### PR TITLE
ci: gate Checks jobs with if-filter instead of on-level paths

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,34 +1,46 @@
 name: Checks
 
+# The workflow itself runs on every push/PR to main (no on-level paths filter).
+# A `changes` job inspects which files changed and downstream jobs gate on its
+# output with `if:`. A job whose `if:` evaluates false is reported to required
+# status checks as success, so PRs that only touch docs/workflows aren't stuck
+# on "Expected — Waiting for status to be reported".
+#
+# See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
 on:
   push:
     branches: [main]
-    paths:
-      - "**/*.swift"
-      - "project.yml"
-      - "mise.toml"
-      - "scripts/**"
-      - ".swiftformat"
-      - ".swiftlint.yml"
-      - ".github/workflows/checks.yml"
-      - "Macterm/Info.plist"
-      - "Macterm/Macterm.entitlements"
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.swift"
-      - "project.yml"
-      - "mise.toml"
-      - "scripts/**"
-      - ".swiftformat"
-      - ".swiftlint.yml"
-      - ".github/workflows/checks.yml"
-      - "Macterm/Info.plist"
-      - "Macterm/Macterm.entitlements"
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      swift: ${{ steps.filter.outputs.swift }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            swift:
+              - "**/*.swift"
+              - "project.yml"
+              - "mise.toml"
+              - "scripts/**"
+              - ".swiftformat"
+              - ".swiftlint.yml"
+              - ".github/workflows/checks.yml"
+              - "Macterm/Info.plist"
+              - "Macterm/Macterm.entitlements"
+
   format:
     name: Format
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
     runs-on: macos-26
     steps:
       - name: Checkout
@@ -41,6 +53,8 @@ jobs:
 
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
     runs-on: macos-26
     steps:
       - name: Checkout
@@ -53,6 +67,8 @@ jobs:
 
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
     runs-on: macos-26
     steps:
       - name: Checkout

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,13 +1,5 @@
 name: Checks
 
-# The workflow itself runs on every push/PR to main (no on-level paths filter).
-# A `changes` job inspects which files changed and downstream jobs gate on its
-# output with `if:`. A job whose `if:` evaluates false is reported to required
-# status checks as success, so PRs that only touch docs/workflows aren't stuck
-# on "Expected — Waiting for status to be reported".
-#
-# See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Problem
PR #21 (and any docs- or workflow-only PR) sits forever in:

```
Format    Expected — Waiting for status to be reported   Required
Lint      Expected — Waiting for status to be reported   Required
Test      Expected — Waiting for status to be reported   Required
```

`checks.yml` had an on-level \`paths:\` filter so the entire workflow skipped when Swift paths weren't touched. The required contexts then never get reported.

## Fix
Per [GitHub docs on handling skipped but required checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks): a required job whose \`if:\` evaluates false reports as **success**, but a workflow that never starts (because of on-level \`paths:\`) leaves required contexts pending.

Restructure:
- Drop the on-level \`paths:\` filter — workflow always starts.
- Add a \`changes\` job that uses \`dorny/paths-filter\` to set a \`swift\` output.
- Gate \`format\`, \`lint\`, \`test\` with \`if: needs.changes.outputs.swift == 'true'\`.

Non-Swift PRs see all three contexts report success in a few seconds; Swift PRs run the full suite as before.

## Test plan
- [ ] After merge, rebase PR #21 onto main and confirm Format/Lint/Test pass.
- [ ] Open a Swift-only PR and confirm the full macOS suite still runs.