### PR TITLE
feat: paste copied file paths into terminals

### DIFF
--- a/Macterm/Ghostty/GhosttyCallbacks.swift
+++ b/Macterm/Ghostty/GhosttyCallbacks.swift
@@ -58,9 +58,75 @@ final class GhosttyCallbacks: @unchecked Sendable {
     }
 
     func readClipboard(ud: UnsafeMutableRawPointer?, location: ghostty_clipboard_e, state: UnsafeMutableRawPointer?) -> Bool {
-        let text = NSPasteboard.general.string(forType: .string) ?? ""
+        let text = Self.readPasteboardText() ?? ""
         text.withCString { ghostty_surface_complete_clipboard_request(surface(from: ud), $0, state, false) }
         return true
+    }
+
+    // MARK: - Pasteboard text resolution (shared with GhosttyTerminalNSView)
+
+    /// Mirrors Ghostty's ShellEscapeWriter for file paths pasted into the shell.
+    private static func shellEscape(_ s: String) -> String {
+        var result = ""
+        result.reserveCapacity(s.utf8.count)
+        for ch in s {
+            switch ch {
+            case "\\",
+                 "\"",
+                 "'",
+                 "$",
+                 "`",
+                 "*",
+                 "?",
+                 " ",
+                 "|",
+                 "(",
+                 ")":
+                result.append("\\" + String(ch))
+            default:
+                result.append(ch)
+            }
+        }
+        return result
+    }
+
+    /// Returns pasted text from the pasteboard: file paths (Finder drag/copy)
+    /// fall back to plain string. Called by both the context-menu paste path
+    /// and the libghostty Cmd+V clipboard path.
+    static func readPasteboardText() -> String? {
+        let pb = NSPasteboard.general
+
+        // Finder copies files as NSURL data, not strings.
+        if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL] {
+            let paths = urls
+                .filter(\.isFileURL)
+                .map { Self.shellEscape($0.path(percentEncoded: false)) }
+                .filter { !$0.isEmpty }
+            if !paths.isEmpty {
+                return paths.joined(separator: " ")
+            }
+        }
+
+        if let items = pb.pasteboardItems {
+            let paths = items.compactMap { item -> String? in
+                guard let urlStr = item.string(forType: .fileURL), !urlStr.isEmpty
+                else { return nil }
+                let url: URL
+                if urlStr.hasPrefix("file://") {
+                    guard let parsed = URL(string: urlStr) else { return nil }
+                    url = parsed
+                } else {
+                    url = URL(filePath: urlStr)
+                }
+                let resolved = Self.shellEscape(url.path(percentEncoded: false))
+                return resolved.isEmpty ? nil : resolved
+            }
+            if !paths.isEmpty {
+                return paths.joined(separator: " ")
+            }
+        }
+
+        return pb.string(forType: .string).flatMap { !$0.isEmpty ? $0 : nil }
     }
 
     func confirmReadClipboard(ud: UnsafeMutableRawPointer?, content: UnsafePointer<CChar>?, state: UnsafeMutableRawPointer?) {

--- a/Macterm/Ghostty/GhosttyCallbacks.swift
+++ b/Macterm/Ghostty/GhosttyCallbacks.swift
@@ -65,27 +65,15 @@ final class GhosttyCallbacks: @unchecked Sendable {
 
     // MARK: - Pasteboard text resolution (shared with GhosttyTerminalNSView)
 
-    /// Mirrors Ghostty's ShellEscapeWriter for file paths pasted into the shell.
+    /// Characters to escape when pasting paths into the shell.
+    private static let escapeCharacters = "\\ ()[]{}<>\"'`!#$&;|*?\t"
+
+    /// Escape shell-sensitive characters in a string by prefixing each with a
+    /// backslash. Suitable for inserting paths/URLs into a live terminal buffer.
     private static func shellEscape(_ s: String) -> String {
-        var result = ""
-        result.reserveCapacity(s.utf8.count)
-        for ch in s {
-            switch ch {
-            case "\\",
-                 "\"",
-                 "'",
-                 "$",
-                 "`",
-                 "*",
-                 "?",
-                 " ",
-                 "|",
-                 "(",
-                 ")":
-                result.append("\\" + String(ch))
-            default:
-                result.append(ch)
-            }
+        var result = s
+        for char in escapeCharacters {
+            result = result.replacingOccurrences(of: String(char), with: "\\\(char)")
         }
         return result
     }
@@ -99,28 +87,10 @@ final class GhosttyCallbacks: @unchecked Sendable {
         // Finder copies files as NSURL data, not strings.
         if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL] {
             let paths = urls
-                .filter(\.isFileURL)
-                .map { Self.shellEscape($0.path(percentEncoded: false)) }
-                .filter { !$0.isEmpty }
-            if !paths.isEmpty {
-                return paths.joined(separator: " ")
-            }
-        }
-
-        if let items = pb.pasteboardItems {
-            let paths = items.compactMap { item -> String? in
-                guard let urlStr = item.string(forType: .fileURL), !urlStr.isEmpty
-                else { return nil }
-                let url: URL
-                if urlStr.hasPrefix("file://") {
-                    guard let parsed = URL(string: urlStr) else { return nil }
-                    url = parsed
-                } else {
-                    url = URL(filePath: urlStr)
+                .map { url in
+                    url.isFileURL ? Self.shellEscape(url.path(percentEncoded: false)) : url.absoluteString
                 }
-                let resolved = Self.shellEscape(url.path(percentEncoded: false))
-                return resolved.isEmpty ? nil : resolved
-            }
+                .filter { !$0.isEmpty }
             if !paths.isEmpty {
                 return paths.joined(separator: " ")
             }

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -443,7 +443,7 @@ final class GhosttyTerminalNSView: NSView {
         let menu = NSMenu(title: "Terminal")
         let paste = NSMenuItem(title: "Paste", action: #selector(handlePaste), keyEquivalent: "")
         paste.target = self
-        paste.isEnabled = NSPasteboard.general.string(forType: .string).map { !$0.isEmpty } ?? false
+        paste.isEnabled = GhosttyCallbacks.readPasteboardText() != nil
         menu.addItem(paste)
         menu.addItem(.separator())
         addSplitItem(menu, "Split Right", .horizontal, .second)
@@ -477,7 +477,7 @@ final class GhosttyTerminalNSView: NSView {
 
     @objc
     private func handlePaste() {
-        guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else { return }
+        guard let text = GhosttyCallbacks.readPasteboardText() else { return }
         window?.makeFirstResponder(self)
         insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
     }


### PR DESCRIPTION
## Summary

- Paste Finder-copied files as shell-escaped paths
- Use the same pasteboard handling for Cmd+V and context menu Paste
- Helps tools like opencode accept pasted screenshots/images by receiving the copied file path

## Verification

- mise run format
- mise run lint
- mise run test