### PR TITLE
fix: release notes rendered the tempfile path instead of the body

### DIFF
--- a/scripts/publish-appcast.sh
+++ b/scripts/publish-appcast.sh
@@ -38,7 +38,7 @@ fi
 # Render Markdown → HTML using GitHub's renderer (same one that produces the
 # release page). Wrap in a minimal document so Sparkle's WebView gets readable
 # typography without inheriting any GitHub chrome.
-RENDERED_HTML=$(gh api -X POST /markdown -f mode=gfm -f "text=@${NOTES_BODY_FILE}")
+RENDERED_HTML=$(gh api -X POST /markdown -f mode=gfm -F "text=@${NOTES_BODY_FILE}")
 cat > "$NOTES_HTML_FILE" <<HTML
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary

The v1.13.0 release notes page rendered as literally `<p>@/var/folders/.../tmp.Qug2LjQ1f3</p>` — the tempfile path, not the release body. Cause: I used `gh api … -f text=@<file>` in `publish-appcast.sh`. Per `gh api --help`:

- `-F` / `--field` — typed; `@path` reads file contents
- `-f` / `--raw-field` — literal string; `@path` is passed through as-is

So the Markdown endpoint received the literal string `@/var/.../tmp.X` and dutifully rendered it as a paragraph.

## Fix

One-character change: `-f` → `-F` on the `text=` field. The `mode=gfm` argument stays on `-f` because it's a literal string.

Verified locally:
\`\`\`
$ tmp=\$(mktemp); printf '## Heading\n\n- item 1\n' > "\$tmp"
$ gh api -X POST /markdown -f mode=gfm -F "text=@\${tmp}"
<h2>Heading</h2>
<ul><li>item 1</li></ul>
\`\`\`

## Cleanup

The broken `notes/v1.13.0.html` on `gh-pages` is still wrong. After this PR lands, either:
- Re-run the release workflow for the same tag (it'll overwrite), or
- Manually edit the file on `gh-pages` (one-shot).

The next release will produce a correctly-rendered notes page automatically.