### PR TITLE
Bundle ghostty themes + shell-integration so theming works standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,14 @@ DerivedData/
 GhosttyKit.xcframework
 GhosttyKit/ghostty.h
 /ghostty
+
+# Ghostty resources (themes + shell-integration) downloaded by setup.sh from
+# the thdxg/ghostty release. The two committed custom themes are kept; every
+# other theme and the whole shell-integration tree are fetched, not committed.
+/Macterm/Resources/shell-integration/
+/Macterm/Resources/themes/*
+!/Macterm/Resources/themes/Macterm
+!/Macterm/Resources/themes/Macterm Light
 /build
 .agents/
 .claude/

--- a/Macterm/Config/MactermConfig.swift
+++ b/Macterm/Config/MactermConfig.swift
@@ -40,7 +40,7 @@ final class MactermConfig {
             // these without needing to know they exist. Anything we'd set to
             // ghostty's own default (e.g. scrollbar=system) isn't listed —
             // libghostty already does the right thing.
-            "theme = \"Rose Pine\"",
+            "theme = \"Macterm\"",
             "font-size = 16",
             "macos-option-as-alt = true",
             "window-padding-x = 16",

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -185,19 +185,31 @@ final class GhosttyApp {
         return (cfg, result)
     }
 
-    private static let resourcePaths = [
-        "/Applications/Ghostty.app/Contents/Resources/ghostty",
-        NSHomeDirectory() + "/Applications/Ghostty.app/Contents/Resources/ghostty",
-    ]
+    /// Candidate ghostty resource dirs, highest priority first. Macterm ships
+    /// themes + shell-integration in its own bundle (downloaded by setup.sh),
+    /// so named themes and shell integration resolve with no Ghostty.app
+    /// install. The installed Ghostty.app dirs remain as fallbacks for the rare
+    /// case the bundle is missing them (e.g. an unprepared dev checkout).
+    private static let resourcePaths: [String] = {
+        var paths: [String] = []
+        if let bundle = Bundle.main.resourceURL?.path {
+            paths.append(bundle)
+        }
+        paths.append("/Applications/Ghostty.app/Contents/Resources/ghostty")
+        paths.append(NSHomeDirectory() + "/Applications/Ghostty.app/Contents/Resources/ghostty")
+        return paths
+    }()
 
     private func resolveResources() {
-        if let existing = getenv("GHOSTTY_RESOURCES_DIR").map({ String(cString: $0) }) {
-            guard Self.resourcePaths.contains(where: { existing.hasPrefix($0) }) else {
-                unsetenv("GHOSTTY_RESOURCES_DIR")
-                return
-            }
+        // Honor an explicit GHOSTTY_RESOURCES_DIR only if it points at a dir we
+        // recognize; otherwise drop it so a stale/foreign value can't shadow
+        // our bundle. A bare value is replaced below.
+        if let existing = getenv("GHOSTTY_RESOURCES_DIR").map({ String(cString: $0) }),
+           Self.resourcePaths.contains(where: { existing.hasPrefix($0) })
+        {
             return
         }
+        unsetenv("GHOSTTY_RESOURCES_DIR")
         for path in Self.resourcePaths where FileManager.default.fileExists(atPath: path + "/shell-integration") {
             setenv("GHOSTTY_RESOURCES_DIR", path, 1)
             return

--- a/project.yml
+++ b/project.yml
@@ -47,10 +47,19 @@ targets:
           - "Info.plist"
           - "Macterm.entitlements"
           - "Resources/themes"
+          - "Resources/shell-integration"
           - "AppIcon.icon"
       # Bundle the themes/ directory verbatim as a folder reference. Treating
       # it as a "group" (the default) made Xcode skip files with no extension.
+      # Lands at Contents/Resources/themes — GHOSTTY_RESOURCES_DIR points at
+      # Contents/Resources so libghostty resolves named themes from here.
       - path: Macterm/Resources/themes
+        type: folder
+        buildPhase: resources
+      # Ghostty shell-integration scripts (bash/zsh/fish/...), downloaded by
+      # setup.sh. Folder reference for the same reason as themes — extensionless
+      # files. Lands at Contents/Resources/shell-integration.
+      - path: Macterm/Resources/shell-integration
         type: folder
         buildPhase: resources
       # Icon Composer file. Xcode 26 prefers this over an Assets.xcassets

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,6 +16,11 @@ DERIVED_DATA="$BUILD_DIR/DerivedData"
 ARCHIVE_PATH="$BUILD_DIR/Macterm.xcarchive"
 EXPORT_PATH="$BUILD_DIR/export"
 
+# Ensure GhosttyKit + bundled resources (themes, shell-integration) are present
+# before xcodegen resolves the folder references. Idempotent; no-op in CI where
+# ci:setup already ran.
+"$PROJECT_ROOT/scripts/setup.sh"
+
 # Regenerate the Xcode project so any project.yml edits land in CI builds
 # without requiring a developer to commit the generated .xcodeproj.
 xcodegen generate --spec "$PROJECT_ROOT/project.yml" >/dev/null

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 PROJECT_ROOT="$PWD"
 DERIVED_DATA="$PROJECT_ROOT/build/DerivedData"
 
+# Ensure GhosttyKit + bundled resources (themes, shell-integration) are present
+# before xcodegen resolves the folder references. Idempotent and fast when they
+# already exist.
+"$PROJECT_ROOT/scripts/setup.sh"
+
 xcodegen generate --spec "$PROJECT_ROOT/project.yml" >/dev/null
 
 xcodebuild \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,9 +3,18 @@ set -euo pipefail
 
 FORK_REPO="thdxg/ghostty"
 XCFRAMEWORK_DIR="GhosttyKit.xcframework"
+# Marker for the downloaded upstream resources. The two committed custom themes
+# (Macterm, Macterm Light) live in Resources/themes/ alongside them, so we can't
+# key off the themes dir existing — shell-integration ships only in the tarball.
+RESOURCES_MARKER="Macterm/Resources/shell-integration"
 
-if [[ -d "$XCFRAMEWORK_DIR" ]]; then
-  echo "GhosttyKit already present"
+need_xcframework=true
+need_resources=true
+[[ -d "$XCFRAMEWORK_DIR" ]] && need_xcframework=false
+[[ -d "$RESOURCES_MARKER" ]] && need_resources=false
+
+if ! $need_xcframework && ! $need_resources; then
+  echo "GhosttyKit and resources already present"
   exit 0
 fi
 
@@ -15,7 +24,20 @@ if [[ -z "$LATEST_TAG" ]]; then
   exit 1
 fi
 
-gh release download "$LATEST_TAG" --pattern "GhosttyKit.xcframework.tar.gz" --repo "$FORK_REPO"
+if $need_xcframework; then
+  gh release download "$LATEST_TAG" --pattern "GhosttyKit.xcframework.tar.gz" --repo "$FORK_REPO"
+  tar xzf GhosttyKit.xcframework.tar.gz
+  rm GhosttyKit.xcframework.tar.gz
+fi
 
-tar xzf GhosttyKit.xcframework.tar.gz
-rm GhosttyKit.xcframework.tar.gz
+if $need_resources; then
+  # Bundled themes + shell-integration so named themes (Rose Pine, etc.) and
+  # shell integration resolve without a separate Ghostty.app install. The
+  # tarball contains top-level themes/ and shell-integration/ dirs; extract
+  # them into Macterm/Resources/. The committed custom themes are preserved
+  # because tar only writes the files it carries.
+  gh release download "$LATEST_TAG" --pattern "ghostty-resources.tar.gz" --repo "$FORK_REPO"
+  mkdir -p Macterm/Resources
+  tar xzf ghostty-resources.tar.gz -C Macterm/Resources
+  rm ghostty-resources.tar.gz
+fi


### PR DESCRIPTION
## Summary
- Macterm now ships ghostty's themes and shell-integration scripts in its own app bundle, so **named themes resolve without a separate Ghostty.app install**. Previously `GHOSTTY_RESOURCES_DIR` only ever pointed at `/Applications/Ghostty.app`; without it the default `Rose Pine` theme failed to load and the app fell back to hardcoded colors.
- `resolveResources()` now points `GHOSTTY_RESOURCES_DIR` at Macterm's **own bundle first**, falling back to an installed Ghostty.app.
- Default theme switches from `Rose Pine` to the bundled custom `Macterm` theme.
- `setup.sh` downloads `ghostty-resources.tar.gz` (themes + shell-integration) from the `thdxg/ghostty` release into `Macterm/Resources/`; `project.yml` bundles them as folder references; `run.sh`/`build.sh` run `setup.sh` first so the folder refs always resolve. Downloaded files are gitignored (the 2 committed custom themes are kept).

## Depends on
- thdxg/ghostty PR that publishes `ghostty-resources.tar.gz`. **`setup.sh`'s resources download will fail until that lands and the fork workflow runs** (the current release has no such asset).

## Test plan
- [x] `xcodegen generate` accepts the new shell-integration folder reference
- [x] Debug build succeeds; bundle contains `Contents/Resources/{themes,shell-integration}` (514 themes)
- [x] swiftformat / swiftlint clean
- [x] test suite passes
- [x] gitignore leaves downloaded resources untracked, keeps custom themes
- [ ] **Manual:** launch with Ghostty.app absent and confirm a named theme renders (blocked on the fork release shipping the tarball)