### PR TITLE
Insert dropped file paths into the terminal

### DIFF
--- a/Macterm/Ghostty/GhosttyCallbacks.swift
+++ b/Macterm/Ghostty/GhosttyCallbacks.swift
@@ -93,7 +93,7 @@ final class GhosttyCallbacks: @unchecked Sendable {
 
     /// Escape shell-sensitive characters in a string by prefixing each with a
     /// backslash. Suitable for inserting paths/URLs into a live terminal buffer.
-    private static func shellEscape(_ s: String) -> String {
+    static func shellEscape(_ s: String) -> String {
         var result = s
         for char in escapeCharacters {
             result = result.replacingOccurrences(of: String(char), with: "\\\(char)")

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -42,6 +42,7 @@ final class GhosttyTerminalNSView: NSView {
         self.workingDirectory = workingDirectory
         super.init(frame: .zero)
         setupTrackingArea()
+        registerForDraggedTypes(Array(Self.dropTypes))
         Self.liveViews.add(self)
     }
 
@@ -654,6 +655,46 @@ final class GhosttyTerminalNSView: NSView {
               let scalar = chars.unicodeScalars.first
         else { return 0 }
         return scalar.value
+    }
+
+    // MARK: - Drag & drop
+
+    /// Pasteboard types we accept when something is dragged onto the surface.
+    private static let dropTypes: Set<NSPasteboard.PasteboardType> = [.string, .fileURL, .URL]
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        guard let types = sender.draggingPasteboard.types, !Set(types).isDisjoint(with: Self.dropTypes) else {
+            return []
+        }
+        // .copy gives the drop the familiar green "+" cursor.
+        return .copy
+    }
+
+    /// Drops insert the escaped file path(s) / URL at the cursor. File URLs are
+    /// shell-escaped individually and space-joined; plain strings are inserted
+    /// verbatim (they may be a command the user means to run).
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        let pb = sender.draggingPasteboard
+
+        let content: String? = if let url = pb.string(forType: .URL) {
+            GhosttyCallbacks.shellEscape(url)
+        } else if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL], !urls.isEmpty {
+            urls
+                .map { GhosttyCallbacks.shellEscape($0.path(percentEncoded: false)) }
+                .joined(separator: " ")
+        } else if let str = pb.string(forType: .string) {
+            str
+        } else {
+            nil
+        }
+
+        guard let content else { return false }
+        // Defer the insert (as Ghostty does) so the drag session fully unwinds
+        // before we mutate the terminal buffer.
+        DispatchQueue.main.async {
+            self.insertText(content, replacementRange: NSRange(location: 0, length: 0))
+        }
+        return true
     }
 }
 


### PR DESCRIPTION
Closes #54.

## What

Dragging files, images, or URLs onto a terminal surface now inserts their path(s) at the cursor — previously nothing happened. This makes the common "drop a screenshot into a CLI tool" workflow (e.g. Codex) work without manually copying paths.

## How

`GhosttyTerminalNSView` becomes an `NSDraggingDestination`, mirroring Ghostty's own `SurfaceView_AppKit.swift`:

- Registers for `.string`, `.fileURL`, and `.URL` pasteboard types in `init`.
- `draggingEntered` returns `.copy` (green "+" cursor) when the drag carries an accepted type.
- `performDragOperation` resolves content in the same order Ghostty uses — `.URL` string → file URLs → plain string — then defers the `insertText` via `DispatchQueue.main.async` so the drag session unwinds first.
  - **File URLs** (Finder drag): each path shell-escaped individually, space-joined for multiple files.
  - **URLs**: escaped as-is.
  - **Plain strings**: inserted verbatim (may be a command the user means to run).

The existing `shellEscape` helper in `GhosttyCallbacks` (already identical to Ghostty's `Shell.escape`, and already used by the paste path) is promoted from `private` to internal and reused — no duplicate escaping logic.

## Notes for reviewers

- One deliberate deviation from Ghostty: file-URL paths are read via `url.path(percentEncoded: false)` instead of Ghostty's deprecated `$0.path`. This matches Macterm's own existing paste path (`readPasteboardText`) so both paths escape identically, and avoids the deprecation warning. The resulting string is the same.
- Drag-and-drop is AppKit UI behavior, which per the repo's testing conventions isn't unit-tested; the path-escaping logic it relies on is already covered.

## Verification

`mise run format`, `mise run lint`, and `mise run test` all pass.