### PR TITLE
Hide keybind in palette for unmapped bindable actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ mise run test         # Run the test suite
 mise run build        # Release build + DMG
 ```
 
-`format`, `lint`, and `test` show a spinner and print output only on failure. Pass `--verbose` (e.g. `mise run test --verbose`) to stream the raw output instead — useful when a run fails and you need the full log.
+`format`, `lint`, and `test` show a spinner and print output only on failure. **Always pass `--verbose`** (e.g. `mise run test --verbose`) to stream the raw output — a spinner-only run hides the logs you need to confirm what happened, even on success.
 
 Requires macOS 26+, Swift 6.0+. GhosttyKit is a pre-built xcframework from `thdxg/ghostty` (a fork that adds CI builds). No zig toolchain needed for development.
 

--- a/Macterm/Palette/CommandSource.swift
+++ b/Macterm/Palette/CommandSource.swift
@@ -66,7 +66,7 @@ struct CommandSource: PaletteSource {
     private func keybindDisplay(_ action: HotkeyAction) -> String? {
         let raw = HotkeyRegistry.selectedShortcutString(for: action)
         let display = HotkeyRegistry.displayString(for: raw)
-        return display == "Disabled" ? nil : display
+        return (display == "Disabled" || display == "None") ? nil : display
     }
 
     private func keybindSymbols(_ action: HotkeyAction) -> [String]? {


### PR DESCRIPTION
## What

Keybindable command-palette actions that have no shortcut mapped were showing **None** as their keybind. They should show nothing instead — matching how non-keybindable actions render.

## Why

`CommandSource.keybindDisplay` only filtered out `"Disabled"`, so an unmapped action's `"None"` display string fell through and got stored in `PaletteItem.keybind`. Even though `keybindSymbols` was already `nil`, the text fallback branch in `CommandPalette.keybindView` rendered `item.keybind` → "None".

The fix treats `"None"` the same as `"Disabled"` in `keybindDisplay`, returning `nil`. With both `keybind` and `keybindSymbols` nil, `keybindView` renders nothing.

## Notes

- Also bundles a small docs tweak making `--verbose` the default guidance for `mise` tasks (separate commit).
- `mise run test --verbose` passes.