### PR TITLE
fix: show an icon for the plain Number choice in the icon picker

### DIFF
--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -236,7 +236,7 @@ private struct AppearanceSettings: View {
         case Preferences.numberIconSquare:
             Label("Number — square", systemImage: "1.square")
         case Preferences.numberIconPlain:
-            Text("Number")
+            Label("Number", systemImage: "number")
         default:
             Label(name, systemImage: name)
         }


### PR DESCRIPTION
## What

In the project/tab icon picker (Settings → General), the plain **Number** choice rendered without a leading icon while every other visible option had one.

## Why

`iconPickerLabel(_:)` in `SettingsView.swift` emitted a bare `Text("Number")` for the `numberIconPlain` case, whereas all other visible cases use `Label(..., systemImage:)` — and it's the `Label`'s `systemImage` that produces the leading SF Symbol.

## Fix

Give the plain Number entry the `number` (`#`) SF Symbol via a `Label`, matching the rest of the menu:

```swift
case Preferences.numberIconPlain:
    Label("Number", systemImage: "number")
```

## Notes for reviewers

- Used `number` rather than a literal `1` because there's no bare `1` SF Symbol (the digit symbols only exist in containers like `1.circle`/`1.square`). Keeping it a native `Label(systemImage:)` avoids hand-building an icon layout.
- The "None" entry still intentionally uses bare `Text` — there's no icon for "no icon".
- `mise run lint` passes.