### PR TITLE
Show Settings banner when the ghostty CLI is missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ mise run test         # Run the test suite
 mise run build        # Release build + DMG
 ```
 
+`format`, `lint`, and `test` show a spinner and print output only on failure. Pass `--verbose` (e.g. `mise run test --verbose`) to stream the raw output instead — useful when a run fails and you need the full log.
+
 Requires macOS 26+, Swift 6.0+. GhosttyKit is a pre-built xcframework from `thdxg/ghostty` (a fork that adds CI builds). No zig toolchain needed for development.
 
 ## Updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ A floating `NSPanel` that reuses the same `TerminalTab` / `SplitNode` / `Pane` m
 | ------------------------ | ---------------------------------------------------------------------------------- |
 | `GhosttyApp.swift`       | libghostty init, config, tick loop, color queries; resolves `GHOSTTY_RESOURCES_DIR` |
 | `GhosttyResources.swift` | Pure `GhosttyResourceResolver` — picks the resources dir (testable selection logic) |
+| `GhosttyCLI.swift`       | Detects the external `ghostty` CLI (Ghostty.app); lists the shell-integration features gated on it  |
 | `GhosttyCallbacks.swift` | Routes libghostty callbacks to terminal views                                      |
 | `Theme.swift`            | All UI colors derived from ghostty config                                          |
 
@@ -200,6 +201,7 @@ Mirror the production tree. Use `@testable import Macterm` and `@MainActor` on t
 | `Palette/CommandSourceTests.swift`                                                                                          | `CommandSource` palette-item generation from `AppCommand.allCases`                  |
 | `Ghostty/GhosttyResourceResolverTests.swift`                                                                                | Resource dir selection (`GhosttyResourceResolver`)                                   |
 | `Ghostty/BundledResourcesTests.swift`                                                                                       | Bundle layout: terminfo is a sibling of `ghostty/`, has `78/xterm-ghostty`, shells, themes (#39/#40 guard) |
+| `Ghostty/GhosttyCLITests.swift`                                                                                             | External `ghostty` CLI detection + bin-dir priority (`GhosttyCLI`)                    |
 | `Persistence/WorkspaceSerializerTests.swift`                                                                                | Snapshot/restore round-trip + on-disk via `WorkspaceStore`                          |
 | `Support/TreeBuilder.swift`                                                                                                 | DSL: `H(pane("a"), V(pane("b"), pane("c")))` → `(SplitNode, [name: UUID])`          |
 | `Support/TreeRenderer.swift`                                                                                                | Inverse DSL for readable assertions                                                 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,13 +120,13 @@ A floating `NSPanel` that reuses the same `TerminalTab` / `SplitNode` / `Pane` m
 
 ### Ghostty Integration (`Macterm/Ghostty/`)
 
-| File                     | Purpose                                                                            |
-| ------------------------ | ---------------------------------------------------------------------------------- |
-| `GhosttyApp.swift`       | libghostty init, config, tick loop, color queries; resolves `GHOSTTY_RESOURCES_DIR` |
-| `GhosttyResources.swift` | Pure `GhosttyResourceResolver` — picks the resources dir (testable selection logic) |
-| `GhosttyCLI.swift`       | Detects the external `ghostty` CLI (Ghostty.app); lists the shell-integration features gated on it  |
-| `GhosttyCallbacks.swift` | Routes libghostty callbacks to terminal views                                      |
-| `Theme.swift`            | All UI colors derived from ghostty config                                          |
+| File                     | Purpose                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------- |
+| `GhosttyApp.swift`       | libghostty init, config, tick loop, color queries; resolves `GHOSTTY_RESOURCES_DIR`                |
+| `GhosttyCLI.swift`       | Detects the external `ghostty` CLI (Ghostty.app); lists the shell-integration features gated on it |
+| `GhosttyResources.swift` | Pure `GhosttyResourceResolver` — picks the resources dir (testable selection logic)                |
+| `GhosttyCallbacks.swift` | Routes libghostty callbacks to terminal views                                                      |
+| `Theme.swift`            | All UI colors derived from ghostty config                                                          |
 
 ### Palette (`Macterm/Palette/`)
 
@@ -183,30 +183,30 @@ libghostty reads two things at runtime via `GHOSTTY_RESOURCES_DIR`: `shell-integ
 
 Two non-obvious terminfo facts (the regression behind issues #39/#40, where 1.13.3 pointed `GHOSTTY_RESOURCES_DIR` at a bundle shipping no terminfo, breaking `TERM=xterm-ghostty` and key input):
 
-- **TERMINFO must NOT be set by us — the bundle layout makes libghostty derive it correctly.** At shell spawn libghostty *unconditionally overwrites* `TERMINFO` with `dirname(GHOSTTY_RESOURCES_DIR)/terminfo` (`src/termio/Exec.zig`), so any `setenv` we do is clobbered. Because our resources dir is `.../Resources/ghostty`, that derivation lands on the sibling `.../Resources/terminfo` — exactly the dir we ship. This is why terminfo MUST be a sibling of `ghostty/`, never inside it (a flat layout reintroduces #39/#40). `BundledResourcesTests` asserts this invariant.
+- **TERMINFO must NOT be set by us — the bundle layout makes libghostty derive it correctly.** At shell spawn libghostty _unconditionally overwrites_ `TERMINFO` with `dirname(GHOSTTY_RESOURCES_DIR)/terminfo` (`src/termio/Exec.zig`), so any `setenv` we do is clobbered. Because our resources dir is `.../Resources/ghostty`, that derivation lands on the sibling `.../Resources/terminfo` — exactly the dir we ship. This is why terminfo MUST be a sibling of `ghostty/`, never inside it (a flat layout reintroduces #39/#40). `BundledResourcesTests` asserts this invariant.
 - **The terminfo tree uses the macOS hashed layout.** The compiled `xterm-ghostty` entry lives at `terminfo/78/xterm-ghostty` (`x` = 0x78), not `terminfo/x/...`. It's a `tic -x` compiled tree, shipped verbatim from the ghostty build.
 
 ### Tests (`MactermTests/`)
 
 Mirror the production tree. Use `@testable import Macterm` and `@MainActor` on test classes. `mise run test` runs the suite locally and on every CI push.
 
-| Path                                                                                                                        | Covers                                                                              |
-| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `Model/SplitNodeTests.swift`, `SplitNodeResizeTests.swift`, `SplitNodeGeometryTests.swift`, `SplitNodeRebalanceTests.swift` | Tree ops, resize, geometry (`paneFrames`, `nearestPane`), rebalance                 |
-| `Model/TerminalTabTests.swift`                                                                                              | Focus history, split/resize/removePane, HV-close regression                         |
-| `Model/WorkspaceTests.swift`                                                                                                | Tab lifecycle, recency, reorder                                                     |
-| `Model/PaneTests.swift`                                                                                                     | `processTitle` heuristics, `destroySurface` idempotency                             |
-| `App/AppStateTests.swift`                                                                                                   | Integration: splitPane/closePane/focusPaneInDirection via injected `WorkspaceStore` |
-| `App/RecencyStackTests.swift`                                                                                               | Generic stack helper                                                                |
-| `App/HotkeysTests.swift`                                                                                                    | `parseShortcut`, `displayString`, `HotkeyAction` sanity                             |
-| `Palette/PaletteEngineTests.swift`                                                                                          | `fuzzyScore`, engine sections/sort/path-mode                                        |
-| `Palette/CommandSourceTests.swift`                                                                                          | `CommandSource` palette-item generation from `AppCommand.allCases`                  |
-| `Ghostty/GhosttyResourceResolverTests.swift`                                                                                | Resource dir selection (`GhosttyResourceResolver`)                                   |
+| Path                                                                                                                        | Covers                                                                                                     |
+| --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `Model/SplitNodeTests.swift`, `SplitNodeResizeTests.swift`, `SplitNodeGeometryTests.swift`, `SplitNodeRebalanceTests.swift` | Tree ops, resize, geometry (`paneFrames`, `nearestPane`), rebalance                                        |
+| `Model/TerminalTabTests.swift`                                                                                              | Focus history, split/resize/removePane, HV-close regression                                                |
+| `Model/WorkspaceTests.swift`                                                                                                | Tab lifecycle, recency, reorder                                                                            |
+| `Model/PaneTests.swift`                                                                                                     | `processTitle` heuristics, `destroySurface` idempotency                                                    |
+| `App/AppStateTests.swift`                                                                                                   | Integration: splitPane/closePane/focusPaneInDirection via injected `WorkspaceStore`                        |
+| `App/RecencyStackTests.swift`                                                                                               | Generic stack helper                                                                                       |
+| `App/HotkeysTests.swift`                                                                                                    | `parseShortcut`, `displayString`, `HotkeyAction` sanity                                                    |
+| `Palette/PaletteEngineTests.swift`                                                                                          | `fuzzyScore`, engine sections/sort/path-mode                                                               |
+| `Palette/CommandSourceTests.swift`                                                                                          | `CommandSource` palette-item generation from `AppCommand.allCases`                                         |
+| `Ghostty/GhosttyCLITests.swift`                                                                                             | External `ghostty` CLI detection + bin-dir priority (`GhosttyCLI`)                                         |
+| `Ghostty/GhosttyResourceResolverTests.swift`                                                                                | Resource dir selection (`GhosttyResourceResolver`)                                                         |
 | `Ghostty/BundledResourcesTests.swift`                                                                                       | Bundle layout: terminfo is a sibling of `ghostty/`, has `78/xterm-ghostty`, shells, themes (#39/#40 guard) |
-| `Ghostty/GhosttyCLITests.swift`                                                                                             | External `ghostty` CLI detection + bin-dir priority (`GhosttyCLI`)                    |
-| `Persistence/WorkspaceSerializerTests.swift`                                                                                | Snapshot/restore round-trip + on-disk via `WorkspaceStore`                          |
-| `Support/TreeBuilder.swift`                                                                                                 | DSL: `H(pane("a"), V(pane("b"), pane("c")))` → `(SplitNode, [name: UUID])`          |
-| `Support/TreeRenderer.swift`                                                                                                | Inverse DSL for readable assertions                                                 |
+| `Persistence/WorkspaceSerializerTests.swift`                                                                                | Snapshot/restore round-trip + on-disk via `WorkspaceStore`                                                 |
+| `Support/TreeBuilder.swift`                                                                                                 | DSL: `H(pane("a"), V(pane("b"), pane("c")))` → `(SplitNode, [name: UUID])`                                 |
+| `Support/TreeRenderer.swift`                                                                                                | Inverse DSL for readable assertions                                                                        |
 
 **Testing conventions:**
 

--- a/Macterm/Config/MactermConfig.swift
+++ b/Macterm/Config/MactermConfig.swift
@@ -66,7 +66,7 @@ final class MactermConfig {
         // otherwise disable the wrappers that need the binary so they fall
         // through to plain `ssh`. The `path` feature also relies on this dir
         // being useful — turn it off when we have nothing to add.
-        if let binDir = resolveGhosttyBinDir() {
+        if let binDir = GhosttyCLI.standard.resolveBinDir() {
             overrides.append("env = GHOSTTY_BIN_DIR=\(binDir)")
         } else {
             overrides.append("shell-integration-features = no-ssh-env,no-ssh-terminfo,no-path")
@@ -74,13 +74,5 @@ final class MactermConfig {
 
         let body = overrides.joined(separator: "\n") + "\n"
         try? Data(body.utf8).write(to: overridesURL, options: .atomic)
-    }
-
-    private func resolveGhosttyBinDir() -> String? {
-        let candidates = [
-            "/Applications/Ghostty.app/Contents/MacOS",
-            NSHomeDirectory() + "/Applications/Ghostty.app/Contents/MacOS",
-        ]
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0 + "/ghostty") }
     }
 }

--- a/Macterm/Ghostty/GhosttyCLI.swift
+++ b/Macterm/Ghostty/GhosttyCLI.swift
@@ -6,7 +6,7 @@ import Foundation
 /// wrappers exec the standalone `ghostty` CLI at runtime. Macterm ships no such
 /// binary, so those wrappers only work when the user also has Ghostty.app
 /// installed. When it's missing, `MactermConfig` disables the dependent
-/// features (see `GhosttyCLI.gatedFeatures`) and Settings surfaces a banner.
+/// shell-integration features and Settings surfaces a banner.
 ///
 /// Selection logic only — the candidate paths and a filesystem probe are
 /// injected so the detection is unit-testable without touching disk.
@@ -23,28 +23,6 @@ struct GhosttyCLI {
     }
 
     var isInstalled: Bool { resolveBinDir() != nil }
-
-    /// Features that silently stop working without the external CLI, matching
-    /// the `shell-integration-features` Macterm disables in `MactermConfig`.
-    struct GatedFeature {
-        let name: String
-        let detail: String
-    }
-
-    static let gatedFeatures: [GatedFeature] = [
-        GatedFeature(
-            name: "SSH terminfo",
-            detail: "Installs the xterm-ghostty terminfo on remote hosts so keys and colors work over SSH."
-        ),
-        GatedFeature(
-            name: "SSH environment",
-            detail: "Propagates TERM and shell-integration variables to SSH sessions."
-        ),
-        GatedFeature(
-            name: "Shell PATH integration",
-            detail: "Adds the ghostty CLI to PATH inside spawned shells."
-        ),
-    ]
 }
 
 extension GhosttyCLI {

--- a/Macterm/Ghostty/GhosttyCLI.swift
+++ b/Macterm/Ghostty/GhosttyCLI.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Detection for the external ghostty CLI binary (shipped inside Ghostty.app).
+///
+/// libghostty is embedded in Macterm, but a handful of shell-integration
+/// wrappers exec the standalone `ghostty` CLI at runtime. Macterm ships no such
+/// binary, so those wrappers only work when the user also has Ghostty.app
+/// installed. When it's missing, `MactermConfig` disables the dependent
+/// features (see `GhosttyCLI.gatedFeatures`) and Settings surfaces a banner.
+///
+/// Selection logic only — the candidate paths and a filesystem probe are
+/// injected so the detection is unit-testable without touching disk.
+struct GhosttyCLI {
+    /// Directories that may contain the `ghostty` CLI, highest priority first.
+    let binDirCandidates: [String]
+    /// Filesystem executable probe. Injected so tests don't touch disk.
+    let isExecutable: (String) -> Bool
+
+    /// The directory holding the `ghostty` binary, or nil when none is found.
+    /// `MactermConfig` feeds this into `GHOSTTY_BIN_DIR` for spawned shells.
+    func resolveBinDir() -> String? {
+        binDirCandidates.first { isExecutable($0 + "/ghostty") }
+    }
+
+    var isInstalled: Bool { resolveBinDir() != nil }
+
+    /// Features that silently stop working without the external CLI, matching
+    /// the `shell-integration-features` Macterm disables in `MactermConfig`.
+    struct GatedFeature {
+        let name: String
+        let detail: String
+    }
+
+    static let gatedFeatures: [GatedFeature] = [
+        GatedFeature(
+            name: "SSH terminfo",
+            detail: "Installs the xterm-ghostty terminfo on remote hosts so keys and colors work over SSH."
+        ),
+        GatedFeature(
+            name: "SSH environment",
+            detail: "Propagates TERM and shell-integration variables to SSH sessions."
+        ),
+        GatedFeature(
+            name: "Shell PATH integration",
+            detail: "Adds the ghostty CLI to PATH inside spawned shells."
+        ),
+    ]
+}
+
+extension GhosttyCLI {
+    /// The detector Macterm uses at runtime: probes the standard Ghostty.app
+    /// install locations on disk.
+    static var standard: GhosttyCLI {
+        GhosttyCLI(
+            binDirCandidates: [
+                "/Applications/Ghostty.app/Contents/MacOS",
+                NSHomeDirectory() + "/Applications/Ghostty.app/Contents/MacOS",
+            ],
+            isExecutable: FileManager.default.isExecutableFile(atPath:)
+        )
+    }
+}

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -110,7 +110,7 @@ private struct GeneralSettings: View {
 /// out which. Embedded directly in a `Form`, so it renders as its own section.
 private struct MissingGhosttyCLIBanner: View {
     private static let detailsURL = URL(
-        string: "https://github.com/thdxg/macterm#whats-different-from-ghosttyapp"
+        string: "https://github.com/thdxg/macterm#shell-integration"
     )
 
     var body: some View {

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -111,18 +111,19 @@ private struct GeneralSettings: View {
 private struct MissingGhosttyCLIBanner: View {
     private static let detailsURL = "https://github.com/thdxg/macterm#whats-different-from-ghosttyapp"
 
+    // Typed as LocalizedStringKey (not String) so Text parses the markdown link.
+    private static let detail: LocalizedStringKey =
+        "Ghostty.app isn't installed, so a few shell-integration features can't run. [Learn more](\(detailsURL))"
+
     var body: some View {
         Section {
             Label {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Some features are disabled")
                         .font(.system(size: 13, weight: .semibold))
-                    Text(
-                        "Ghostty.app isn't installed, so a few shell-integration "
-                            + "features can't run. [Learn more](\(Self.detailsURL))"
-                    )
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                    Text(Self.detail)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
                 }
             } icon: {
                 Image(systemName: "exclamationmark.triangle.fill")

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -109,11 +109,9 @@ private struct GeneralSettings: View {
 /// binary, so without it some features are disabled — the README link spells
 /// out which. Embedded directly in a `Form`, so it renders as its own section.
 private struct MissingGhosttyCLIBanner: View {
-    private static let detailsURL = "https://github.com/thdxg/macterm#whats-different-from-ghosttyapp"
-
-    // Typed as LocalizedStringKey (not String) so Text parses the markdown link.
-    private static let detail: LocalizedStringKey =
-        "Ghostty.app isn't installed, so a few shell-integration features can't run. [Learn more](\(detailsURL))"
+    private static let detailsURL = URL(
+        string: "https://github.com/thdxg/macterm#whats-different-from-ghosttyapp"
+    )
 
     var body: some View {
         Section {
@@ -121,9 +119,13 @@ private struct MissingGhosttyCLIBanner: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Some features are disabled")
                         .font(.system(size: 13, weight: .semibold))
-                    Text(Self.detail)
+                    Text("Ghostty.app isn't installed, so a few shell-integration features can't run.")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
+                    if let url = Self.detailsURL {
+                        Link("Learn more", destination: url)
+                            .font(.system(size: 11))
+                    }
                 }
             } icon: {
                 Image(systemName: "exclamationmark.triangle.fill")

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -30,8 +30,14 @@ private struct GeneralSettings: View {
     @State
     private var ghosttyConfigPath: String = Preferences.shared.userGhosttyConfigPath
 
+    private let ghosttyCLI = GhosttyCLI.standard
+
     var body: some View {
         Form {
+            if !ghosttyCLI.isInstalled {
+                MissingGhosttyCLIBanner()
+            }
+
             Section("Ghostty Config") {
                 HStack {
                     TextField(
@@ -93,6 +99,49 @@ private struct GeneralSettings: View {
         guard panel.runModal() == .OK, let url = panel.url else { return }
         ghosttyConfigPath = url.path(percentEncoded: false)
         commitPath()
+    }
+}
+
+// MARK: - Missing CLI banner
+
+/// Shown in General settings when the standalone ghostty CLI (shipped in
+/// Ghostty.app) isn't installed. A few shell-integration wrappers exec that
+/// binary, so without it the features in `GhosttyCLI.gatedFeatures` are
+/// disabled. Embedded directly in a `Form`, so it renders as its own section.
+private struct MissingGhosttyCLIBanner: View {
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 10) {
+                Label {
+                    Text("Some features need the Ghostty app")
+                        .font(.system(size: 13, weight: .semibold))
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.yellow)
+                }
+
+                Text(
+                    "Macterm couldn't find the ghostty command-line tool. It ships inside "
+                        + "Ghostty.app — install it to /Applications and reopen Macterm to "
+                        + "enable these features:"
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(GhosttyCLI.gatedFeatures, id: \.name) { feature in
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(feature.name)
+                                .font(.system(size: 11, weight: .medium))
+                            Text(feature.detail)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 2)
+        }
     }
 }
 

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -106,39 +106,29 @@ private struct GeneralSettings: View {
 
 /// Shown in General settings when the standalone ghostty CLI (shipped in
 /// Ghostty.app) isn't installed. A few shell-integration wrappers exec that
-/// binary, so without it the features in `GhosttyCLI.gatedFeatures` are
-/// disabled. Embedded directly in a `Form`, so it renders as its own section.
+/// binary, so without it some features are disabled — the README link spells
+/// out which. Embedded directly in a `Form`, so it renders as its own section.
 private struct MissingGhosttyCLIBanner: View {
+    private static let detailsURL = URL(
+        string: "https://github.com/thdxg/macterm#whats-different-from-ghosttyapp"
+    )!
+
     var body: some View {
         Section {
-            VStack(alignment: .leading, spacing: 10) {
-                Label {
-                    Text("Some features need the Ghostty app")
+            Label {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Some features are disabled")
                         .font(.system(size: 13, weight: .semibold))
-                } icon: {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.yellow)
+                    Text(
+                        "Ghostty.app isn't installed, so a few shell-integration "
+                            + "features can't run. [Learn more](\(Self.detailsURL.absoluteString))"
+                    )
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
                 }
-
-                Text(
-                    "Macterm couldn't find the ghostty command-line tool. It ships inside "
-                        + "Ghostty.app — install it to /Applications and reopen Macterm to "
-                        + "enable these features:"
-                )
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-
-                VStack(alignment: .leading, spacing: 6) {
-                    ForEach(GhosttyCLI.gatedFeatures, id: \.name) { feature in
-                        VStack(alignment: .leading, spacing: 1) {
-                            Text(feature.name)
-                                .font(.system(size: 11, weight: .medium))
-                            Text(feature.detail)
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
+            } icon: {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.yellow)
             }
             .padding(.vertical, 2)
         }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -109,9 +109,7 @@ private struct GeneralSettings: View {
 /// binary, so without it some features are disabled — the README link spells
 /// out which. Embedded directly in a `Form`, so it renders as its own section.
 private struct MissingGhosttyCLIBanner: View {
-    private static let detailsURL = URL(
-        string: "https://github.com/thdxg/macterm#whats-different-from-ghosttyapp"
-    )!
+    private static let detailsURL = "https://github.com/thdxg/macterm#whats-different-from-ghosttyapp"
 
     var body: some View {
         Section {
@@ -121,7 +119,7 @@ private struct MissingGhosttyCLIBanner: View {
                         .font(.system(size: 13, weight: .semibold))
                     Text(
                         "Ghostty.app isn't installed, so a few shell-integration "
-                            + "features can't run. [Learn more](\(Self.detailsURL.absoluteString))"
+                            + "features can't run. [Learn more](\(Self.detailsURL))"
                     )
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)

--- a/MactermTests/Ghostty/GhosttyCLITests.swift
+++ b/MactermTests/Ghostty/GhosttyCLITests.swift
@@ -35,9 +35,4 @@ struct GhosttyCLITests {
         #expect(c.resolveBinDir() == nil)
         #expect(!c.isInstalled)
     }
-
-    @Test
-    func gated_features_are_nonempty() {
-        #expect(!GhosttyCLI.gatedFeatures.isEmpty)
-    }
 }

--- a/MactermTests/Ghostty/GhosttyCLITests.swift
+++ b/MactermTests/Ghostty/GhosttyCLITests.swift
@@ -1,0 +1,43 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+struct GhosttyCLITests {
+    private func cli(candidates: [String], executable: Set<String>) -> GhosttyCLI {
+        GhosttyCLI(
+            binDirCandidates: candidates,
+            isExecutable: { executable.contains($0) }
+        )
+    }
+
+    @Test
+    func resolves_first_candidate_with_executable() {
+        let c = cli(
+            candidates: ["/Applications/Ghostty.app/Contents/MacOS", "/home/Ghostty.app/Contents/MacOS"],
+            executable: ["/home/Ghostty.app/Contents/MacOS/ghostty"]
+        )
+        #expect(c.resolveBinDir() == "/home/Ghostty.app/Contents/MacOS")
+        #expect(c.isInstalled)
+    }
+
+    @Test
+    func prefers_higher_priority_candidate() {
+        let c = cli(
+            candidates: ["/a", "/b"],
+            executable: ["/a/ghostty", "/b/ghostty"]
+        )
+        #expect(c.resolveBinDir() == "/a")
+    }
+
+    @Test
+    func not_installed_when_no_executable() {
+        let c = cli(candidates: ["/a", "/b"], executable: [])
+        #expect(c.resolveBinDir() == nil)
+        #expect(!c.isInstalled)
+    }
+
+    @Test
+    func gated_features_are_nonempty() {
+        #expect(!GhosttyCLI.gatedFeatures.isEmpty)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ Macterm-specific settings (window opacity/blur, quick terminal dimensions, hotke
 
 Macterm bundles Ghostty's terminfo, shell-integration scripts, and themes, so `TERM=xterm-ghostty`, named themes, and shell integration all work standalone — no Ghostty.app install required.
 
-The one exception is the `ssh-env`, `ssh-terminfo`, and `path` shell-integration features, which need the `ghostty` CLI to do anything useful, and Macterm doesn't ship one. If Ghostty.app is installed alongside in `/Applications`, Macterm points the wrappers at its binary and they work normally. Otherwise these features are disabled — `ssh` and `sudo` still work, they just skip Ghostty's terminfo-forwarding tricks for remote hosts. Install Ghostty.app if you want them. When the CLI is missing, **Settings → General** shows a banner listing the disabled features.
+### Shell integration
+
+The one exception is the `ssh-env`, `ssh-terminfo`, and `path` shell-integration features, which need the `ghostty` CLI to do anything useful, and Macterm doesn't ship one. If Ghostty.app is installed alongside in `/Applications`, Macterm points the wrappers at its binary and they work normally. Otherwise these features are disabled — `ssh` and `sudo` still work, they just skip Ghostty's terminfo-forwarding tricks for remote hosts. Install Ghostty.app if you want them. When the CLI is missing, **Settings → General** shows a banner that links here.
 
 ### Keybinds
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Macterm-specific settings (window opacity/blur, quick terminal dimensions, hotke
 
 Macterm bundles Ghostty's terminfo, shell-integration scripts, and themes, so `TERM=xterm-ghostty`, named themes, and shell integration all work standalone — no Ghostty.app install required.
 
-The one exception is the `ssh-env`, `ssh-terminfo`, and `path` shell-integration features, which need the `ghostty` CLI to do anything useful, and Macterm doesn't ship one. If Ghostty.app is installed alongside in `/Applications`, Macterm points the wrappers at its binary and they work normally. Otherwise these features are disabled — `ssh` and `sudo` still work, they just skip Ghostty's terminfo-forwarding tricks for remote hosts. Install Ghostty.app if you want them.
+The one exception is the `ssh-env`, `ssh-terminfo`, and `path` shell-integration features, which need the `ghostty` CLI to do anything useful, and Macterm doesn't ship one. If Ghostty.app is installed alongside in `/Applications`, Macterm points the wrappers at its binary and they work normally. Otherwise these features are disabled — `ssh` and `sudo` still work, they just skip Ghostty's terminfo-forwarding tricks for remote hosts. Install Ghostty.app if you want them. When the CLI is missing, **Settings → General** shows a banner listing the disabled features.
 
 ### Keybinds
 


### PR DESCRIPTION
## Summary

- Some shell-integration features (`ssh-terminfo`, `ssh-env`, `path`) silently stop working without the standalone `ghostty` CLI, which ships only inside Ghostty.app. There was no signal to the user that this was happening.
- Extracts the CLI-detection logic out of `MactermConfig` into a small, testable `GhosttyCLI` type (`GhosttyCLI.standard` probes the standard Ghostty.app install locations). `MactermConfig` now calls `GhosttyCLI.standard.resolveBinDir()` instead of its private helper — single source of truth for the candidate paths.
- Adds a minimal `MissingGhosttyCLIBanner` to **Settings → General**, shown only when the CLI isn't found: a one-line notice plus a "Learn more" link to the README's "What's different from Ghostty.app" section, which already documents exactly which features are disabled. Native SwiftUI `Section`/`Label`.

## Notes

- The banner reads detection once when General settings opens, so installing Ghostty.app while the window is open won't live-refresh it — reopening Settings will. This matches the existing "reopen to enable" behavior, since the config only re-checks on regenerate.
- README "For Ghostty Users" now mentions the banner; `CLAUDE.md` file/test maps list the new `GhosttyCLI.swift` / `GhosttyCLITests.swift`.

## Test plan

- [x] `mise run format`, `mise run lint`, `mise run test` all pass
- [x] Manually: with Ghostty.app absent from `/Applications`, open Settings → General and confirm the banner appears and the link opens the README section
- [x] Manually: with Ghostty.app installed, confirm the banner does not appear