### PR TITLE
fix: match shortcuts by keyboard layout

### DIFF
--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -73,11 +73,16 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
 
 struct HotkeyShortcut: Identifiable {
     let id: String
-    let keyCode: UInt16
+    let keyCode: UInt16 // Hardware keyCode for Carbon global hotkey registration.
+    let keyToken: String // Logical key token used for local NSEvent matching.
     let modifiers: NSEvent.ModifierFlags
 
+    /// Match by logical character, not hardware keyCode.
     func matches(_ event: NSEvent) -> Bool {
-        event.keyCode == keyCode && event.modifierFlags.intersection(.deviceIndependentFlagsMask) == modifiers
+        guard let token = HotkeyRegistry.eventToken(event),
+              token == keyToken
+        else { return false }
+        return event.modifierFlags.intersection(.deviceIndependentFlagsMask) == modifiers
     }
 }
 
@@ -94,16 +99,84 @@ enum HotkeyRegistry {
         "'": 39, "k": 40, ";": 41, "\\": 42,
         ",": 43, "/": 44, "n": 45, "m": 46, ".": 47,
         "tab": 48, "space": 49, "`": 50,
+        "escape": 53,
+        "left": 123, "right": 124, "down": 125, "up": 126,
     ]
+
+    /// Reverse mapping: hardware keyCode → base key token.
+    /// Used as a fallback when `charactersIgnoringModifiers` yields a shifted
+    /// symbol (e.g. `<` from `shift+,`) that is not itself a valid key token.
+    /// Populated from one representative per keyCode (lowercase for letters,
+    /// unshifted for symbols).
+    private static let keyCodeToBaseToken: [UInt16: String] = {
+        var result: [UInt16: String] = [:]
+        // Letters → lowercase
+        for letter in "abcdefghijklmnopqrstuvwxyz" {
+            if let code = keyCodes[String(letter)] { result[code] = String(letter) }
+        }
+        // Digits → digit
+        for digit in "0123456789" {
+            if let code = keyCodes[String(digit)] { result[code] = String(digit) }
+        }
+        // Symbols and special keys — pick the unshifted/base form per keyCode.
+        let baseEntries: [String: UInt16] = [
+            "=": 24, "-": 27, "]": 30, "[": 33,
+            "'": 39, ";": 41, "\\": 42, ",": 43, "/": 44, ".": 47,
+            "tab": 48, "space": 49, "`": 50,
+            "return": 36, "escape": 53,
+            "left": 123, "right": 124, "down": 125, "up": 126,
+        ]
+        for (token, code) in baseEntries {
+            result[code] = token
+        }
+        return result
+    }()
+
     private static let modifierOnlyCodes: Set<UInt16> = [54, 55, 56, 57, 58, 59, 60, 61, 62]
 
-    private static let keyTokensByCode: [UInt16: String] = {
-        var map: [UInt16: String] = [:]
-        for (token, code) in keyCodes where map[code] == nil {
-            map[code] = token
+    /// Characters produced by special keys → their named token form.
+    private static let specialCharsToToken: [String: String] = [
+        "\t": "tab",
+        "\r": "return",
+        " ": "space",
+        "\u{1b}": "escape",
+    ]
+
+    /// Normalize an NSEvent's key to a token string.
+    ///
+    /// Priority:
+    /// 1. Special chars (tab, return, space, escape)
+    /// 2. Single printable ASCII that is itself a known key token → use as-is
+    ///    (handles letters, digits, unshifted symbols — correct for Colemak/AZERTY)
+    /// 3. Printable but NOT a known key token (e.g. `<`, `?`, `!` from shifted
+    ///    symbols) → fall back to `keyCodeToBaseToken` to recover the base key
+    /// 4. Empty chars → arrow/non-character keys by keyCode
+    static func eventToken(_ event: NSEvent) -> String? {
+        guard let chars = event.charactersIgnoringModifiers else {
+            return Self.keyCodeToBaseToken[event.keyCode]
         }
-        return map
-    }()
+
+        // Special named keys
+        if let token = specialCharsToToken[chars] { return token }
+
+        // Single printable ASCII
+        if chars.count == 1, let scalar = chars.unicodeScalars.first,
+           scalar.value >= 0x20, scalar.value < 0x7F
+        {
+            let lower = chars.lowercased()
+            // If the char itself is a known key token, use it directly.
+            // This is the correct path for letters (layout-independent),
+            // digits, and unshifted symbols.
+            if keyCodes[lower] != nil { return lower }
+            // Printable but not a known token (e.g. "<" from shift+, "?")
+            // → fall back to the keyCode → base-token mapping.
+            if let token = Self.keyCodeToBaseToken[event.keyCode] { return token }
+            return nil
+        }
+
+        // Empty or multi-char → try named non-character keys by position
+        return Self.keyCodeToBaseToken[event.keyCode]
+    }
 
     static func parseShortcut(_ raw: String) -> HotkeyShortcut? {
         let cleaned = raw.lowercased().replacingOccurrences(of: " ", with: "")
@@ -135,7 +208,7 @@ enum HotkeyRegistry {
             }
         }
 
-        return HotkeyShortcut(id: cleaned, keyCode: keyCode, modifiers: modifiers)
+        return HotkeyShortcut(id: cleaned, keyCode: keyCode, keyToken: keyToken, modifiers: modifiers)
     }
 
     static func shortcutString(from event: NSEvent) -> String? {
@@ -149,7 +222,8 @@ enum HotkeyRegistry {
         if flags.contains(.option) { parts.append("opt") }
         guard !parts.isEmpty else { return nil }
 
-        guard let keyToken = keyTokensByCode[event.keyCode] else { return nil }
+        guard let keyToken = eventToken(event) else { return nil }
+        guard keyCodes[keyToken] != nil else { return nil }
         parts.append(keyToken)
         return parts.joined(separator: "+")
     }
@@ -184,6 +258,11 @@ enum HotkeyRegistry {
         case "space": "Space"
         case "return",
              "enter": "↩"
+        case "escape": "Esc"
+        case "left": "←"
+        case "right": "→"
+        case "up": "↑"
+        case "down": "↓"
         default: key.uppercased()
         }
         return out + keyLabel

--- a/MactermTests/App/HotkeysTests.swift
+++ b/MactermTests/App/HotkeysTests.swift
@@ -112,6 +112,160 @@ struct HotkeysTests {
         #expect(!HotkeyRegistry.isValidShortcutString("bogus+t"))
     }
 
+    // MARK: - Hotkey Action keyToken
+
+    @Test
+    func parseShortcut_sets_keyToken_for_regular_key() throws {
+        let s = try #require(HotkeyRegistry.parseShortcut("cmd+p"))
+        #expect(s.keyToken == "p")
+        #expect(s.keyCode == 35) // hardware keyCode for 'p' on QWERTY
+    }
+
+    @Test
+    func parseShortcut_sets_keyToken_for_special_keys() throws {
+        let tab = try #require(HotkeyRegistry.parseShortcut("ctrl+tab"))
+        #expect(tab.keyToken == "tab")
+
+        let ret = try #require(HotkeyRegistry.parseShortcut("cmd+return"))
+        #expect(ret.keyToken == "return")
+
+        let sp = try #require(HotkeyRegistry.parseShortcut("cmd+space"))
+        #expect(sp.keyToken == "space")
+    }
+
+    // MARK: - shortcutString (logical-key capture)
+
+    /// Simulate layout mismatch: characters = "p" but keyCode = 0 ('a' on QWERTY).
+    @Test
+    func shortcutString_captures_token_from_characters() throws {
+        let pEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "p",
+            charactersIgnoringModifiers: "p",
+            isARepeat: false,
+            keyCode: 0
+        ))
+        let str = try #require(HotkeyRegistry.shortcutString(from: pEvent))
+        #expect(str == "cmd+p")
+    }
+
+    @Test
+    func shortcutString_captures_special_key_from_characters() throws {
+        let tabEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\t",
+            charactersIgnoringModifiers: "\t",
+            isARepeat: false,
+            keyCode: 48
+        ))
+        let str = try #require(HotkeyRegistry.shortcutString(from: tabEvent))
+        #expect(str == "ctrl+tab")
+    }
+
+    @Test
+    func shortcutString_captures_return_key() throws {
+        let retEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\r",
+            charactersIgnoringModifiers: "\r",
+            isARepeat: false,
+            keyCode: 36
+        ))
+        let str = try #require(HotkeyRegistry.shortcutString(from: retEvent))
+        #expect(str == "cmd+shift+return")
+    }
+
+    // MARK: - HotkeyShortcut.matches (logical-key)
+
+    /// Character-based match succeeds despite wrong keyCode AZERTY-style mismatch.
+    @Test
+    func matches_succeeds_when_characters_match_token_regardless_of_keyCode() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+q"))
+        let azertyEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "q",
+            charactersIgnoringModifiers: "q",
+            isARepeat: false,
+            keyCode: 0
+        ))
+        #expect(shortcut.matches(azertyEvent))
+    }
+
+    /// Character mismatch should fail even if keyCode happens to match.
+    @Test
+    func matches_fails_when_characters_dont_match_even_if_keyCode_matches() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+q"))
+        let wrongCharEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "z",
+            charactersIgnoringModifiers: "z",
+            isARepeat: false,
+            keyCode: 12
+        ))
+        #expect(!shortcut.matches(wrongCharEvent))
+    }
+
+    @Test
+    func matches_special_keys_by_token() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("ctrl+tab"))
+        let tabEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\t",
+            charactersIgnoringModifiers: "\t",
+            isARepeat: false,
+            keyCode: 48
+        ))
+        #expect(shortcut.matches(tabEvent))
+    }
+
+    @Test
+    func matches_rejects_wrong_modifiers() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+p"))
+        let wrongModEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control], // should be .command
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "p",
+            charactersIgnoringModifiers: "p",
+            isARepeat: false,
+            keyCode: 35
+        ))
+        #expect(!shortcut.matches(wrongModEvent))
+    }
+
     // MARK: - HotkeyAction sanity
 
     @Test
@@ -141,5 +295,290 @@ struct HotkeysTests {
     func all_action_defaultsKeys_are_unique() {
         let keys = HotkeyAction.allCases.map(\.defaultsKey)
         #expect(keys.count == Set(keys).count)
+    }
+
+    // MARK: - Arrow key support (layout-independent by position)
+
+    @Test
+    func parseShortcut_arrow_keys() throws {
+        let left = try #require(HotkeyRegistry.parseShortcut("cmd+left"))
+        #expect(left.keyToken == "left")
+        #expect(left.keyCode == 123)
+
+        let right = try #require(HotkeyRegistry.parseShortcut("ctrl+right"))
+        #expect(right.keyToken == "right")
+        #expect(right.keyCode == 124)
+
+        let down = try #require(HotkeyRegistry.parseShortcut("opt+down"))
+        #expect(down.keyToken == "down")
+        #expect(down.keyCode == 125)
+
+        let up = try #require(HotkeyRegistry.parseShortcut("shift+up"))
+        #expect(up.keyToken == "up")
+        #expect(up.keyCode == 126)
+    }
+
+    // Arrow: characters = "", matched by keyCode fallback.
+    @Test
+    func matches_arrow_keys_by_position() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+left"))
+        let leftEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 123 // left arrow
+        ))
+        #expect(shortcut.matches(leftEvent))
+
+        // Wrong arrow direction should not match.
+        let rightEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 124 // right arrow — should NOT match "cmd+left"
+        ))
+        #expect(!shortcut.matches(rightEvent))
+    }
+
+    @Test
+    func shortcutString_captures_arrow_key_from_keyCode() throws {
+        let leftEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 125 // down arrow
+        ))
+        let str = try #require(HotkeyRegistry.shortcutString(from: leftEvent))
+        #expect(str == "cmd+down")
+    }
+
+    @Test
+    func displayString_arrow_keys() {
+        #expect(HotkeyRegistry.displayString(for: "cmd+left") == "⌘←")
+        #expect(HotkeyRegistry.displayString(for: "cmd+right") == "⌘→")
+        #expect(HotkeyRegistry.displayString(for: "cmd+up") == "⌘↑")
+        #expect(HotkeyRegistry.displayString(for: "cmd+down") == "⌘↓")
+    }
+
+    // MARK: - Escape key support
+
+    @Test
+    func parseShortcut_escape() throws {
+        let esc = try #require(HotkeyRegistry.parseShortcut("cmd+escape"))
+        #expect(esc.keyToken == "escape")
+        #expect(esc.keyCode == 53)
+    }
+
+    @Test
+    func matches_escape_key() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+escape"))
+        let escEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1b}",
+            charactersIgnoringModifiers: "\u{1b}",
+            isARepeat: false,
+            keyCode: 53
+        ))
+        #expect(shortcut.matches(escEvent))
+    }
+
+    @Test
+    func shortcutString_captures_escape() throws {
+        let escEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1b}",
+            charactersIgnoringModifiers: "\u{1b}",
+            isARepeat: false,
+            keyCode: 53
+        ))
+        let str = try #require(HotkeyRegistry.shortcutString(from: escEvent))
+        #expect(str == "cmd+escape")
+    }
+
+    @Test
+    func displayString_escape() {
+        #expect(HotkeyRegistry.displayString(for: "cmd+escape") == "⌘Esc")
+    }
+
+    // MARK: - Colemak-like layout mismatch
+
+    // Colemak: QWERTY P position (keyCode 35) produces "d". Should NOT match "cmd+p".
+    @Test
+    func colemak_mismatch_char_and_keyCode_both_wrong_does_not_match() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+p"))
+        let colemakEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "d",
+            charactersIgnoringModifiers: "d",
+            isARepeat: false,
+            keyCode: 35
+        ))
+        #expect(!shortcut.matches(colemakEvent))
+
+        // But should match "cmd+d" since that's what was actually typed.
+        let dShortcut = try #require(HotkeyRegistry.parseShortcut("cmd+d"))
+        #expect(dShortcut.matches(colemakEvent))
+    }
+
+    // MARK: - Shifted-symbol regression (charactersIgnoringModifiers != base key)
+
+    /// cmd+shift+,  →  charactersIgnoringModifiers="<", keyCode=43.
+    /// Should match stored token "," via keyCode fallback.
+    @Test
+    func shifted_symbol_match_falls_back_to_keyCode() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+shift+,"))
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "<",
+            charactersIgnoringModifiers: "<",
+            isARepeat: false,
+            keyCode: 43
+        ))
+        #expect(shortcut.matches(event))
+    }
+
+    /// Same shifted symbol but without shift modifier should NOT match.
+    @Test
+    func shifted_symbol_wrong_modifiers_does_not_match() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+shift+,"))
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command], // no shift
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: ",",
+            charactersIgnoringModifiers: ",",
+            isARepeat: false,
+            keyCode: 43
+        ))
+        #expect(!shortcut.matches(event))
+    }
+
+    /// shift+/  →  charactersIgnoringModifiers="?", keyCode=44.
+    /// shortcutString should capture as "shift+/".
+    @Test
+    func shortcutString_shifted_slash_captures_base_token() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "?",
+            charactersIgnoringModifiers: "?",
+            isARepeat: false,
+            keyCode: 44
+        ))
+        let str = try #require(HotkeyRegistry.shortcutString(from: event))
+        #expect(str == "shift+/")
+    }
+
+    /// cmd+shift+/  (e.g. a hypothetical shortcut) should also work.
+    @Test
+    func shifted_slash_match_with_command() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+shift+/"))
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "?",
+            charactersIgnoringModifiers: "?",
+            isARepeat: false,
+            keyCode: 44
+        ))
+        #expect(shortcut.matches(event))
+    }
+
+    /// Ensure letter shortcuts still use character-based matching even when
+    /// keyCode differs (Colemak/AZERTY). The keyCode fallback must NOT
+    /// cause a mismatched letter to match.
+    @Test
+    func colemak_letter_uses_char_not_keyCode_fallback() throws {
+        // User presses the key at QWERTY keyCode 35 (P position),
+        // which produces "d" in Colemak.
+        // "cmd+p" should NOT match — the char "d" is a known token,
+        // so it takes precedence over keyCode fallback.
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+p"))
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "d",
+            charactersIgnoringModifiers: "d",
+            isARepeat: false,
+            keyCode: 35 // P's keyCode
+        ))
+        #expect(!shortcut.matches(event))
+
+        // "cmd+d" should match.
+        let dShortcut = try #require(HotkeyRegistry.parseShortcut("cmd+d"))
+        #expect(dShortcut.matches(event))
+    }
+
+    /// Letters should also be captured correctly by shortcutString.
+    @Test
+    func shortcutString_letter_captures_by_char_not_keyCode() throws {
+        // keyCode=0 is 'a' on QWERTY; characters="q" (AZERTY-style)
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "q",
+            charactersIgnoringModifiers: "q",
+            isARepeat: false,
+            keyCode: 0 // 'a' keyCode
+        ))
+        let str = try #require(HotkeyRegistry.shortcutString(from: event))
+        #expect(str == "cmd+q") // Should be "q", not "a"
     }
 }


### PR DESCRIPTION
## Summary
- match local app shortcuts by logical key token instead of hardware keyCode
- capture custom shortcuts from typed characters so alternate keyboard layouts work correctly
- preserve shifted-symbol shortcuts and Carbon keyCode registration for the global quick terminal hotkey

## Tests
- ./scripts/test.sh