### PR TITLE
Liquid glass window background (regular/clear) + full opacity range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ A floating `NSPanel` that reuses the same `TerminalTab` / `SplitNode` / `Pane` m
 | File                                   | Purpose                                                                                                          |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `MainWindow.swift`                     | Main window layout, `WorkspaceView`, `WindowStyler`                                                              |
-| `WindowAppearance.swift`               | Window opacity/blur — sets `NSWindow.backgroundColor`, dives into private titlebar view tree, calls CGS blur SPI |
+| `WindowAppearance.swift`               | Window opacity/blur/liquid glass — sets `NSWindow.backgroundColor`, dives into private titlebar view tree, calls CGS blur SPI, or installs a macOS 26 `NSGlassEffectView` (`MactermGlassView`) below the content view |
 | `Sidebar.swift`                        | Project/tab list with native `List(selection:)`                                                                  |
 | `SplitTreeView.swift`                  | Recursive split rendering with draggable dividers                                                                |
 | `TerminalPane.swift`                   | `TerminalPane` + `TerminalSurface` (`NSViewRepresentable` borrowing `pane.nsView`) + search bar overlay          |

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -19,6 +19,22 @@ enum TabSwitcherVisibility: String, CaseIterable, Identifiable {
     }
 }
 
+/// Which `NSGlassEffectView.Style` the liquid-glass window background uses.
+/// Maps to AppKit's `.regular` / `.clear` (see `WindowAppearance`).
+enum WindowGlassStyle: String, CaseIterable, Identifiable {
+    case regular
+    case clear
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .regular: "Regular"
+        case .clear: "Clear"
+        }
+    }
+}
+
 /// Single observable source of truth for UserDefaults-backed preferences.
 ///
 /// Macterm only stores app-shaped state here (window opacity/blur, quick
@@ -129,6 +145,29 @@ final class Preferences {
         }
     }
 
+    /// Use the macOS 26 liquid-glass material (`NSGlassEffectView`) for the
+    /// translucent window background instead of the legacy CGS Gaussian blur.
+    /// Only has any effect when `windowOpacity < 1` — at full opacity the
+    /// window is solid and neither blur nor glass is visible. When enabled the
+    /// `windowBlurRadius` slider is ignored; the glass material defines its own
+    /// look.
+    var windowGlassEnabled: Bool {
+        didSet {
+            defaults.set(windowGlassEnabled, forKey: Keys.windowGlassEnabled)
+            notifyConfigChanged()
+        }
+    }
+
+    /// Which liquid-glass material to use when `windowGlassEnabled` is on.
+    /// `.regular` is frostier/more tinted; `.clear` is more transparent. No
+    /// effect unless glass is enabled.
+    var windowGlassStyle: WindowGlassStyle {
+        didSet {
+            defaults.set(windowGlassStyle.rawValue, forKey: Keys.windowGlassStyle)
+            notifyConfigChanged()
+        }
+    }
+
     // MARK: - Ghostty config
 
     /// Path to the user's Ghostty config. Empty string = don't load any user
@@ -191,6 +230,9 @@ final class Preferences {
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
         windowOpacity = (defaults.object(forKey: Keys.windowOpacity) as? Double) ?? 1.0
         windowBlurRadius = defaults.integer(forKey: Keys.windowBlurRadius)
+        windowGlassEnabled = defaults.object(forKey: Keys.windowGlassEnabled) as? Bool ?? false
+        windowGlassStyle = (defaults.string(forKey: Keys.windowGlassStyle))
+            .flatMap(WindowGlassStyle.init(rawValue:)) ?? .regular
         userGhosttyConfigPath = defaults.string(forKey: Keys.userGhosttyConfigPath) ?? "~/.config/ghostty/config"
         quickTerminalEnabled = defaults.object(forKey: Keys.quickTerminalEnabled) as? Bool ?? true
         quickTerminalWidthFraction = Self.clampFraction(defaults.double(forKey: Keys.quickTerminalWidth), fallback: 0.6)
@@ -236,6 +278,8 @@ final class Preferences {
         static let autoTiling = "macterm.autoTiling.enabled"
         static let windowOpacity = "macterm.window.opacity"
         static let windowBlurRadius = "macterm.window.blurRadius"
+        static let windowGlassEnabled = "macterm.window.glassEnabled"
+        static let windowGlassStyle = "macterm.window.glassStyle"
         static let userGhosttyConfigPath = "macterm.ghostty.userConfigPath"
         static let quickTerminalEnabled = "macterm.quickTerminal.enabled"
         static let quickTerminalWidth = "macterm.quickTerminal.width"

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -151,13 +151,17 @@ private struct AppearanceSettings: View {
     private var backgroundOpacity: Double = Preferences.shared.windowOpacity
     @State
     private var backgroundBlurRadius: Double = .init(Preferences.shared.windowBlurRadius)
+    @State
+    private var liquidGlass: Bool = Preferences.shared.windowGlassEnabled
+    @State
+    private var liquidGlassStyle: WindowGlassStyle = Preferences.shared.windowGlassStyle
 
     var body: some View {
         Form {
             Section("Window") {
                 HStack {
                     Text("Background Opacity")
-                    Slider(value: $backgroundOpacity, in: 0.3 ... 1.0)
+                    Slider(value: $backgroundOpacity, in: 0.0 ... 1.0)
                     Text("\(Int((backgroundOpacity * 100).rounded()))%")
                         .monospacedDigit()
                         .frame(width: 42, alignment: .trailing)
@@ -165,6 +169,22 @@ private struct AppearanceSettings: View {
                 .onChange(of: backgroundOpacity) { _, v in
                     Preferences.shared.windowOpacity = v
                 }
+
+                Toggle("Liquid Glass", isOn: $liquidGlass)
+                    .onChange(of: liquidGlass) { _, v in
+                        Preferences.shared.windowGlassEnabled = v
+                    }
+                    .disabled(backgroundOpacity >= 0.999)
+
+                Picker("Glass Style", selection: $liquidGlassStyle) {
+                    ForEach(WindowGlassStyle.allCases) { style in
+                        Text(style.displayName).tag(style)
+                    }
+                }
+                .onChange(of: liquidGlassStyle) { _, v in
+                    Preferences.shared.windowGlassStyle = v
+                }
+                .disabled(backgroundOpacity >= 0.999 || !liquidGlass)
 
                 HStack {
                     Text("Background Blur")
@@ -176,9 +196,9 @@ private struct AppearanceSettings: View {
                 .onChange(of: backgroundBlurRadius) { _, v in
                     Preferences.shared.windowBlurRadius = Int(v.rounded())
                 }
-                .disabled(backgroundOpacity >= 0.999)
+                .disabled(backgroundOpacity >= 0.999 || liquidGlass)
 
-                Text("Blur only takes effect when opacity is below 100%. Set to 0 to disable.")
+                Text(blurFootnote)
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }
@@ -220,6 +240,16 @@ private struct AppearanceSettings: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    private var blurFootnote: String {
+        if backgroundOpacity >= 0.999 {
+            return "Blur and Liquid Glass only take effect when opacity is below 100%."
+        }
+        if liquidGlass {
+            return "Liquid Glass uses the macOS material (blur slider ignored). Regular is frostier; Clear is more transparent."
+        }
+        return "Set blur to 0 to disable."
     }
 
     @ViewBuilder

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -308,6 +308,20 @@ private struct WindowStyler: NSViewRepresentable {
             swiftuiDelegate?.windowDidBecomeMain?(notification)
         }
 
+        func windowDidBecomeKey(_ notification: Notification) {
+            if let window = notification.object as? NSWindow {
+                WindowAppearance.syncKeyStatus(window: window)
+            }
+            swiftuiDelegate?.windowDidBecomeKey?(notification)
+        }
+
+        func windowDidResignKey(_ notification: Notification) {
+            if let window = notification.object as? NSWindow {
+                WindowAppearance.syncKeyStatus(window: window)
+            }
+            swiftuiDelegate?.windowDidResignKey?(notification)
+        }
+
         func windowDidEnterFullScreen(_ notification: Notification) {
             guard let window = notification.object as? NSWindow else { return }
             WindowAppearance.sync(window: window)

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -84,6 +84,12 @@ final class MactermGlassView: NSView {
     private let tintOverlay = NSView()
     private var topConstraint: NSLayoutConstraint!
 
+    /// The window opacity the glass is currently configured for. The inactive
+    /// tint is scaled by this so an unfocused window never reads as more opaque
+    /// than the user asked for — at 30% opacity the desaturation overlay is far
+    /// subtler than at 100%.
+    private var backgroundOpacity: CGFloat = 1
+
     init(topOffset: CGFloat) {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
@@ -127,6 +133,7 @@ final class MactermGlassView: NSView {
         glassEffectView.style = style
         glassEffectView.tintColor = backgroundColor.withAlphaComponent(backgroundOpacity)
         glassEffectView.cornerRadius = cornerRadius ?? 0
+        self.backgroundOpacity = CGFloat(backgroundOpacity)
         updateKeyStatus(isKeyWindow, backgroundColor: backgroundColor)
     }
 
@@ -137,7 +144,10 @@ final class MactermGlassView: NSView {
     func updateKeyStatus(_ isKeyWindow: Bool, backgroundColor: NSColor) {
         let tint = tintProperties(for: backgroundColor)
         tintOverlay.layer?.backgroundColor = tint.color.cgColor
-        tintOverlay.alphaValue = isKeyWindow ? 0 : tint.opacity
+        // Scale by the window opacity so the inactive tint stays within the
+        // translucency the user chose — otherwise an unfocused window reads as
+        // near-opaque regardless of the opacity slider.
+        tintOverlay.alphaValue = isKeyWindow ? 0 : tint.opacity * backgroundOpacity
     }
 
     /// A saturation-boosted tint + opacity for the inactive overlay, lifted

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 
 extension NSView {
     /// Recursively finds the first descendant view whose class name (as a string)
@@ -15,6 +16,29 @@ extension NSView {
             }
         }
         return nil
+    }
+}
+
+// MARK: - Color helpers (for the inactive-glass tint)
+
+extension NSColor {
+    /// Perceptual luminance in 0...1, computed in sRGB. Returns 0 for colors
+    /// that can't be converted to an RGB space (e.g. pattern colors).
+    var luminance: CGFloat {
+        guard let rgb = usingColorSpace(.sRGB) else { return 0 }
+        return 0.2126 * rgb.redComponent + 0.7152 * rgb.greenComponent + 0.0722 * rgb.blueComponent
+    }
+
+    var isLightColor: Bool { luminance > 0.5 }
+
+    /// Returns a copy with its HSB saturation multiplied by `factor` (clamped
+    /// to 0...1). Used to make the inactive-window overlay read as a desaturated
+    /// version of the terminal background, matching Ghostty.
+    func adjustingSaturation(by factor: CGFloat) -> NSColor {
+        guard let hsb = usingColorSpace(.sRGB) else { return self }
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        hsb.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        return NSColor(hue: h, saturation: min(max(s * factor, 0), 1), brightness: b, alpha: a)
     }
 }
 
@@ -43,6 +67,87 @@ private let cgsSetBlurFnPtr: @convention(c) (Int32, Int, Int32) -> Int32 = {
 @MainActor
 func setWindowBackgroundBlur(_ window: NSWindow, radius: Int) {
     _ = cgsSetBlurFnPtr(cgsConnectionFnPtr(), window.windowNumber, Int32(radius))
+}
+
+// MARK: - Liquid glass background
+
+/// A container that hosts a macOS 26 `NSGlassEffectView` (the real liquid
+/// glass material) plus an inactive-window tint overlay. Mirrors Ghostty's
+/// `TerminalGlassView` (`TerminalViewContainer.swift`). Macterm inserts this
+/// below the window's content view, filling the whole window — including the
+/// region under the titlebar (via a negative top inset equal to the content
+/// view's top safe-area inset) — so the glass reads as one continuous surface
+/// behind the sidebar, titlebar, and terminal.
+@available(macOS 26.0, *)
+final class MactermGlassView: NSView {
+    private let glassEffectView = NSGlassEffectView()
+    private let tintOverlay = NSView()
+    private var topConstraint: NSLayoutConstraint!
+
+    init(topOffset: CGFloat) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        glassEffectView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(glassEffectView)
+        topConstraint = glassEffectView.topAnchor.constraint(equalTo: topAnchor, constant: topOffset)
+        NSLayoutConstraint.activate([
+            topConstraint,
+            glassEffectView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            glassEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            glassEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+
+        // The inactive tint sits above the glass and fades in when the window
+        // resigns key, matching how the system desaturates inactive glass.
+        tintOverlay.translatesAutoresizingMaskIntoConstraints = false
+        tintOverlay.wantsLayer = true
+        tintOverlay.alphaValue = 0
+        addSubview(tintOverlay, positioned: .above, relativeTo: glassEffectView)
+        NSLayoutConstraint.activate([
+            tintOverlay.topAnchor.constraint(equalTo: glassEffectView.topAnchor),
+            tintOverlay.leadingAnchor.constraint(equalTo: glassEffectView.leadingAnchor),
+            tintOverlay.bottomAnchor.constraint(equalTo: glassEffectView.bottomAnchor),
+            tintOverlay.trailingAnchor.constraint(equalTo: glassEffectView.trailingAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        style: NSGlassEffectView.Style,
+        backgroundColor: NSColor,
+        backgroundOpacity: Double,
+        cornerRadius: CGFloat?,
+        isKeyWindow: Bool
+    ) {
+        glassEffectView.style = style
+        glassEffectView.tintColor = backgroundColor.withAlphaComponent(backgroundOpacity)
+        glassEffectView.cornerRadius = cornerRadius ?? 0
+        updateKeyStatus(isKeyWindow, backgroundColor: backgroundColor)
+    }
+
+    func updateTopInset(_ offset: CGFloat) {
+        topConstraint.constant = offset
+    }
+
+    func updateKeyStatus(_ isKeyWindow: Bool, backgroundColor: NSColor) {
+        let tint = tintProperties(for: backgroundColor)
+        tintOverlay.layer?.backgroundColor = tint.color.cgColor
+        tintOverlay.alphaValue = isKeyWindow ? 0 : tint.opacity
+    }
+
+    /// A saturation-boosted tint + opacity for the inactive overlay, lifted
+    /// from Ghostty's `tintProperties`.
+    private func tintProperties(for color: NSColor) -> (color: NSColor, opacity: CGFloat) {
+        let isLight = color.isLightColor
+        let vibrant = color.adjustingSaturation(by: 1.2)
+        let overlayOpacity: CGFloat = isLight ? 0.35 : 0.85
+        return (vibrant, overlayOpacity)
+    }
 }
 
 // MARK: - Window styling
@@ -75,21 +180,37 @@ enum WindowAppearance {
         let forceOpaque = window.styleMask.contains(.fullScreen)
         let effectiveTransparent = isTransparent && !forceOpaque
 
+        // Liquid glass replaces the CGS blur when enabled. It only makes sense
+        // while the window is translucent; at full opacity there's nothing to
+        // see behind, so we fall back to the plain solid-background path.
+        let useGlass = glassSupported && Preferences.shared.windowGlassEnabled && effectiveTransparent
+
         if effectiveTransparent {
             window.isOpaque = false
-            // The window's backgroundColor is the *only* tinted layer.
-            // Ghostty renders fully transparent, the detail ZStack and
-            // sidebar paint nothing, so the whole interior — including the
-            // strip around the system glass sidebar — reads as one
-            // continuous translucent surface backed by this color.
-            window.backgroundColor = bg.withAlphaComponent(opacity)
-            // Apply blur unconditionally; passing 0 clears any previous blur.
-            setWindowBackgroundBlur(window, radius: blurRadius)
+            if useGlass {
+                // The NSGlassEffectView is the tinted layer. Keep the window
+                // background itself clear so we don't double-tint over the
+                // glass material.
+                window.backgroundColor = .clear
+                setWindowBackgroundBlur(window, radius: 0)
+                syncGlass(window: window, backgroundColor: bg, opacity: opacity)
+            } else {
+                // The window's backgroundColor is the *only* tinted layer.
+                // Ghostty renders fully transparent, the detail ZStack and
+                // sidebar paint nothing, so the whole interior — including the
+                // strip around the system glass sidebar — reads as one
+                // continuous translucent surface backed by this color.
+                window.backgroundColor = bg.withAlphaComponent(opacity)
+                // Apply blur unconditionally; passing 0 clears any previous blur.
+                setWindowBackgroundBlur(window, radius: blurRadius)
+                removeGlass(window: window)
+            }
         } else {
             window.isOpaque = true
             window.backgroundColor = bg
             // Make sure a previous blur is cleared when going opaque.
             setWindowBackgroundBlur(window, radius: 0)
+            removeGlass(window: window)
         }
 
         // Override the titlebar's private background layer so its color
@@ -97,6 +218,83 @@ enum WindowAppearance {
         // window is). Without this the titlebar paints its own material
         // and you get a visible seam at y=titlebarHeight.
         syncTitlebar(window: window, isTransparent: effectiveTransparent)
+    }
+
+    /// Update the inactive-glass tint when the window gains/loses key status.
+    /// Cheap no-op unless the glass view is currently installed.
+    static func syncKeyStatus(window: NSWindow) {
+        guard glassSupported else { return }
+        if #available(macOS 26.0, *) {
+            guard let glass = existingGlass(in: window) else { return }
+            glass.updateKeyStatus(window.isKeyWindow, backgroundColor: GhosttyApp.shared.backgroundColor)
+        }
+    }
+
+    private static var glassSupported: Bool {
+        if #available(macOS 26.0, *) { return true }
+        return false
+    }
+
+    // MARK: Liquid glass
+
+    /// Install (if needed) and configure the liquid-glass background view so it
+    /// fills the window behind SwiftUI's content, including the area under the
+    /// titlebar. Follows Ghostty's `updateGlassEffectIfNeeded` pattern.
+    private static func syncGlass(window: NSWindow, backgroundColor: NSColor, opacity: Double) {
+        guard #available(macOS 26.0, *) else { return }
+        guard let contentView = window.contentView, let themeFrame = contentView.superview else { return }
+
+        let glass = existingGlass(in: window) ?? {
+            let view = MactermGlassView(topOffset: -contentView.safeAreaInsets.top)
+            // Below the content view so SwiftUI (sidebar, terminal, toolbar)
+            // composites on top of the glass.
+            themeFrame.addSubview(view, positioned: .below, relativeTo: contentView)
+            NSLayoutConstraint.activate([
+                view.topAnchor.constraint(equalTo: themeFrame.topAnchor),
+                view.leadingAnchor.constraint(equalTo: themeFrame.leadingAnchor),
+                view.bottomAnchor.constraint(equalTo: themeFrame.bottomAnchor),
+                view.trailingAnchor.constraint(equalTo: themeFrame.trailingAnchor),
+            ])
+            return view
+        }()
+
+        glass.updateTopInset(-contentView.safeAreaInsets.top)
+        glass.configure(
+            style: officialGlassStyle(Preferences.shared.windowGlassStyle),
+            backgroundColor: backgroundColor,
+            backgroundOpacity: opacity,
+            cornerRadius: windowCornerRadius(window),
+            isKeyWindow: window.isKeyWindow
+        )
+    }
+
+    @available(macOS 26.0, *)
+    private static func officialGlassStyle(_ style: WindowGlassStyle) -> NSGlassEffectView.Style {
+        switch style {
+        case .regular: .regular
+        case .clear: .clear
+        }
+    }
+
+    private static func removeGlass(window: NSWindow) {
+        guard glassSupported else { return }
+        if #available(macOS 26.0, *) {
+            existingGlass(in: window)?.removeFromSuperview()
+        }
+    }
+
+    @available(macOS 26.0, *)
+    private static func existingGlass(in window: NSWindow) -> MactermGlassView? {
+        guard let themeFrame = window.contentView?.superview else { return nil }
+        return themeFrame.subviews.compactMap { $0 as? MactermGlassView }.first
+    }
+
+    /// The window's private corner radius, so the glass clips to the same
+    /// rounded corners as the window. Falls back to nil (square) if the SPI
+    /// is unavailable.
+    private static func windowCornerRadius(_ window: NSWindow) -> CGFloat? {
+        guard window.responds(to: Selector(("_cornerRadius"))) else { return nil }
+        return window.value(forKey: "_cornerRadius") as? CGFloat
     }
 
     private static func syncTitlebar(window: NSWindow, isTransparent: Bool) {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ https://github.com/user-attachments/assets/42b2dce8-1d6d-41d6-a4c8-2e0c1339810b
 
 ### Window Opacity & Blur
 
-Macterm's window appearance is highly customizable and hot-reloaded.
+Macterm's window appearance is highly customizable and hot-reloaded. Drop the
+opacity below 100% and choose between a classic Gaussian **Background Blur** or
+the macOS 26 **Liquid Glass** material — in two styles, frostier **Regular** or
+more transparent **Clear** — all in **Settings → General → Window**.
 
 https://github.com/user-attachments/assets/1486ed55-e653-43ce-98aa-232a61d234a7
 


### PR DESCRIPTION
## What

Adds a **Liquid Glass** option for the translucent window background — the real macOS 26 `NSGlassEffectView` material — as an alternative to the existing CGS Gaussian blur, in two styles:

- **Regular** — frostier, more tinted (default)
- **Clear** — more transparent, glassier

Both are selectable in **Settings → General → Window**, alongside a new **Glass Style** picker that appears when Liquid Glass is on.

Also widens the **Background Opacity** slider to the full **0–100%** range (was floored at 30%).

## Why

The window previously only supported a legacy Gaussian blur ("frosted glass"), not the macOS 26 liquid glass material. This follows Ghostty's own implementation pattern so the look matches a native Tahoe terminal.

The 30% opacity floor was only the slider's range — nothing in `Preferences` or `WindowAppearance` actually clamped the value — so the cap was arbitrary and is now lifted.

## How

Mirrors Ghostty's `TerminalGlassView` (`TerminalViewContainer.swift`):

- New `MactermGlassView` wraps an `NSGlassEffectView` plus an inactive-window desaturation overlay.
- `WindowAppearance.sync` branches: when the window is translucent **and** glass is enabled (macOS 26+), it installs the glass view *below* the SwiftUI content view, filling the window including the region under the titlebar (negative top inset = `-safeAreaInsets.top`), tinted with the terminal background at the configured opacity and clipped to the window's `_cornerRadius`. Otherwise it falls back to the existing CGS blur path and tears the glass view down.
- `windowDidBecomeKey`/`windowDidResignKey` hooks fade the inactive tint in/out with focus.
- Two new prefs: `windowGlassEnabled` (Bool) and `windowGlassStyle` (`WindowGlassStyle` enum). Toggling either triggers a live resync via the existing `.mactermConfigDidChange` path.

## Notes for reviewers

- Gated to macOS 26+ (`NSGlassEffectView` is 26-only), which matches the project's minimum target — the `#available` fallback branches are effectively dead but kept for safety.
- The blur slider is disabled while glass is on (the material defines its own look); the glass style picker is disabled when glass is off or opacity is 100%.
- At 0% opacity the window interior renders fully transparent (chrome + terminal text over the desktop), the expected meaning of a 0% setting.

## Verification

- `mise run format`, `mise run lint`, `mise run test` all pass; debug build succeeds.
- Ran the app at 80% opacity and confirmed both glass styles render and switch live — Regular is visibly frostier, Clear shows the background through more crisply. No crash from the glass/SPI path.