### PR TITLE
fix: re-derive surface colors on libghostty soft config reload

### DIFF
--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -124,6 +124,31 @@ final class GhosttyApp {
         return result
     }
 
+    /// Re-apply the *current* config object to the app and every live surface,
+    /// without re-reading any file from disk.
+    ///
+    /// libghostty emits a soft `GHOSTTY_ACTION_RELOAD_CONFIG` whenever a
+    /// surface's conditional state changes — most importantly when we call
+    /// `ghostty_surface_set_color_scheme`, which flips the `theme =
+    /// light:X,dark:Y` split's resolved side. The surface mutates its
+    /// conditional state but defers re-deriving its colors until the apprt
+    /// hands the config back. If we ignore the action, the surface keeps
+    /// rendering the side it resolved at creation (libghostty defaults a new
+    /// surface's conditional state to `.light`), so a new dark-mode pane shows
+    /// light-side foreground until something else reloads the config. Feeding
+    /// the existing config back here re-derives the colors against the updated
+    /// conditional state. (Companion to issue #38, which fixes the same split
+    /// for Macterm's own chrome.)
+    func softReloadConfig() {
+        guard let app, let config else { return }
+        ghostty_app_update_config(app, config)
+        for view in GhosttyTerminalNSView.allLiveViews() {
+            if let surface = view.surface {
+                ghostty_surface_update_config(surface, config)
+            }
+        }
+    }
+
     /// Reload and surface any user-visible errors (missing file, parse errors)
     /// as a modal alert. Silent on success. Used by both the Settings reload
     /// button and the rebindable "Reload Ghostty config" hotkey.

--- a/Macterm/Ghostty/GhosttyCallbacks.swift
+++ b/Macterm/Ghostty/GhosttyCallbacks.swift
@@ -52,6 +52,24 @@ final class GhosttyCallbacks: @unchecked Sendable {
             let duration = action.action.command_finished.duration
             DispatchQueue.main.async { view.onCommandFinished?(exitCode, duration) }
             return true
+        case GHOSTTY_ACTION_RELOAD_CONFIG:
+            // libghostty fires this (with soft = true) when a surface's
+            // conditional state changes — notably on set_color_scheme, which
+            // re-resolves a `theme = light:X,dark:Y` split. The surface won't
+            // re-derive its colors until we hand the config back, so a soft
+            // reload re-applies the current config. A hard reload re-reads the
+            // user's config from disk. Without this, new dark-mode panes render
+            // the light-side foreground until a manual reload. See
+            // GhosttyApp.softReloadConfig.
+            let soft = action.action.reload_config.soft
+            DispatchQueue.main.async {
+                if soft {
+                    GhosttyApp.shared.softReloadConfig()
+                } else {
+                    GhosttyApp.shared.reloadConfig()
+                }
+            }
+            return true
         default:
             return false
         }


### PR DESCRIPTION
## Symptom

With a `theme = light:X,dark:Y` split and the system in dark mode, every new pane/tab rendered the terminal **background** correctly (dark) but the **foreground text** with the light theme's colors. Reloading the Ghostty config (`Cmd+Shift+,`) corrected it.

## Root cause

- libghostty defaults a **new surface's conditional state to `.light`** (`src/config/conditional.zig`: `theme: Theme = .light`), so a `light:/dark:` split resolves to the light side at surface creation.
- Macterm calls `ghostty_surface_set_color_scheme(DARK)` in `createSurface()`. That flips the surface's conditional state but does **not** re-derive colors directly — internally it calls `notifyConfigConditionalState`, which emits a **soft `GHOSTTY_ACTION_RELOAD_CONFIG`**, expecting the apprt to hand the config back so the surface re-derives.
- `GhosttyCallbacks.action` never handled `GHOSTTY_ACTION_RELOAD_CONFIG` (fell through to `default → return false`), so the re-derive never happened and the foreground stayed on the light side.
- The background still looked dark because Macterm composites it itself (`background-opacity = 0` override + the #38 `ThemeResolver` chrome path); only the libghostty-rendered foreground was stuck.
- `Cmd+Shift+,` worked because `reloadConfig()` calls `ghostty_surface_update_config` on every surface, which re-derives against the now-dark state.

This is the terminal-surface counterpart to #38, which only fixed Macterm's own chrome.

## Fix

- **`GhosttyCallbacks.swift`** — handle `GHOSTTY_ACTION_RELOAD_CONFIG`: soft reload → `softReloadConfig()`, hard reload → `reloadConfig()`. Mirrors how Ghostty's own app handles the action.
- **`GhosttyApp.swift`** — new `softReloadConfig()` re-applies the *existing* config object to the app and every live surface (no disk re-read), letting libghostty re-derive the split against the updated scheme.

## Verification

- Diagnosis confirmed against the real `ghostty.h` (action existed, was unhandled), upstream ghostty source (default conditional state `.light`; soft-reload contract), and a live repro config (`theme = light:Rose Pine Dawn,dark:Rose Pine` + dark mode).
- Release build succeeds; full test suite green; format + lint clean.

## Reviewer notes

Not exercised at runtime via screenshot (a running single-window Macterm instance made a side-by-side dev launch disruptive). The fix is a callback the app previously dropped; the soft/hard split matches Ghostty's `configReload`.