### PR TITLE
feat: native overlay scrollbar for terminal panes

### DIFF
--- a/Macterm/Ghostty/GhosttyCallbacks.swift
+++ b/Macterm/Ghostty/GhosttyCallbacks.swift
@@ -52,6 +52,11 @@ final class GhosttyCallbacks: @unchecked Sendable {
             let duration = action.action.command_finished.duration
             DispatchQueue.main.async { view.onCommandFinished?(exitCode, duration) }
             return true
+        case GHOSTTY_ACTION_SCROLLBAR:
+            guard let view = surfaceView(from: target) else { return true }
+            let s = action.action.scrollbar
+            DispatchQueue.main.async { view.onScrollbarUpdate?(s.total, s.offset, s.len) }
+            return true
         default:
             return false
         }

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -31,6 +31,20 @@ final class Pane: Identifiable {
 
     var nsView: GhosttyTerminalNSView? { _nsView }
 
+    /// The `NSScrollView` that hosts this pane's surface and renders the native
+    /// overlay scrollbar. Owned here (not by SwiftUI) for the same reason as
+    /// `_nsView`: it must survive tab switches and split reshapes, and it
+    /// sidesteps Ghostty's #9444 bug where the scroll wrapper isn't persisted.
+    @ObservationIgnored
+    private var _scrollView: SurfaceScrollView?
+
+    func ensureScrollView() -> SurfaceScrollView {
+        if let existing = _scrollView { return existing }
+        let scroll = SurfaceScrollView(surfaceView: ensureNSView())
+        _scrollView = scroll
+        return scroll
+    }
+
     /// Tear down the ghostty surface and null out callbacks. Call when the
     /// pane is removed from the tree. Safe to call multiple times.
     func destroySurface() {
@@ -47,14 +61,21 @@ final class Pane: Identifiable {
         view.onSplitRequest = nil
         view.onDesktopNotification = nil
         view.onCommandFinished = nil
+        view.onScrollbarUpdate = nil
         view.destroySurface()
+        let scroll = _scrollView
+        _scrollView = nil
         _nsView = nil
-        // Keep the NSView alive for a runloop tick so any in-flight ghostty
-        // callback (which holds an unretained pointer to the view) can drain
-        // before the view is deallocated. Without this, SwiftUI can remove
-        // the view from its superview the same turn we destroy the surface,
-        // deallocating the NSView before ghostty has finished unwinding.
-        DispatchQueue.main.async { _ = view }
+        // Keep the NSView (and its scroll-view host) alive for a runloop tick so
+        // any in-flight ghostty callback (which holds an unretained pointer to
+        // the view) can drain before the view is deallocated. Without this,
+        // SwiftUI can remove the view from its superview the same turn we
+        // destroy the surface, deallocating the NSView before ghostty has
+        // finished unwinding.
+        DispatchQueue.main.async {
+            _ = view
+            _ = scroll
+        }
     }
 
     var processTitle: String {

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -25,6 +25,11 @@ final class GhosttyTerminalNSView: NSView {
     var onSearchSelected: ((Int?) -> Void)?
     var onDesktopNotification: ((String, String) -> Void)?
     var onCommandFinished: ((Int16, UInt64) -> Void)?
+    /// libghostty pushes scrollback geometry (all values in rows) whenever the
+    /// viewport, scrollback size, or visible row count changes.
+    /// `(total, offset, len)`: total rows including scrollback, the first
+    /// visible row (0 = top of history), and the visible row count.
+    var onScrollbarUpdate: ((UInt64, UInt64, UInt64) -> Void)?
     var isFocused: Bool = false
     var currentPwd: String?
 
@@ -201,6 +206,18 @@ final class GhosttyTerminalNSView: NSView {
     func needsConfirmQuit() -> Bool {
         guard let surface else { return false }
         return ghostty_surface_needs_confirm_quit(surface)
+    }
+
+    /// Cell height in points (not backing pixels). libghostty reports cell
+    /// dimensions in backing pixels; divide by the backing scale so callers
+    /// working in AppKit's point space (e.g. the scroll view's document view)
+    /// get the right value. Returns 0 if the surface isn't ready.
+    var cellHeightPoints: CGFloat {
+        guard let surface else { return 0 }
+        let size = ghostty_surface_size(surface)
+        guard size.cell_height_px > 0 else { return 0 }
+        let scale = window?.backingScaleFactor ?? 2.0
+        return CGFloat(size.cell_height_px) / scale
     }
 
     func notifySurfaceFocused() {

--- a/Macterm/Views/Terminal/SurfaceScrollView.swift
+++ b/Macterm/Views/Terminal/SurfaceScrollView.swift
@@ -1,0 +1,252 @@
+import AppKit
+import GhosttyKit
+
+/// Native overlay scrollbar for a terminal surface, mirroring Ghostty's macOS
+/// approach (Ghostty 1.3.0+, `SurfaceScrollView`).
+///
+/// The trick: nest the Metal terminal surface inside a standard `NSScrollView`
+/// whose `documentView` is a **blank spacer** sized to the full scrollback
+/// height. AppKit then renders and hit-tests a real overlay scroller (auto-hide
+/// / fade for free) and the surface only ever draws the visible viewport.
+///
+/// ```
+/// SurfaceScrollView : NSScrollView
+///   └─ documentView : NSView          (blank, height = total rows * cellHeight)
+///        └─ GhosttyTerminalNSView      (pinned to the visible rect)
+/// ```
+///
+/// Wheel/trackpad events are NOT arbitrated here: they hit the frontmost
+/// surface view, whose `scrollWheel` forwards every event to libghostty, which
+/// decides scrollback vs. cursor-keys vs. mouse-report. The scroll view is
+/// display/drag-only. Scrollback geometry flows **into** this view via the
+/// `GHOSTTY_ACTION_SCROLLBAR` action (`onScrollbarUpdate`), and user drags flow
+/// **out** via the `scroll_to_row:<n>` keybind action.
+final class SurfaceScrollView: NSScrollView {
+    /// The Metal terminal surface. Owned by `Pane`; we just re-parent it into
+    /// our document view.
+    let surfaceView: GhosttyTerminalNSView
+
+    /// The blank spacer whose height represents the full scrollback.
+    private let spacer = NSView()
+
+    /// Latest scrollback geometry pushed by libghostty, in rows.
+    private var total: UInt64 = 0
+    private var offset: UInt64 = 0
+    private var len: UInt64 = 0
+
+    /// True while the user is dragging the scroller (live scroll). During a
+    /// drag we resize the document but must not programmatically scroll the clip
+    /// view — that would fight the user's gesture.
+    private var isLiveScrolling = false
+
+    /// Last row index sent to the core via `scroll_to_row`, to dedupe spam.
+    private var lastSentRow: Int = -1
+
+    nonisolated(unsafe) private var observers: [NSObjectProtocol] = []
+
+    init(surfaceView: GhosttyTerminalNSView) {
+        self.surfaceView = surfaceView
+        super.init(frame: .zero)
+
+        // Overlay style always: matches Ghostty, gives auto-hide/fade for free,
+        // and overlays the grid without reserving a gutter (so the surface is
+        // never resized by the scrollbar appearing).
+        scrollerStyle = .overlay
+        hasVerticalScroller = true
+        hasHorizontalScroller = false
+        autohidesScrollers = false
+        usesPredominantAxisScrolling = true
+        // The window composites its own translucency (see WindowAppearance);
+        // drawing a background here would double-tint.
+        drawsBackground = false
+        contentView.drawsBackground = false
+        // Let the surface paint the full visible rect without the clip view
+        // clipping its layer at the edges.
+        contentView.clipsToBounds = false
+
+        spacer.translatesAutoresizingMaskIntoConstraints = true
+        spacer.addSubview(surfaceView)
+        documentView = spacer
+
+        wireObservers()
+        surfaceView.onScrollbarUpdate = { [weak self] total, offset, len in
+            self?.applyScrollbar(total: total, offset: offset, len: len)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    deinit {
+        for token in observers {
+            NotificationCenter.default.removeObserver(token)
+        }
+    }
+
+    // MARK: - Observers
+
+    private func wireObservers() {
+        let nc = NotificationCenter.default
+
+        let willStart = nc.addObserver(
+            forName: NSScrollView.willStartLiveScrollNotification, object: self, queue: .main
+        ) { [weak self] _ in MainActor.assumeIsolated { self?.isLiveScrolling = true } }
+
+        let didLive = nc.addObserver(
+            forName: NSScrollView.didLiveScrollNotification, object: self, queue: .main
+        ) { [weak self] _ in MainActor.assumeIsolated { self?.handleLiveScroll() } }
+
+        let didEnd = nc.addObserver(
+            forName: NSScrollView.didEndLiveScrollNotification, object: self, queue: .main
+        ) { [weak self] _ in MainActor.assumeIsolated { self?.isLiveScrolling = false } }
+
+        // Keep the surface pinned to the visible rect as the clip view moves.
+        contentView.postsBoundsChangedNotifications = true
+        let bounds = nc.addObserver(
+            forName: NSView.boundsDidChangeNotification, object: contentView, queue: .main
+        ) { [weak self] _ in MainActor.assumeIsolated { self?.layoutSurface() } }
+
+        // Re-assert overlay style if the user toggles the system "always show
+        // scrollbars" preference.
+        let style = nc.addObserver(
+            forName: NSScroller.preferredScrollerStyleDidChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in MainActor.assumeIsolated { self?.scrollerStyle = .overlay } }
+
+        observers = [willStart, didLive, didEnd, bounds, style]
+    }
+
+    // MARK: - Layout
+
+    override func layout() {
+        super.layout()
+        synchronize()
+    }
+
+    /// Pin the surface to fill the currently visible rect of the document.
+    private func layoutSurface() {
+        let visible = contentView.documentVisibleRect
+        // The surface always fills exactly what's on screen; libghostty renders
+        // the viewport, not the whole scrollback.
+        surfaceView.frame = visible
+    }
+
+    /// Resize the spacer to the full scrollback height and, unless the user is
+    /// mid-drag, scroll the clip view to mirror libghostty's viewport.
+    private func synchronize() {
+        let cellHeight = surfaceView.cellHeightPoints
+        let viewportHeight = contentView.bounds.height
+        guard cellHeight > 0, viewportHeight > 0 else {
+            // Surface not ready: spacer matches the viewport (no scrollback).
+            spacer.frame = NSRect(origin: .zero, size: contentView.bounds.size)
+            layoutSurface()
+            return
+        }
+
+        let docHeight = Self.documentHeight(total: total, cellHeight: cellHeight, viewportHeight: viewportHeight)
+        if spacer.frame.height != docHeight || spacer.frame.width != contentView.bounds.width {
+            spacer.frame = NSRect(x: 0, y: 0, width: contentView.bounds.width, height: docHeight)
+        }
+
+        if !isLiveScrolling {
+            let y = Self.documentOffsetY(total: total, offset: offset, len: len, cellHeight: cellHeight)
+            contentView.scroll(to: NSPoint(x: 0, y: y))
+            reflectScrolledClipView(contentView)
+        }
+        layoutSurface()
+    }
+
+    // MARK: - Core → UI
+
+    private func applyScrollbar(total: UInt64, offset: UInt64, len: UInt64) {
+        self.total = total
+        self.offset = offset
+        self.len = len
+        synchronize()
+    }
+
+    // MARK: - UI → Core
+
+    private func handleLiveScroll() {
+        let cellHeight = surfaceView.cellHeightPoints
+        guard cellHeight > 0, let surface = surfaceView.surface else { return }
+        let visible = contentView.documentVisibleRect
+        let docHeight = spacer.frame.height
+        let row = Self.rowFromOffset(
+            visibleOriginY: visible.origin.y,
+            visibleHeight: visible.height,
+            documentHeight: docHeight,
+            cellHeight: cellHeight
+        )
+        guard row != lastSentRow else {
+            layoutSurface()
+            return
+        }
+        lastSentRow = row
+        let action = "scroll_to_row:\(row)"
+        ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
+        layoutSurface()
+    }
+
+    // MARK: - Legacy scroller discoverability
+
+    private var scrollerTracking: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let existing = scrollerTracking { removeTrackingArea(existing) }
+        guard let scroller = verticalScroller else { return }
+        let area = NSTrackingArea(
+            rect: scroller.frame,
+            options: [.mouseMoved, .activeInKeyWindow, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(area)
+        scrollerTracking = area
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+        // With a legacy "always show scrollbars" preference we force overlay
+        // style, which would otherwise hide the click-drag affordance. Flash the
+        // scroller when the pointer is over its track so it stays discoverable.
+        guard NSScroller.preferredScrollerStyle == .legacy else { return }
+        flashScrollers()
+    }
+}
+
+// MARK: - Pure geometry
+
+extension SurfaceScrollView {
+    /// Height of the blank document view (points). At least the viewport height
+    /// so there's nothing to scroll when scrollback is empty.
+    nonisolated static func documentHeight(total: UInt64, cellHeight: CGFloat, viewportHeight: CGFloat) -> CGFloat {
+        max(CGFloat(total) * cellHeight, viewportHeight)
+    }
+
+    /// AppKit clip-view origin (points, Y-up from the document bottom) that
+    /// places the visible region over libghostty's current viewport.
+    ///
+    /// libghostty's `offset` is the first visible row counted from the top of
+    /// history (Y-down); AppKit scrolls from the bottom (Y-up), so we invert:
+    /// rows below the viewport = `total - offset - len`.
+    nonisolated static func documentOffsetY(total: UInt64, offset: UInt64, len: UInt64, cellHeight: CGFloat) -> CGFloat {
+        let rowsBelow = Int64(total) - Int64(offset) - Int64(len)
+        return CGFloat(max(0, rowsBelow)) * cellHeight
+    }
+
+    /// Inverse of `documentOffsetY`: the top visible row (from the top of
+    /// history) for a given clip-view position. Used when the user drags the
+    /// scroller, to tell the core which row to scroll to.
+    nonisolated static func rowFromOffset(
+        visibleOriginY: CGFloat,
+        visibleHeight: CGFloat,
+        documentHeight: CGFloat,
+        cellHeight: CGFloat
+    ) -> Int {
+        guard cellHeight > 0 else { return 0 }
+        let topFromTop = documentHeight - visibleOriginY - visibleHeight
+        return max(0, Int((topFromTop / cellHeight).rounded()))
+    }
+}

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -63,8 +63,11 @@ private struct TerminalSurface: NSViewRepresentable {
         Coordinator()
     }
 
-    func makeNSView(context: Context) -> GhosttyTerminalNSView {
-        let view = pane.ensureNSView()
+    func makeNSView(context: Context) -> SurfaceScrollView {
+        // SwiftUI hosts the scroll view; the surface lives inside it. Both are
+        // owned by `Pane` so they survive tab switches / split reshapes.
+        let scroll = pane.ensureScrollView()
+        let view = scroll.surfaceView
         configure(view)
         // Defer surface creation until the view is actually in a window — the
         // Metal layer needs a non-zero size to initialize.
@@ -77,10 +80,11 @@ private struct TerminalSurface: NSViewRepresentable {
             }
         }
         context.coordinator.wasFocused = focused
-        return view
+        return scroll
     }
 
-    func updateNSView(_ view: GhosttyTerminalNSView, context: Context) {
+    func updateNSView(_ scroll: SurfaceScrollView, context: Context) {
+        let view = scroll.surfaceView
         configure(view)
 
         // Create the surface now if it's still pending (e.g. the view was
@@ -100,13 +104,13 @@ private struct TerminalSurface: NSViewRepresentable {
         }
     }
 
-    static func dismantleNSView(_ view: GhosttyTerminalNSView, coordinator _: Coordinator) {
-        // Intentionally empty. The NSView is owned by `Pane`; SwiftUI just
-        // borrows it. When the pane is removed from the tree, AppState calls
-        // pane.destroySurface() explicitly.
+    static func dismantleNSView(_ scroll: SurfaceScrollView, coordinator _: Coordinator) {
+        // Intentionally empty. The scroll view and its surface are owned by
+        // `Pane`; SwiftUI just borrows them. When the pane is removed from the
+        // tree, AppState calls pane.destroySurface() explicitly.
         // SwiftUI will have already removed the view from its superview by
         // the time this runs, so we don't need to do anything here.
-        _ = view
+        _ = scroll
     }
 
     private func configure(_ view: GhosttyTerminalNSView) {

--- a/MactermTests/Views/SurfaceScrollGeometryTests.swift
+++ b/MactermTests/Views/SurfaceScrollGeometryTests.swift
@@ -1,0 +1,94 @@
+import CoreGraphics
+@testable import Macterm
+import Testing
+
+/// Pure row↔pixel conversion used by `SurfaceScrollView` to bridge libghostty's
+/// row-based scrollback geometry (Y-down) and AppKit's point-based clip view
+/// (Y-up). UI behavior isn't unit-tested per the project's conventions, but
+/// this inversion is the one piece of error-prone pure logic.
+struct SurfaceScrollGeometryTests {
+    private let cell: CGFloat = 20
+
+    // MARK: - documentHeight
+
+    @Test
+    func document_height_is_total_rows_times_cell() {
+        // 100 rows of scrollback at 20pt cells.
+        #expect(SurfaceScrollView.documentHeight(total: 100, cellHeight: cell, viewportHeight: 480) == 2000)
+    }
+
+    @Test
+    func document_height_never_below_viewport() {
+        // No scrollback (total == visible rows): document can't be shorter than
+        // what's on screen, or there'd be a phantom scroll region.
+        #expect(SurfaceScrollView.documentHeight(total: 24, cellHeight: cell, viewportHeight: 600) == 600)
+    }
+
+    // MARK: - documentOffsetY (core → clip view)
+
+    @Test
+    func offset_at_bottom_is_zero() {
+        // Viewport pinned to the bottom of history: offset = total - len.
+        // total 100, len 24, offset 76 → 0 rows below → y == 0.
+        #expect(SurfaceScrollView.documentOffsetY(total: 100, offset: 76, len: 24, cellHeight: cell) == 0)
+    }
+
+    @Test
+    func offset_at_top_is_full_scrollback() {
+        // Scrolled to the very top: offset 0. Rows below = 100 - 0 - 24 = 76.
+        #expect(SurfaceScrollView.documentOffsetY(total: 100, offset: 0, len: 24, cellHeight: cell) == 76 * cell)
+    }
+
+    @Test
+    func offset_in_middle() {
+        // offset 40 → rows below = 100 - 40 - 24 = 36.
+        #expect(SurfaceScrollView.documentOffsetY(total: 100, offset: 40, len: 24, cellHeight: cell) == 36 * cell)
+    }
+
+    @Test
+    func offset_never_negative() {
+        // Degenerate geometry (len momentarily exceeds remaining rows) clamps.
+        #expect(SurfaceScrollView.documentOffsetY(total: 24, offset: 10, len: 24, cellHeight: cell) == 0)
+    }
+
+    // MARK: - rowFromOffset (clip view → core), inverse of documentOffsetY
+
+    @Test
+    func row_at_bottom_is_total_minus_len() {
+        // documentHeight 2000, visible height 480 (24 rows), clip at bottom
+        // (originY 0) → top visible row = (2000 - 0 - 480) / 20 = 76.
+        let row = SurfaceScrollView.rowFromOffset(
+            visibleOriginY: 0, visibleHeight: 480, documentHeight: 2000, cellHeight: cell
+        )
+        #expect(row == 76)
+    }
+
+    @Test
+    func row_at_top_is_zero() {
+        // Clip scrolled to the document top: originY = docHeight - visibleHeight.
+        let row = SurfaceScrollView.rowFromOffset(
+            visibleOriginY: 1520, visibleHeight: 480, documentHeight: 2000, cellHeight: cell
+        )
+        #expect(row == 0)
+    }
+
+    @Test
+    func row_round_trips_with_offset() {
+        // For a given core offset, documentOffsetY → rowFromOffset recovers it.
+        let total: UInt64 = 100, len: UInt64 = 24, offset: UInt64 = 40
+        let docHeight = SurfaceScrollView.documentHeight(total: total, cellHeight: cell, viewportHeight: CGFloat(len) * cell)
+        let y = SurfaceScrollView.documentOffsetY(total: total, offset: offset, len: len, cellHeight: cell)
+        let row = SurfaceScrollView.rowFromOffset(
+            visibleOriginY: y, visibleHeight: CGFloat(len) * cell, documentHeight: docHeight, cellHeight: cell
+        )
+        #expect(row == Int(offset))
+    }
+
+    @Test
+    func row_never_negative() {
+        let row = SurfaceScrollView.rowFromOffset(
+            visibleOriginY: 9999, visibleHeight: 480, documentHeight: 2000, cellHeight: cell
+        )
+        #expect(row == 0)
+    }
+}


### PR DESCRIPTION
## What

Adds a native macOS overlay scrollbar to terminal panes, replicating Ghostty's macOS approach (Ghostty 1.3.0+).

Before, you could scroll the scrollback with the trackpad/wheel but had no visual indicator of where you were in the buffer and no draggable scroller.

## How

Instead of a custom widget, the Metal terminal surface is nested inside a standard `NSScrollView` whose blank `documentView` is sized to the full scrollback height. AppKit then renders and hit-tests a real overlay scroller — auto-hide/fade comes for free — while the surface only ever draws the visible viewport.

```
SurfaceScrollView : NSScrollView      (overlay scroller, owned by Pane)
  └─ documentView : NSView            (blank spacer, height = total rows × cellHeight)
       └─ GhosttyTerminalNSView       (pinned to the visible rect)
```

**Data flow** (both directions go through libghostty, no custom scroll state):
- **Core → UI:** libghostty pushes `GHOSTTY_ACTION_SCROLLBAR` (`total`/`offset`/`len`, in rows) on new output, keyboard scroll, or resize → resize the spacer and reposition the clip view (with Y-inversion: terminal is top-down, AppKit bottom-up).
- **UI → Core:** dragging the scroller fires `didLiveScrollNotification` → convert the clip offset to a row → perform the `scroll_to_row:<n>` keybind action. A live-scroll flag stops core updates from fighting the drag.
- **Wheel/trackpad:** unchanged — the surface's existing `scrollWheel` still forwards to libghostty, which arbitrates scrollback vs. cursor-keys vs. mouse-report, so alt-screen apps (`vim`, `less`, `htop`) keep receiving scroll.

## Notes for reviewers

- The `SurfaceScrollView` is owned by `Pane` (like the surface `NSView`), not by SwiftUI, so it survives tab switches and split reshapes — and this sidesteps the persistence bug [ghostty-org/ghostty#9444](https://github.com/ghostty-org/ghostty/issues/9444) where Ghostty's own wrapper isn't kept across split-tree rebuilds.
- Verified `GHOSTTY_ACTION_SCROLLBAR` and the `scroll_to_row` action are both present in the bundled `GhosttyKit.xcframework`.
- The row↔pixel conversion is extracted into pure `static` functions on `SurfaceScrollView` and unit-tested in `SurfaceScrollGeometryTests.swift` (incl. a round-trip test), matching the project's "pure helpers get tests, UI doesn't" convention.
- **Not** ported: Ghostty's macOS 26.0-only `NSScrollPocket` zeroing hook (liquid-glass titlebar blur clipping the top under a hidden titlebar). Not needed on the test machine; flag if the top row ever clips on 26.0.

## Testing

- `mise run test` — full suite passes, including the new geometry tests.
- `mise run format` / `mise run lint` — clean.
- Manually verified in the running app: scrollbar appears on scroll and fades, thumb tracks output, dragging scrolls the viewport, splits/tabs persist, alt-screen apps still scroll.