### PR TITLE
feat: show GitHub Release notes in Sparkle's update dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Tag-pushed builds are released via `.github/workflows/release.yml`. The workflow
 
 Generate the keypair once by downloading Sparkle and running `./bin/generate_keys`. Store the public key in `SPARKLE_ED_PUBLIC_KEY` (it's not secret, but keeping it as a secret avoids committing it to the repo) and the private key in `SPARKLE_ED_PRIVATE_KEY`. Back the private key up in a password manager — losing it means users cannot auto-update to any further release.
 
-The workflow pushes a new `<item>` to `appcast.xml` on the `gh-pages` branch, which GitHub Pages serves at `https://thdxg.github.io/macterm/appcast.xml` — the feed URL baked into `Info.plist`.
+The workflow pushes a new `<item>` to `appcast.xml` on the `gh-pages` branch, which GitHub Pages serves at `https://thdxg.github.io/macterm/appcast.xml` — the feed URL baked into `Info.plist`. The item also includes a `<sparkle:releaseNotesLink>` to a per-version notes page (`notes/v<version>.html`) also published on `gh-pages`; Sparkle's update dialog loads that into its WebView. Notes are sourced from the GitHub Release body (`--generate-notes` produces them) and rendered to HTML via the GitHub API's `/markdown` endpoint in `publish-appcast.sh`.
 
 ## Architecture Overview
 

--- a/scripts/publish-appcast.sh
+++ b/scripts/publish-appcast.sh
@@ -16,10 +16,57 @@ set -euo pipefail
 DMG_DIR="${1:-dmgs}"
 PUB_DATE=$(date -u "+%a, %d %b %Y %H:%M:%S +0000")
 REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
+PAGES_URL="https://thdxg.github.io/macterm"
+NOTES_REL_PATH="notes/${TAG}.html"
+NOTES_URL="${PAGES_URL}/${NOTES_REL_PATH}"
+
+# Fetch the GitHub Release body (Markdown) and render to HTML via the GitHub
+# API's Markdown endpoint. Sparkle's update dialog loads this URL into a
+# WebView, so we wrap the rendered body in a tiny standalone document with
+# system-matching typography. Empty release notes are tolerated — we still
+# write a placeholder so the link resolves.
+NOTES_BODY_FILE=$(mktemp)
+NOTES_HTML_FILE=$(mktemp)
+ITEMS_FILE=""
+trap 'rm -f "$NOTES_BODY_FILE" "$NOTES_HTML_FILE" ${ITEMS_FILE:+"$ITEMS_FILE"}' EXIT
+
+gh release view "$TAG" --json body --jq .body > "$NOTES_BODY_FILE"
+if [[ ! -s "$NOTES_BODY_FILE" ]]; then
+  echo "_No release notes provided._" > "$NOTES_BODY_FILE"
+fi
+
+# Render Markdown → HTML using GitHub's renderer (same one that produces the
+# release page). Wrap in a minimal document so Sparkle's WebView gets readable
+# typography without inheriting any GitHub chrome.
+RENDERED_HTML=$(gh api -X POST /markdown -f mode=gfm -f "text=@${NOTES_BODY_FILE}")
+cat > "$NOTES_HTML_FILE" <<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Macterm ${VERSION} release notes</title>
+  <style>
+    body { font: 13px -apple-system, system-ui, sans-serif; color: #1d1d1f; padding: 16px; margin: 0; }
+    @media (prefers-color-scheme: dark) { body { color: #f5f5f7; background: transparent; } a { color: #6cb4ff; } }
+    h1, h2, h3 { margin-top: 0.6em; margin-bottom: 0.3em; }
+    h1 { font-size: 1.3em; } h2 { font-size: 1.15em; } h3 { font-size: 1em; }
+    p, ul, ol { margin: 0.4em 0; }
+    ul, ol { padding-left: 1.4em; }
+    code { background: rgba(127, 127, 127, 0.15); padding: 0 4px; border-radius: 3px; font: 12px ui-monospace, monospace; }
+    pre { background: rgba(127, 127, 127, 0.12); padding: 8px; border-radius: 4px; overflow-x: auto; }
+    pre code { background: transparent; padding: 0; }
+    a { color: #0366d6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+${RENDERED_HTML}
+</body>
+</html>
+HTML
 
 # Write the per-DMG <item> blocks into a temp file.
 ITEMS_FILE=$(mktemp)
-trap 'rm -f "$ITEMS_FILE"' EXIT
 
 for dmg in "$DMG_DIR"/*.dmg; do
   name=$(basename "$dmg")
@@ -32,6 +79,7 @@ for dmg in "$DMG_DIR"/*.dmg; do
       <sparkle:version>${VERSION}</sparkle:version>
       <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:releaseNotesLink>${NOTES_URL}</sparkle:releaseNotesLink>
       <link>${REPO_URL}/releases/tag/${TAG}</link>
       <enclosure url="${url}" type="application/octet-stream" ${sig} />
     </item>
@@ -77,7 +125,10 @@ awk -v items_file="$ITEMS_FILE" '
 ' appcast.xml > appcast.xml.new
 mv appcast.xml.new appcast.xml
 
-git add appcast.xml
+mkdir -p notes
+cp "$NOTES_HTML_FILE" "$NOTES_REL_PATH"
+
+git add appcast.xml "$NOTES_REL_PATH"
 git commit -m "Publish appcast for ${TAG}"
 git push origin gh-pages
 


### PR DESCRIPTION
## Summary

Each appcast item now includes `<sparkle:releaseNotesLink>` pointing at a per-version HTML page published alongside `appcast.xml` on `gh-pages`. Sparkle's update dialog loads that URL into its WebView, so users see "What's new in v1.2.3" before applying the update — currently the dialog is blank where notes would go.

## How it works

`publish-appcast.sh` runs in the release workflow after the GitHub Release is created (with `--generate-notes`). The script:

1. Fetches the release body Markdown via `gh release view <tag> --json body --jq .body`.
2. Renders it to HTML via `gh api -X POST /markdown -f mode=gfm` — same renderer that produces the release page on github.com.
3. Wraps the rendered HTML in a minimal standalone document with `prefers-color-scheme` aware styling.
4. Writes it to `notes/<tag>.html` on `gh-pages`.
5. Adds `<sparkle:releaseNotesLink>https://thdxg.github.io/macterm/notes/<tag>.html</sparkle:releaseNotesLink>` to the new appcast `<item>`.

Sparkle's dialog will then load and display that page in its WebView.

## Why not link directly to the GitHub Release page?

Sparkle loads the URL as raw HTML. Linking to `https://github.com/.../releases/tag/v1.2.3` would render the entire GitHub chrome (header, sidebar, footer) cropped to the dialog. Hosting a standalone page gives a clean inline reading experience.

## Why not inline as `<description>`?

That works too, but post-publish edits would require re-running the appcast generator. A hosted URL means you can edit the release body on GitHub and (after a manual re-publish) the dialog updates without touching the appcast.

## Test plan

This PR only affects the release CI script — there's no way to fully test it without cutting a tag. Suggested validation:

- [ ] Inspect the script change for shell-quoting / `set -u` issues (already shellcheck-clean via `bash -n`)
- [ ] Cut a test patch release (e.g. `v1.12.4`) and verify:
  - [ ] `notes/v1.12.4.html` appears on the `gh-pages` branch
  - [ ] `appcast.xml` includes `<sparkle:releaseNotesLink>...</sparkle:releaseNotesLink>` for the new item
  - [ ] Triggering "Check for Updates…" in the previous version shows the release notes in the dialog body
  - [ ] Dark mode renders cleanly (the wrapped HTML respects `prefers-color-scheme`)

Older appcast items remain unchanged — only releases from this point forward will have linked notes.

## Notes

- Empty release bodies fall back to a placeholder paragraph so the link always resolves.
- The page is intentionally minimal (no JS, no external CSS) so it loads instantly in Sparkle's WebView and renders predictably in light/dark mode.