### PR TITLE
fix: respect user-cleared hotkey bindings

### DIFF
--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -273,7 +273,7 @@ enum HotkeyRegistry {
     }
 
     static func selectedShortcut(for action: HotkeyAction) -> HotkeyShortcut? {
-        parseShortcut(selectedShortcutString(for: action)) ?? parseShortcut(action.defaultShortcut)
+        parseShortcut(selectedShortcutString(for: action))
     }
 
     static func setShortcutString(_ shortcut: String, for action: HotkeyAction) {


### PR DESCRIPTION
## Summary

`HotkeyRegistry.selectedShortcut(for:)` silently fell back to the action's default shortcut when the stored value was unparseable (including the literal `"disabled"` written by the **Clear** button in Settings → Keymaps).

Net effect: when a user cleared the quick-terminal binding via Settings → Keymaps, the UI correctly showed **Disabled**, but the Carbon global hotkey kept firing because the runtime used the fallback default (`ctrl+\``). The Settings display didn't match actual behavior.

## Fix

Remove the fallback. `selectedShortcut` now returns `nil` when the stored value parses to nothing — matching what the UI reports. All three call sites (`HotkeyRegistry.matches`, `QuickTerminalService.registerHotKey`, `updateCarbonHotKey`) already early-return on `nil`, so this is a behavior change only for the cleared-binding case.

## Test plan

- [ ] Open Settings → Keymaps, click **Clear** on **Toggle quick terminal**
- [ ] Verify the row shows "Disabled"
- [ ] Verify pressing the previous shortcut (e.g. ⌃\`) no longer toggles the quick terminal
- [ ] Rebind the shortcut and verify it works again

## Note for existing users

After updating, any hotkey you had previously cleared will *actually* be cleared. Rebind via Settings → Keymaps if you find a global shortcut you expected has stopped working.