### PR TITLE
feat: liquid glass command palette

### DIFF
--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -229,25 +229,34 @@ enum HotkeyRegistry {
     }
 
     static func displayString(for shortcut: String) -> String {
+        let symbols = displaySymbols(for: shortcut)
+        return symbols.isEmpty ? "Disabled" : symbols.joined()
+    }
+
+    /// The shortcut's modifier glyphs and key label as separate elements, in
+    /// Apple order — e.g. `["⇧", "⌘", "A"]`, `["⌘", "Tab"]`. Returns `[]` for a
+    /// disabled/empty shortcut. Used to render each key as its own cap; the
+    /// joined form is `displayString`.
+    static func displaySymbols(for shortcut: String) -> [String] {
         let cleaned = shortcut.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if cleaned.isEmpty || cleaned == "disabled" || cleaned == "none" {
-            return "Disabled"
+            return []
         }
 
         let tokens = cleaned.split(separator: "+").map(String.init)
-        guard !tokens.isEmpty else { return "Disabled" }
+        guard !tokens.isEmpty else { return [] }
 
-        var out = ""
+        var symbols: [String] = []
         for token in tokens.dropLast() {
             switch token {
             case "cmd",
-                 "command": out += "⌘"
+                 "command": symbols.append("⌘")
             case "ctrl",
-                 "control": out += "⌃"
-            case "shift": out += "⇧"
+                 "control": symbols.append("⌃")
+            case "shift": symbols.append("⇧")
             case "opt",
                  "option",
-                 "alt": out += "⌥"
+                 "alt": symbols.append("⌥")
             default: break
             }
         }
@@ -265,7 +274,8 @@ enum HotkeyRegistry {
         case "down": "↓"
         default: key.uppercased()
         }
-        return out + keyLabel
+        symbols.append(keyLabel)
+        return symbols
     }
 
     static func selectedShortcutString(for action: HotkeyAction) -> String {

--- a/Macterm/Palette/CommandSource.swift
+++ b/Macterm/Palette/CommandSource.swift
@@ -15,6 +15,7 @@ struct CommandSource: PaletteSource {
                 subtitle: item.subtitle,
                 category: item.category,
                 keybind: item.keybind,
+                keybindSymbols: item.keybindSymbols,
                 score: score,
                 action: item.action
             )
@@ -56,6 +57,7 @@ struct CommandSource: PaletteSource {
             title: command.title,
             category: command.category.rawValue,
             keybind: command.hotkeyAction.flatMap(keybindDisplay),
+            keybindSymbols: command.hotkeyAction.flatMap(keybindSymbols),
             score: 0,
             action: action
         )
@@ -65,5 +67,11 @@ struct CommandSource: PaletteSource {
         let raw = HotkeyRegistry.selectedShortcutString(for: action)
         let display = HotkeyRegistry.displayString(for: raw)
         return display == "Disabled" ? nil : display
+    }
+
+    private func keybindSymbols(_ action: HotkeyAction) -> [String]? {
+        let raw = HotkeyRegistry.selectedShortcutString(for: action)
+        let symbols = HotkeyRegistry.displaySymbols(for: raw)
+        return symbols.isEmpty ? nil : symbols
     }
 }

--- a/Macterm/Palette/PaletteEngine.swift
+++ b/Macterm/Palette/PaletteEngine.swift
@@ -17,6 +17,10 @@ struct PaletteItem: Identifiable {
     let subtitle: String?
     let category: String?
     let keybind: String?
+    /// The keybind split into individual glyphs (e.g. `["⇧", "⌘", "A"]`) so the
+    /// row can render each as its own key-cap. `nil` when the item has no
+    /// keybind. Mirrors `keybind`, which keeps the joined form.
+    let keybindSymbols: [String]?
     /// Lower is better. 0 = exact prefix match, ~5 = substring, ~40 = subsequence.
     let score: Int
     let action: () -> Void
@@ -27,6 +31,7 @@ struct PaletteItem: Identifiable {
         subtitle: String? = nil,
         category: String? = nil,
         keybind: String? = nil,
+        keybindSymbols: [String]? = nil,
         score: Int = 1,
         action: @escaping () -> Void
     ) {
@@ -35,6 +40,7 @@ struct PaletteItem: Identifiable {
         self.subtitle = subtitle
         self.category = category
         self.keybind = keybind
+        self.keybindSymbols = keybindSymbols
         self.score = score
         self.action = action
     }

--- a/Macterm/Views/CommandPalette.swift
+++ b/Macterm/Views/CommandPalette.swift
@@ -10,6 +10,10 @@ struct CommandPaletteOverlay: View {
     @Environment(AppState.self)
     private var appState
 
+    /// Matches the macOS Tahoe window corner radius so the palette reads as a
+    /// native floating surface.
+    private static let cornerRadius: CGFloat = 16
+
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .top) {
@@ -22,10 +26,9 @@ struct CommandPaletteOverlay: View {
 
                 CommandPalettePanel()
                     .frame(width: 500)
-                    .background(MactermTheme.bg)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .glassEffect(in: .rect(cornerRadius: Self.cornerRadius))
                     .overlay(
-                        RoundedRectangle(cornerRadius: 12)
+                        RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
                             .strokeBorder(MactermTheme.border, lineWidth: 1)
                     )
                     .shadow(color: .black.opacity(0.35), radius: 20, x: 0, y: 8)
@@ -51,8 +54,24 @@ struct CommandPalettePanel: View {
     private var selectedIndex = 0
     @State
     private var sections: [PaletteSection] = []
+    /// Set when the last `selectedIndex` change came from mouse hover, so the
+    /// auto-scroll-to-center (keyboard nav) can skip it.
+    @State
+    private var selectionFromHover = false
+    /// Each row's vertical extent in the `rowSpace` coordinate space (relative
+    /// to the scroll viewport), keyed by flat index. Drives hover-to-select and
+    /// edge-only keyboard scrolling.
+    @State
+    private var rowFrames: [Int: ClosedRange<CGFloat>] = [:]
+    /// Height of the results scroll viewport, for deciding when a row is
+    /// off-screen and needs scrolling into view.
+    @State
+    private var viewportHeight: CGFloat = 0
     @FocusState
     private var isFieldFocused: Bool
+
+    /// Coordinate space the results scroll view and row frames share.
+    private let rowSpace = "paletteRows"
 
     /// Sources are stateless structs, so rebuilding the engine per render is fine.
     private var engine: PaletteEngine {
@@ -114,14 +133,52 @@ struct CommandPalettePanel: View {
                                 }
                                 .buttonStyle(.plain)
                                 .id(idx)
+                                // Publish each row's Y-extent so a single hover
+                                // region on the ScrollView can map the pointer to
+                                // a row. Per-row tracking areas (`.onHover` /
+                                // `.onContinuousHover`) lag on fast pointer motion;
+                                // one region with geometry mapping does not.
+                                .background(
+                                    GeometryReader { geo in
+                                        let frame = geo.frame(in: .named(rowSpace))
+                                        Color.clear.preference(
+                                            key: RowFramesKey.self,
+                                            value: [idx: frame.minY ... frame.maxY]
+                                        )
+                                    }
+                                )
                             }
                         }
                     }
                     .padding(.vertical, 4)
                 }
                 .frame(maxHeight: 340)
+                .coordinateSpace(name: rowSpace)
+                .background(
+                    GeometryReader { geo in
+                        Color.clear
+                            .onAppear { viewportHeight = geo.size.height }
+                            .onChange(of: geo.size.height) { _, h in viewportHeight = h }
+                    }
+                )
+                .onPreferenceChange(RowFramesKey.self) { rowFrames = $0 }
+                .onContinuousHover(coordinateSpace: .named(rowSpace)) { phase in
+                    guard case let .active(point) = phase,
+                          let idx = rowFrames.first(where: { $0.value.contains(point.y) })?.key,
+                          selectedIndex != idx
+                    else { return }
+                    // Mouse drives selection; suppress the keyboard-nav auto-scroll
+                    // below so the list doesn't move under the cursor.
+                    selectionFromHover = true
+                    selectedIndex = idx
+                }
                 .onChange(of: selectedIndex) { _, idx in
-                    proxy.scrollTo(idx, anchor: .center)
+                    // Only follow keyboard navigation; hovering shouldn't scroll.
+                    if selectionFromHover {
+                        selectionFromHover = false
+                    } else {
+                        scrollSelectionIntoView(idx, proxy: proxy)
+                    }
                 }
             }
         }
@@ -164,11 +221,48 @@ struct CommandPalettePanel: View {
         sections = engine.search(query)
     }
 
+    /// Leading/trailing breathing room kept between the selected row and the
+    /// viewport edge when keyboard navigation scrolls it into view.
+    private static let scrollPadding: CGFloat = 8
+
+    /// Scroll just enough to reveal `idx` when it sits within `scrollPadding` of
+    /// an edge, anchoring it that far in from whichever edge it ran toward. A
+    /// row already comfortably inside the viewport is left untouched, so keyboard
+    /// navigation nudges the list instead of re-centering on every move. Falls
+    /// back to a plain `scrollTo` until the row's geometry is known.
+    private func scrollSelectionIntoView(_ idx: Int, proxy: ScrollViewProxy) {
+        guard let range = rowFrames[idx], viewportHeight > 0 else {
+            proxy.scrollTo(idx)
+            return
+        }
+        let pad = Self.scrollPadding
+        // `scrollTo` aligns the row's anchor fraction to the same fraction of the
+        // viewport, so anchoring `pad` in from an edge leaves that gap.
+        if range.lowerBound < pad {
+            proxy.scrollTo(idx, anchor: UnitPoint(x: 0, y: pad / viewportHeight))
+        } else if range.upperBound > viewportHeight - pad {
+            proxy.scrollTo(idx, anchor: UnitPoint(x: 0, y: 1 - pad / viewportHeight))
+        }
+        // Otherwise the row is already comfortably visible — leave it alone.
+    }
+
     private func execute() {
         guard selectedIndex >= 0, selectedIndex < flatItems.count else { return }
         let item = flatItems[selectedIndex]
         appState.isCommandPaletteVisible = false
         item.action()
+    }
+}
+
+// MARK: - Hover geometry
+
+/// Collects each result row's vertical extent (keyed by flat index) so a single
+/// hover region can map the pointer to a row, avoiding per-row tracking areas
+/// that lag on fast pointer motion.
+private struct RowFramesKey: PreferenceKey {
+    static let defaultValue: [Int: ClosedRange<CGFloat>] = [:]
+    static func reduce(value: inout [Int: ClosedRange<CGFloat>], nextValue: () -> [Int: ClosedRange<CGFloat>]) {
+        value.merge(nextValue()) { _, new in new }
     }
 }
 
@@ -192,16 +286,48 @@ private struct CommandPaletteRow: View {
                 }
             }
             Spacer()
-            if let keybind = item.keybind {
-                Text(keybind)
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundStyle(MactermTheme.fgDim)
-            }
+            keybindView
         }
         .padding(.horizontal, 14)
-        .padding(.vertical, 6)
-        .background(isSelected ? MactermTheme.surface : .clear)
+        .padding(.vertical, 8)
+        .background(isSelected ? MactermTheme.fg.opacity(0.12) : .clear)
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .padding(.horizontal, 6)
+    }
+
+    @ViewBuilder
+    private var keybindView: some View {
+        if let symbols = item.keybindSymbols {
+            HStack(spacing: 4) {
+                ForEach(Array(symbols.enumerated()), id: \.offset) { _, sym in
+                    KeyCap(symbol: sym)
+                }
+            }
+        } else if let keybind = item.keybind {
+            // Defensive fallback: an item with a joined keybind but no split
+            // symbols (command items always supply symbols).
+            Text(keybind)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(MactermTheme.fgDim)
+        }
+    }
+}
+
+/// A single rounded key-cap, e.g. `⌘` or `Tab`, rendered Raycast-style.
+private struct KeyCap: View {
+    let symbol: String
+
+    var body: some View {
+        Text(symbol)
+            .font(.system(size: 11, weight: .medium, design: .rounded))
+            .foregroundStyle(MactermTheme.fgMuted)
+            .frame(minWidth: 16)
+            .padding(.vertical, 2)
+            .padding(.horizontal, 4)
+            .background(MactermTheme.surface, in: .rect(cornerRadius: 5))
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .strokeBorder(MactermTheme.border, lineWidth: 1)
+            )
     }
 }

--- a/MactermTests/App/HotkeysTests.swift
+++ b/MactermTests/App/HotkeysTests.swift
@@ -92,6 +92,30 @@ struct HotkeysTests {
         #expect(HotkeyRegistry.displayString(for: "disabled") == "Disabled")
     }
 
+    // MARK: - displaySymbols
+
+    @Test
+    func displaySymbols_splits_modifiers_and_key() {
+        // Glyphs follow the order tokens appear in the shortcut string, matching
+        // displayString (which joins these same symbols).
+        #expect(HotkeyRegistry.displaySymbols(for: "cmd+shift+a") == ["⌘", "⇧", "A"])
+        #expect(HotkeyRegistry.displaySymbols(for: "cmd+ctrl+shift+opt+k") == ["⌘", "⌃", "⇧", "⌥", "K"])
+    }
+
+    @Test
+    func displaySymbols_keeps_multichar_key_labels_whole() {
+        #expect(HotkeyRegistry.displaySymbols(for: "cmd+tab") == ["⌘", "Tab"])
+        #expect(HotkeyRegistry.displaySymbols(for: "cmd+space") == ["⌘", "Space"])
+        #expect(HotkeyRegistry.displaySymbols(for: "cmd+escape") == ["⌘", "Esc"])
+    }
+
+    @Test
+    func displaySymbols_empty_or_disabled() {
+        #expect(HotkeyRegistry.displaySymbols(for: "").isEmpty)
+        #expect(HotkeyRegistry.displaySymbols(for: "none").isEmpty)
+        #expect(HotkeyRegistry.displaySymbols(for: "disabled").isEmpty)
+    }
+
     // MARK: - isValidShortcutString
 
     @Test


### PR DESCRIPTION
## What

Reworks the command palette (`Cmd+P` / `Cmd+Shift+P`) into a translucent Liquid Glass panel and brings its interactions closer to a native fuzzy launcher (Raycast-style).

- **Liquid Glass panel** — the palette now renders with `.glassEffect` over the terminal content instead of a solid `MactermTheme.bg` fill, so it refracts what's beneath it. Corner radius bumped to 16pt (continuous) to match the macOS Tahoe window chrome.
- **Key-cap chips** — keyboard shortcuts render as individual rounded key-caps (e.g. `⇧` `⌘` `A` in separate boxes) instead of one concatenated glyph string. Adds `HotkeyRegistry.displaySymbols(for:) -> [String]` (sibling to `displayString`, sharing the same glyph/key mapping) and a `keybindSymbols` field on `PaletteItem`, populated by `CommandSource`. No per-row icons.
- **Hover-to-select** — moving the mouse over a row now moves the selection. Implemented with a single hover region over the results list that maps the pointer's Y to the row under it (via row-frame preferences), because per-row tracking areas (`.onHover` / `.onContinuousHover`) lagged badly on fast pointer motion.
- **Edge-only keyboard scroll** — arrow / `Ctrl+N` / `Ctrl+P` navigation now scrolls the selection into view only when it runs toward an edge, with an 8pt margin, instead of re-centering the list on every move.

## Why

The rest of the app already leans on Tahoe's liquid-glass appearance (the native sidebar, window chrome), so the flat opaque palette looked out of place. This makes it feel native and more polished.

## Notes for reviewers

- `displayString`'s existing contract is unchanged (Settings and the menu in `MainWindow.swift` still get the joined string); it now just joins `displaySymbols`.
- Added `displaySymbols` test cases to `HotkeysTests.swift` mirroring the existing `displayString` tests. Palette row UI itself stays untested per the project's conventions (UI/AppKit surfaces are excluded from unit tests).
- Colors remain sourced from `MactermTheme`; the only new "material" is the system glass.

## Testing

`mise run format`, `mise run lint`, and `mise run test` all pass.