### PR TITLE
feat: tab switcher in title bar + Appearance settings tab

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -2,6 +2,23 @@ import AppKit
 import Foundation
 import Observation
 
+/// When the numbered tab switcher in the title bar is shown.
+enum TabSwitcherVisibility: String, CaseIterable, Identifiable {
+    case always
+    case whenMultiple = "when_multiple"
+    case hidden
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .always: "Always"
+        case .whenMultiple: "When multiple tabs"
+        case .hidden: "Hidden"
+        }
+    }
+}
+
 /// Single observable source of truth for UserDefaults-backed preferences.
 ///
 /// Macterm only stores app-shaped state here (window opacity/blur, quick
@@ -34,6 +51,12 @@ final class Preferences {
 
     var showNewProjectButton: Bool {
         didSet { defaults.set(showNewProjectButton, forKey: Keys.showNewProjectButton) }
+    }
+
+    // MARK: - Toolbar
+
+    var tabSwitcherVisibility: TabSwitcherVisibility {
+        didSet { defaults.set(tabSwitcherVisibility.rawValue, forKey: Keys.tabSwitcherVisibility) }
     }
 
     /// Sentinel for "no icon" — sidebar rows skip the leading glyph when set.
@@ -176,6 +199,8 @@ final class Preferences {
         projectIconSymbol = defaults.string(forKey: Keys.projectIconSymbol) ?? "folder"
         tabIconSymbol = defaults.string(forKey: Keys.tabIconSymbol) ?? "terminal"
         showNewProjectButton = defaults.object(forKey: Keys.showNewProjectButton) as? Bool ?? true
+        tabSwitcherVisibility = (defaults.string(forKey: Keys.tabSwitcherVisibility))
+            .flatMap(TabSwitcherVisibility.init(rawValue:)) ?? .whenMultiple
         Self.runOneTimeMigrations(defaults: defaults)
     }
 
@@ -219,6 +244,7 @@ final class Preferences {
         static let projectIconSymbol = "macterm.sidebar.projectIcon"
         static let tabIconSymbol = "macterm.sidebar.tabIcon"
         static let showNewProjectButton = "macterm.sidebar.showNewProjectButton"
+        static let tabSwitcherVisibility = "macterm.toolbar.tabSwitcherVisibility"
         static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"
     }
 }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -7,6 +7,8 @@ struct SettingsView: View {
         TabView {
             GeneralSettings()
                 .tabItem { Label("General", systemImage: "gearshape") }
+            AppearanceSettings()
+                .tabItem { Label("Appearance", systemImage: "paintpalette") }
             QuickTerminalSettings()
                 .tabItem {
                     Label("Quick Terminal", systemImage: "rectangle.bottomthird.inset.filled")
@@ -25,18 +27,8 @@ struct SettingsView: View {
 private struct GeneralSettings: View {
     @AppStorage(Preferences.Keys.autoTiling)
     private var autoTilingEnabled = false
-    @AppStorage(Preferences.Keys.projectIconSymbol)
-    private var projectIconSymbol = "folder"
-    @AppStorage(Preferences.Keys.tabIconSymbol)
-    private var tabIconSymbol = "terminal"
-    @AppStorage(Preferences.Keys.showNewProjectButton)
-    private var showNewProjectButton = true
     @State
     private var ghosttyConfigPath: String = Preferences.shared.userGhosttyConfigPath
-    @State
-    private var backgroundOpacity: Double = Preferences.shared.windowOpacity
-    @State
-    private var backgroundBlurRadius: Double = .init(Preferences.shared.windowBlurRadius)
 
     var body: some View {
         Form {
@@ -63,6 +55,65 @@ private struct GeneralSettings: View {
                 .foregroundStyle(.secondary)
             }
 
+            Section("Layout") {
+                Toggle("Auto-tile panes", isOn: $autoTilingEnabled)
+                    .onChange(of: autoTilingEnabled) { _, v in
+                        Preferences.shared.autoTilingEnabled = v
+                    }
+                Text("Distributes pane sizes evenly on split and close.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    /// Push the text-field's current value into Preferences and reload. We
+    /// don't bind directly because that would reload on every keystroke;
+    /// debouncing on submit/blur matches how the path is typically edited.
+    /// If the new path produces errors, the alert surfaces via `reloadAndReport`.
+    private func commitPath() {
+        guard ghosttyConfigPath != Preferences.shared.userGhosttyConfigPath else { return }
+        Preferences.shared.userGhosttyConfigPath = ghosttyConfigPath
+        GhosttyApp.shared.reloadAndReport()
+    }
+
+    private func browse() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
+        // Default the panel to the user's currently configured path's
+        // directory so they don't always start from ~.
+        let current = Preferences.shared.expandedUserGhosttyConfigPath
+        if !current.isEmpty {
+            panel.directoryURL = URL(fileURLWithPath: current).deletingLastPathComponent()
+        }
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        ghosttyConfigPath = url.path(percentEncoded: false)
+        commitPath()
+    }
+}
+
+// MARK: - Appearance
+
+private struct AppearanceSettings: View {
+    @AppStorage(Preferences.Keys.projectIconSymbol)
+    private var projectIconSymbol = "folder"
+    @AppStorage(Preferences.Keys.tabIconSymbol)
+    private var tabIconSymbol = "terminal"
+    @AppStorage(Preferences.Keys.showNewProjectButton)
+    private var showNewProjectButton = true
+    @AppStorage(Preferences.Keys.tabSwitcherVisibility)
+    private var tabSwitcherVisibility = TabSwitcherVisibility.whenMultiple.rawValue
+    @State
+    private var backgroundOpacity: Double = Preferences.shared.windowOpacity
+    @State
+    private var backgroundBlurRadius: Double = .init(Preferences.shared.windowBlurRadius)
+
+    var body: some View {
+        Form {
             Section("Window") {
                 HStack {
                     Text("Background Opacity")
@@ -92,16 +143,6 @@ private struct GeneralSettings: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section("Layout") {
-                Toggle("Auto-tile panes", isOn: $autoTilingEnabled)
-                    .onChange(of: autoTilingEnabled) { _, v in
-                        Preferences.shared.autoTilingEnabled = v
-                    }
-                Text("Distributes pane sizes evenly on split and close.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-            }
-
             Section("Sidebar") {
                 Picker("Project icon", selection: $projectIconSymbol) {
                     ForEach(Preferences.projectIconChoices, id: \.self) { name in
@@ -120,6 +161,20 @@ private struct GeneralSettings: View {
                 Toggle("Show New Project button", isOn: $showNewProjectButton)
                     .onChange(of: showNewProjectButton) { _, v in Preferences.shared.showNewProjectButton = v }
                 Text("When hidden, create projects via the command palette or context menu.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Toolbar") {
+                Picker("Tab switcher", selection: $tabSwitcherVisibility) {
+                    ForEach(TabSwitcherVisibility.allCases) { option in
+                        Text(option.displayName).tag(option.rawValue)
+                    }
+                }
+                .onChange(of: tabSwitcherVisibility) { _, v in
+                    Preferences.shared.tabSwitcherVisibility = TabSwitcherVisibility(rawValue: v) ?? .whenMultiple
+                }
+                Text("Numbered control in the title bar for switching tabs by index.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }
@@ -145,33 +200,6 @@ private struct GeneralSettings: View {
         default:
             Label(name, systemImage: name)
         }
-    }
-
-    /// Push the text-field's current value into Preferences and reload. We
-    /// don't bind directly because that would reload on every keystroke;
-    /// debouncing on submit/blur matches how the path is typically edited.
-    /// If the new path produces errors, the alert surfaces via `reloadAndReport`.
-    private func commitPath() {
-        guard ghosttyConfigPath != Preferences.shared.userGhosttyConfigPath else { return }
-        Preferences.shared.userGhosttyConfigPath = ghosttyConfigPath
-        GhosttyApp.shared.reloadAndReport()
-    }
-
-    private func browse() {
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = true
-        panel.canChooseDirectories = false
-        panel.allowsMultipleSelection = false
-        panel.showsHiddenFiles = true
-        // Default the panel to the user's currently configured path's
-        // directory so they don't always start from ~.
-        let current = Preferences.shared.expandedUserGhosttyConfigPath
-        if !current.isEmpty {
-            panel.directoryURL = URL(fileURLWithPath: current).deletingLastPathComponent()
-        }
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        ghosttyConfigPath = url.path(percentEncoded: false)
-        commitPath()
     }
 }
 

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -38,6 +38,9 @@ struct MainWindow: View {
                 ToolbarItem(placement: .primaryAction) {
                     UpdateAvailableToolbarButton()
                 }
+                ToolbarItem(placement: .primaryAction) {
+                    TabSwitcherToolbarItem()
+                }
             }
         }
         .background(WindowStyler())

--- a/Macterm/Views/TabSwitcherToolbarItem.swift
+++ b/Macterm/Views/TabSwitcherToolbarItem.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// Numbered segmented control in the window title bar that mirrors a fixed
+/// 5-tab sliding window of the active project's tabs. Each segment shows
+/// the tab's 1-based index; Cmd+1…Cmd+9 in `Responders.swift` selects by
+/// that same index.
+///
+/// The window centers the active tab when at least two tabs sit on either
+/// side; otherwise it clamps to the start or end of the workspace. The
+/// control itself never scrolls — switching tabs simply replaces the
+/// visible segments. With ≤ 5 tabs, every tab is shown.
+///
+/// When tabs sit off either end of the visible window, the first/last
+/// segment is relabelled `…` — a quiet affordance that more tabs exist in
+/// that direction. The segment still selects its underlying tab when
+/// clicked. Cmd+1…Cmd+9 keeps using real tab indices via the keyboard
+/// handler in `Responders.swift`, so shortcuts aren't affected.
+struct TabSwitcherToolbarItem: View {
+    @Environment(AppState.self)
+    private var appState
+
+    @AppStorage(Preferences.Keys.tabSwitcherVisibility)
+    private var visibilityRaw: String = TabSwitcherVisibility.whenMultiple.rawValue
+
+    private static let windowSize = 5
+
+    var body: some View {
+        let visibility = TabSwitcherVisibility(rawValue: visibilityRaw) ?? .whenMultiple
+        if visibility != .hidden,
+           let workspace = activeWorkspace,
+           !workspace.tabs.isEmpty,
+           visibility == .always || workspace.tabs.count > 1
+        {
+            let tabs = workspace.tabs
+            let activeIndex = tabs.firstIndex(where: { $0.id == workspace.activeTabID }) ?? 0
+            let window = slidingWindow(activeIndex: activeIndex, tabCount: tabs.count)
+            let windowTabs = Array(tabs[window])
+
+            Picker("Tab", selection: Binding(
+                get: { workspace.activeTabID },
+                set: { newValue in
+                    guard let id = newValue, let projectID = appState.activeProjectID else { return }
+                    appState.selectTab(id, projectID: projectID)
+                }
+            )) {
+                ForEach(Array(windowTabs.enumerated()), id: \.element.id) { offset, tab in
+                    Text(label(
+                        offset: offset,
+                        window: window,
+                        tabCount: tabs.count
+                    ))
+                    .tag(Optional(tab.id))
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+            .help("Cmd+1…\(min(9, tabs.count)) to switch tabs")
+        }
+    }
+
+    /// Label for the segment at `offset` inside `window`. Returns `…` for
+    /// the leading/trailing segment when more tabs exist off that side;
+    /// otherwise the tab's 1-based index.
+    private func label(offset: Int, window: Range<Int>, tabCount: Int) -> String {
+        let isLeading = offset == 0
+        let isTrailing = offset == window.count - 1
+        if isLeading, window.lowerBound > 0 { return "⋯" }
+        if isTrailing, window.upperBound < tabCount { return "⋯" }
+        return "\(window.lowerBound + offset + 1)"
+    }
+
+    /// Window of up to `windowSize` indices centered on `activeIndex`,
+    /// clamped to `0..<tabCount`. Always returns a non-empty range when
+    /// `tabCount > 0`.
+    private func slidingWindow(activeIndex: Int, tabCount: Int) -> Range<Int> {
+        let size = min(Self.windowSize, tabCount)
+        let half = size / 2
+        var start = activeIndex - half
+        start = max(0, min(start, tabCount - size))
+        return start ..< (start + size)
+    }
+
+    private var activeWorkspace: Workspace? {
+        guard let pid = appState.activeProjectID else { return nil }
+        return appState.workspaces[pid]
+    }
+}


### PR DESCRIPTION
## Summary

Two related changes bundled because the new switcher needs a home in Settings:

**Numbered tab switcher** — A native segmented control in the trailing toolbar shows up to 5 tabs at a time as numbered chips (1, 2, …). The visible window slides with the active tab: when ≥ 2 tabs sit on either side, the active tab is centered; otherwise the window clamps to the workspace's start or end. When more tabs exist off either edge, that end's chip shows `⋯` instead of its number — a quiet "more in this direction" hint that doesn't add chevrons or steal toolbar width. Clicking still selects the underlying tab; existing Cmd+1…Cmd+9 shortcuts continue to work via the existing handler in `Responders.swift`.

**New Appearance settings tab** — Window opacity/blur, Sidebar icons, and the new Toolbar visibility preference move out of General into a dedicated Appearance pane. General now holds Ghostty Config + Layout (auto-tile panes). Quick Terminal / Keymaps / Updates are untouched.

Visibility preference: **Always** / **When multiple tabs** (default) / **Hidden**, persisted at `macterm.toolbar.tabSwitcherVisibility`.

## Test plan

- [ ] With one tab and default settings, switcher is hidden
- [ ] Open a second tab — switcher appears with chips `[1] [2]`
- [ ] With 6+ tabs, switcher shows 5 chips with `⋯` at the leading or trailing end depending on where the active tab sits
- [ ] Active tab is centered (1 of 5 / 2 of 5 / 3 of 5 / etc.) when ≥ 2 tabs exist on each side
- [ ] Cmd+1…9 still selects by real tab index
- [ ] Settings → Appearance → Toolbar → Tab switcher picker offers Always / When multiple / Hidden, takes effect immediately
- [ ] Settings → General no longer shows Window / Sidebar / Toolbar sections; Settings → Appearance does
- [ ] Existing window opacity / sidebar icon / new-project-button preferences still work after the move