### PR TITLE
Show keybind conflicts and use 'None' for unmapped shortcuts

### DIFF
--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -230,7 +230,7 @@ enum HotkeyRegistry {
 
     static func displayString(for shortcut: String) -> String {
         let symbols = displaySymbols(for: shortcut)
-        return symbols.isEmpty ? "Disabled" : symbols.joined()
+        return symbols.isEmpty ? "None" : symbols.joined()
     }
 
     /// The shortcut's modifier glyphs and key label as separate elements, in
@@ -301,5 +301,29 @@ enum HotkeyRegistry {
     static func matches(_ event: NSEvent, action: HotkeyAction) -> Bool {
         guard let shortcut = selectedShortcut(for: action), shortcut.id != "none" else { return false }
         return shortcut.matches(event)
+    }
+
+    /// Canonical identity for a parsed shortcut — key token plus sorted
+    /// modifier flags — so `cmd+shift+d` and `shift+cmd+d` compare equal.
+    /// Returns `nil` for unparseable/disabled shortcuts (which never conflict).
+    static func conflictKey(for shortcut: String) -> String? {
+        guard let parsed = parseShortcut(shortcut) else { return nil }
+        return "\(parsed.modifiers.rawValue):\(parsed.keyToken)"
+    }
+
+    /// Given the current shortcut string for each action, returns the set of
+    /// action IDs that share a binding with at least one other action.
+    /// Disabled/invalid bindings never conflict.
+    static func conflictingActionIDs(in shortcuts: [String: String]) -> Set<String> {
+        var idsByKey: [String: [String]] = [:]
+        for (actionID, shortcut) in shortcuts {
+            guard let key = conflictKey(for: shortcut) else { continue }
+            idsByKey[key, default: []].append(actionID)
+        }
+        var conflicting: Set<String> = []
+        for (_, ids) in idsByKey where ids.count > 1 {
+            conflicting.formUnion(ids)
+        }
+        return conflicting
     }
 }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -337,41 +337,70 @@ private struct KeymapSettings: View {
     @State
     private var invalidActions: Set<String> = []
 
+    /// Action IDs whose current binding collides with another action's.
+    private var conflictingActions: Set<String> {
+        HotkeyRegistry.conflictingActionIDs(in: values)
+    }
+
+    /// Titles of the *other* actions that share `action`'s binding, for the
+    /// inline conflict message.
+    private func conflictPartners(for action: HotkeyAction) -> [String] {
+        guard let key = HotkeyRegistry.conflictKey(for: values[action.id] ?? "disabled") else {
+            return []
+        }
+        return HotkeyAction.allCases
+            .filter { $0.id != action.id && HotkeyRegistry.conflictKey(for: values[$0.id] ?? "disabled") == key }
+            .map(\.title)
+    }
+
     var body: some View {
         Form {
             Section("Keyboard Shortcuts") {
                 ForEach(HotkeyAction.allCases) { action in
-                    HStack {
-                        Text(action.title)
-                        Spacer()
-                        Button {
-                            HotkeyCaptureState.shared.isCapturing = true
-                            capturingActionID = action.id
-                        } label: {
-                            Text(
-                                capturingActionID == action.id
-                                    ? "Press keys..."
-                                    : HotkeyRegistry
-                                    .displayString(for: values[action.id] ?? "disabled")
-                            )
-                            .font(.system(size: 12, design: .monospaced))
-                            .frame(width: 140, alignment: .leading)
-                        }
-                        .buttonStyle(.bordered)
+                    let partners = conflictPartners(for: action)
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(action.title)
+                            Spacer()
+                            Button {
+                                HotkeyCaptureState.shared.isCapturing = true
+                                capturingActionID = action.id
+                            } label: {
+                                let isCapturing = capturingActionID == action.id
+                                let isUnmapped = HotkeyRegistry
+                                    .displaySymbols(for: values[action.id] ?? "disabled").isEmpty
+                                Text(
+                                    isCapturing
+                                        ? "Press keys..."
+                                        : HotkeyRegistry
+                                        .displayString(for: values[action.id] ?? "disabled")
+                                )
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundStyle((isUnmapped && !isCapturing) ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary))
+                                .frame(width: 140, alignment: .leading)
+                            }
+                            .buttonStyle(.bordered)
 
-                        Button("Clear") {
-                            values[action.id] = "disabled"
-                            HotkeyRegistry.setShortcutString("disabled", for: action)
-                            invalidActions.remove(action.id)
-                            if capturingActionID == action.id {
-                                capturingActionID = nil
-                                HotkeyCaptureState.shared.isCapturing = false
+                            Button("Clear") {
+                                values[action.id] = "disabled"
+                                HotkeyRegistry.setShortcutString("disabled", for: action)
+                                invalidActions.remove(action.id)
+                                if capturingActionID == action.id {
+                                    capturingActionID = nil
+                                    HotkeyCaptureState.shared.isCapturing = false
+                                }
+                            }
+                            .buttonStyle(.borderless)
+
+                            if invalidActions.contains(action.id) || !partners.isEmpty {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(.yellow)
                             }
                         }
-                        .buttonStyle(.borderless)
 
-                        if invalidActions.contains(action.id) {
-                            Image(systemName: "exclamationmark.triangle.fill")
+                        if !partners.isEmpty {
+                            Text("Conflicts with \(partners.joined(separator: ", "))")
+                                .font(.system(size: 11))
                                 .foregroundStyle(.yellow)
                         }
                     }

--- a/MactermTests/App/HotkeysTests.swift
+++ b/MactermTests/App/HotkeysTests.swift
@@ -87,9 +87,9 @@ struct HotkeysTests {
 
     @Test
     func displayString_empty_or_disabled() {
-        #expect(HotkeyRegistry.displayString(for: "") == "Disabled")
-        #expect(HotkeyRegistry.displayString(for: "none") == "Disabled")
-        #expect(HotkeyRegistry.displayString(for: "disabled") == "Disabled")
+        #expect(HotkeyRegistry.displayString(for: "") == "None")
+        #expect(HotkeyRegistry.displayString(for: "none") == "None")
+        #expect(HotkeyRegistry.displayString(for: "disabled") == "None")
     }
 
     // MARK: - displaySymbols
@@ -604,5 +604,49 @@ struct HotkeysTests {
         ))
         let str = try #require(HotkeyRegistry.shortcutString(from: event))
         #expect(str == "cmd+q") // Should be "q", not "a"
+    }
+
+    // MARK: - Conflict detection
+
+    @Test
+    func conflictKey_ignores_modifier_order() {
+        #expect(HotkeyRegistry.conflictKey(for: "cmd+shift+d")
+            == HotkeyRegistry.conflictKey(for: "shift+cmd+d"))
+    }
+
+    @Test
+    func conflictKey_distinguishes_modifiers_and_keys() {
+        #expect(HotkeyRegistry.conflictKey(for: "cmd+d")
+            != HotkeyRegistry.conflictKey(for: "cmd+shift+d"))
+        #expect(HotkeyRegistry.conflictKey(for: "cmd+d")
+            != HotkeyRegistry.conflictKey(for: "cmd+t"))
+    }
+
+    @Test
+    func conflictKey_is_nil_for_disabled_or_invalid() {
+        #expect(HotkeyRegistry.conflictKey(for: "disabled") == nil)
+        #expect(HotkeyRegistry.conflictKey(for: "") == nil)
+        #expect(HotkeyRegistry.conflictKey(for: "cmd+") == nil)
+    }
+
+    @Test
+    func conflictingActionIDs_flags_shared_bindings() {
+        let conflicts = HotkeyRegistry.conflictingActionIDs(in: [
+            "a": "cmd+t",
+            "b": "shift+cmd+t", // distinct
+            "c": "cmd+t", // collides with a
+            "d": "cmd+w",
+        ])
+        #expect(conflicts == ["a", "c"])
+    }
+
+    @Test
+    func conflictingActionIDs_ignores_disabled_duplicates() {
+        let conflicts = HotkeyRegistry.conflictingActionIDs(in: [
+            "a": "disabled",
+            "b": "disabled",
+            "c": "cmd+t",
+        ])
+        #expect(conflicts.isEmpty)
     }
 }


### PR DESCRIPTION
## What

Two improvements to the Keymaps settings pane:

- **Conflict detection.** When two actions are bound to the same shortcut, each conflicting row now shows a ⚠️ warning and an inline `Conflicts with <Action name(s)>` line naming the other action(s). Modifier order is normalized, so `cmd+shift+d` and `shift+cmd+d` are recognized as the same binding.
- **Unmapped bindings read as "None".** Actions with no shortcut now display a muted **None** instead of **Disabled**, making it clearer that the slot is simply empty.

## Why

Previously nothing warned you when you rebound an action onto a shortcut already in use — the collision was silent. And "Disabled" implied an action was turned off rather than just unbound.

## How

- `HotkeyRegistry.conflictKey(for:)` — canonical identity (sorted modifier flags + key token) so binding strings compare regardless of modifier order; returns `nil` for disabled/invalid bindings (which never conflict).
- `HotkeyRegistry.conflictingActionIDs(in:)` — given the current shortcut per action, returns the IDs sharing a binding with another.
- `displayString(for:)` now returns `"None"` for empty/unmapped shortcuts (applies to the Quick Terminal shortcut label too).
- `KeymapSettings` computes conflicts from the current values and renders the warning + partner list per row; unmapped labels use `.secondary` foreground style.

## Notes for reviewers

- Conflict display is **informational only** — it does not block saving a conflicting binding, matching the existing capture/clear flow. Easy to make it blocking if preferred.

## Tests

Added to `HotkeysTests.swift`: modifier-order independence, key/modifier distinction, nil for disabled/invalid, the multi-action conflict set, and disabled-duplicates-don't-conflict. Updated the existing `displayString_empty_or_disabled` test to expect `"None"`. Full suite + format + lint pass.