### PR TITLE
Disable ssh shell-integration when installed ghostty CLI lacks +ssh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,16 +116,19 @@ A floating `NSPanel` that reuses the same `TerminalTab` / `SplitNode` / `Pane` m
 | `SplitTreeView.swift`                  | Recursive split rendering with draggable dividers                                                                |
 | `TerminalPane.swift`                   | `TerminalPane` + `TerminalSurface` (`NSViewRepresentable` borrowing `pane.nsView`) + search bar overlay          |
 | `Terminal/GhosttyTerminalNSView.swift` | Core terminal NSView — surface, keyboard, mouse, IME                                                             |
+| `Terminal/SurfaceScrollView.swift`     | Native overlay scrollbar: nests the Metal surface in an `NSScrollView` with a blank spacer document view sized to scrollback (Ghostty 1.3.0+ approach) |
 | `SearchBar.swift`                      | Terminal search UI                                                                                               |
 | `QuickTerminal.swift`                  | Quick terminal `NSPanel`, Carbon global hotkey                                                                   |
 | `CommandPalette.swift`                 | `Cmd+Shift+P` / `Cmd+P` command palette                                                                          |
+| `QuitConfirmation.swift`               | Native `Table`-based confirmation shown when quitting with panes still running foreground processes              |
+| `TabSwitcherToolbarItem.swift`         | Numbered segmented control in the title bar mirroring a 5-tab sliding window of the active project's tabs        |
 
 ### Ghostty Integration (`Macterm/Ghostty/`)
 
 | File                     | Purpose                                                                                            |
 | ------------------------ | -------------------------------------------------------------------------------------------------- |
 | `GhosttyApp.swift`       | libghostty init, config, tick loop, color queries; resolves `GHOSTTY_RESOURCES_DIR`                |
-| `GhosttyCLI.swift`       | Detects the external `ghostty` CLI (Ghostty.app); lists the shell-integration features gated on it |
+| `GhosttyCLI.swift`       | Detects the external `ghostty` CLI (Ghostty.app) and probes whether it supports the `+ssh` action; lists the shell-integration features gated on it |
 | `GhosttyResources.swift` | Pure `GhosttyResourceResolver` — picks the resources dir (testable selection logic)                |
 | `GhosttyCallbacks.swift` | Routes libghostty callbacks to terminal views                                                      |
 | `ThemeResolver.swift`    | Pure resolver for `theme = light:X,dark:Y` splits — libghostty's config getters can't (issue #38)  |
@@ -214,7 +217,7 @@ Mirror the production tree. Use `@testable import Macterm` and `@MainActor` on t
 | `App/HotkeysTests.swift`                                                                                                    | `parseShortcut`, `displayString`, `HotkeyAction` sanity                                                    |
 | `Palette/PaletteEngineTests.swift`                                                                                          | `fuzzyScore`, engine sections/sort/path-mode                                                               |
 | `Palette/CommandSourceTests.swift`                                                                                          | `CommandSource` palette-item generation from `AppCommand.allCases`                                         |
-| `Ghostty/GhosttyCLITests.swift`                                                                                             | External `ghostty` CLI detection + bin-dir priority (`GhosttyCLI`)                                         |
+| `Ghostty/GhosttyCLITests.swift`                                                                                             | External `ghostty` CLI detection, bin-dir priority, `+ssh`-support gating (`GhosttyCLI`)                   |
 | `Ghostty/GhosttyResourceResolverTests.swift`                                                                                | Resource dir selection (`GhosttyResourceResolver`)                                                         |
 | `Ghostty/BundledResourcesTests.swift`                                                                                       | Bundle layout: terminfo is a sibling of `ghostty/`, has `78/xterm-ghostty`, shells, themes (#39/#40 guard) |
 | `Ghostty/ThemeResolverTests.swift`                                                                                          | `theme = light:X,dark:Y` split parsing + side selection (`ThemeResolver`, #38)                             |
@@ -222,6 +225,8 @@ Mirror the production tree. Use `@testable import Macterm` and `@MainActor` on t
 | `Persistence/LayoutFileTests.swift`                                                                                         | YAML parse/encode round-trip, flat split-node format, cwd resolution                                       |
 | `Persistence/LayoutSerializerTests.swift`                                                                                   | Live workspace → layout file (topology, project-relative cwd, `run`)                                       |
 | `Persistence/LayoutReconcilerTests.swift`                                                                                   | Minimal-destruction apply: keep/resize/respawn/kill by `(run, cwd)` identity, plain-shell positional match |
+| `System/ProcessInspectorTests.swift`                                                                                        | `ProcessInspector.argv` syscall parsing against real spawned subprocesses                                  |
+| `Views/SurfaceScrollGeometryTests.swift`                                                                                    | Pure row↔pixel scrollback geometry conversion (Y-down rows ↔ Y-up points) for `SurfaceScrollView`          |
 | `Support/TreeBuilder.swift`                                                                                                 | DSL: `H(pane("a"), V(pane("b"), pane("c")))` → `(SplitNode, [name: UUID])`                                 |
 | `Support/TreeRenderer.swift`                                                                                                | Inverse DSL for readable assertions                                                                        |
 

--- a/Macterm/Config/MactermConfig.swift
+++ b/Macterm/Config/MactermConfig.swift
@@ -62,14 +62,28 @@ final class MactermConfig {
         // the host executable's directory — for us that's Macterm's bundle,
         // which ships no `ghostty` CLI. The shell-integration `ssh` wrapper
         // then tries to exec a non-existent `Macterm.app/Contents/MacOS/ghostty`
-        // and dies. If the real Ghostty.app is installed, point at its CLI;
-        // otherwise disable the wrappers that need the binary so they fall
-        // through to plain `ssh`. The `path` feature also relies on this dir
-        // being useful — turn it off when we have nothing to add.
-        if let binDir = GhosttyCLI.standard.resolveBinDir() {
+        // and dies. If the real Ghostty.app is installed, point at its CLI so
+        // the `path` feature works; otherwise disable the wrappers that need
+        // the binary so they fall through to plain `ssh`.
+        //
+        // The ssh wrappers additionally need a *new enough* CLI: the bundled
+        // shell integration calls `ghostty +ssh`, an action older builds (e.g.
+        // 1.3.1) lack. A present-but-too-old CLI makes the wrapper fail with
+        // "Ghostty failed to initialize!" — worse than plain `ssh`. So we gate
+        // the ssh features on `+ssh` support specifically, independent of
+        // whether the binary exists for the `path` feature.
+        let cli = GhosttyCLI.standard
+        var disabledFeatures: [String] = []
+        if let binDir = cli.resolveBinDir() {
             overrides.append("env = GHOSTTY_BIN_DIR=\(binDir)")
         } else {
-            overrides.append("shell-integration-features = no-ssh-env,no-ssh-terminfo,no-path")
+            disabledFeatures.append("no-path")
+        }
+        if cli.resolveSSHWrapperBinDir() == nil {
+            disabledFeatures.append(contentsOf: ["no-ssh-env", "no-ssh-terminfo"])
+        }
+        if !disabledFeatures.isEmpty {
+            overrides.append("shell-integration-features = \(disabledFeatures.joined(separator: ","))")
         }
 
         let body = overrides.joined(separator: "\n") + "\n"

--- a/Macterm/Ghostty/GhosttyCLI.swift
+++ b/Macterm/Ghostty/GhosttyCLI.swift
@@ -8,20 +8,46 @@ import Foundation
 /// installed. When it's missing, `MactermConfig` disables the dependent
 /// shell-integration features and Settings surfaces a banner.
 ///
-/// Selection logic only — the candidate paths and a filesystem probe are
-/// injected so the detection is unit-testable without touching disk.
+/// Detection isn't just "is a binary present" — it's "is a *compatible* binary
+/// present". The bundled shell-integration scripts come from a newer ghostty
+/// (`thdxg/ghostty`) whose `ssh` wrapper invokes `ghostty +ssh -- <args>`. An
+/// older installed Ghostty.app (e.g. 1.3.1) has no `+ssh` action, so the
+/// wrapper dies with "Ghostty failed to initialize!" — strictly worse than not
+/// wrapping `ssh` at all. So we probe for the `+ssh` action before pointing the
+/// wrappers at the binary; a present-but-too-old CLI is treated as unusable for
+/// the ssh wrappers and they're disabled (ssh falls through to plain `ssh`).
+///
+/// Selection logic only — the candidate paths, a filesystem probe, and the
+/// `+ssh`-support probe are injected so the detection is unit-testable without
+/// touching disk or spawning the binary.
 struct GhosttyCLI {
     /// Directories that may contain the `ghostty` CLI, highest priority first.
     let binDirCandidates: [String]
     /// Filesystem executable probe. Injected so tests don't touch disk.
     let isExecutable: (String) -> Bool
+    /// Whether the `ghostty` binary at the given path supports the `+ssh`
+    /// action the bundled shell-integration wrappers depend on. Injected so
+    /// tests don't have to spawn a process.
+    let supportsSSHAction: (String) -> Bool
 
     /// The directory holding the `ghostty` binary, or nil when none is found.
-    /// `MactermConfig` feeds this into `GHOSTTY_BIN_DIR` for spawned shells.
+    /// This is a plain presence check — the binary may be too old to drive the
+    /// ssh wrappers; use `resolveSSHWrapperBinDir()` for that.
     func resolveBinDir() -> String? {
         binDirCandidates.first { isExecutable($0 + "/ghostty") }
     }
 
+    /// The directory holding a `ghostty` binary that's new enough to support the
+    /// ssh shell-integration wrappers (`ghostty +ssh`), or nil when none is.
+    /// `MactermConfig` feeds this into `GHOSTTY_BIN_DIR` only when non-nil;
+    /// otherwise it disables the ssh wrappers so `ssh` falls through to plain
+    /// `ssh` instead of failing on an unknown `+ssh` action.
+    func resolveSSHWrapperBinDir() -> String? {
+        guard let binDir = resolveBinDir() else { return nil }
+        return supportsSSHAction(binDir + "/ghostty") ? binDir : nil
+    }
+
+    /// Whether any `ghostty` CLI is installed (regardless of version).
     var isInstalled: Bool { resolveBinDir() != nil }
 }
 
@@ -34,7 +60,34 @@ extension GhosttyCLI {
                 "/Applications/Ghostty.app/Contents/MacOS",
                 NSHomeDirectory() + "/Applications/Ghostty.app/Contents/MacOS",
             ],
-            isExecutable: FileManager.default.isExecutableFile(atPath:)
+            isExecutable: FileManager.default.isExecutableFile(atPath:),
+            supportsSSHAction: GhosttyCLI.probeSSHAction(at:)
         )
+    }
+
+    /// Runs `ghostty +help` and checks whether `+ssh` is listed among the
+    /// available actions. `+help` exits 0 and prints one action per line; older
+    /// builds simply don't list `+ssh`. We avoid invoking `+ssh` directly so we
+    /// never risk a real connection attempt during a feature probe.
+    private static func probeSSHAction(at path: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = ["+help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0,
+              let output = String(data: data, encoding: .utf8)
+        else { return false }
+        return output
+            .split(separator: "\n")
+            .contains { $0.trimmingCharacters(in: .whitespaces) == "+ssh" }
     }
 }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -35,7 +35,9 @@ private struct GeneralSettings: View {
     var body: some View {
         Form {
             if !ghosttyCLI.isInstalled {
-                MissingGhosttyCLIBanner()
+                GhosttyCLIBanner(reason: .notInstalled)
+            } else if ghosttyCLI.resolveSSHWrapperBinDir() == nil {
+                GhosttyCLIBanner(reason: .tooOldForSSH)
             }
 
             Section("Ghostty Config") {
@@ -105,10 +107,29 @@ private struct GeneralSettings: View {
 // MARK: - Missing CLI banner
 
 /// Shown in General settings when the standalone ghostty CLI (shipped in
-/// Ghostty.app) isn't installed. A few shell-integration wrappers exec that
-/// binary, so without it some features are disabled — the README link spells
-/// out which. Embedded directly in a `Form`, so it renders as its own section.
-private struct MissingGhosttyCLIBanner: View {
+/// Ghostty.app) is missing or too old to drive the shell-integration wrappers.
+/// A few wrappers exec that binary (the `ssh` wrapper calls `ghostty +ssh`), so
+/// without a compatible CLI those features are disabled and fall through to the
+/// plain command — the README link spells out which. Embedded directly in a
+/// `Form`, so it renders as its own section.
+private struct GhosttyCLIBanner: View {
+    enum Reason {
+        case notInstalled
+        case tooOldForSSH
+
+        var message: String {
+            switch self {
+            case .notInstalled:
+                "Ghostty.app isn't installed, so a few shell-integration features can't run."
+            case .tooOldForSSH:
+                "Your installed Ghostty.app is too old for the ssh shell integration. "
+                    + "Update Ghostty.app to forward terminfo over ssh; until then, ssh runs normally."
+            }
+        }
+    }
+
+    let reason: Reason
+
     private static let detailsURL = URL(
         string: "https://github.com/thdxg/macterm#shell-integration"
     )
@@ -119,7 +140,7 @@ private struct MissingGhosttyCLIBanner: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Some features are disabled")
                         .font(.system(size: 13, weight: .semibold))
-                    Text("Ghostty.app isn't installed, so a few shell-integration features can't run.")
+                    Text(reason.message)
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                     if let url = Self.detailsURL {

--- a/MactermTests/Ghostty/GhosttyCLITests.swift
+++ b/MactermTests/Ghostty/GhosttyCLITests.swift
@@ -3,10 +3,15 @@ import Foundation
 import Testing
 
 struct GhosttyCLITests {
-    private func cli(candidates: [String], executable: Set<String>) -> GhosttyCLI {
+    private func cli(
+        candidates: [String],
+        executable: Set<String>,
+        sshCapable: Set<String> = []
+    ) -> GhosttyCLI {
         GhosttyCLI(
             binDirCandidates: candidates,
-            isExecutable: { executable.contains($0) }
+            isExecutable: { executable.contains($0) },
+            supportsSSHAction: { sshCapable.contains($0) }
         )
     }
 
@@ -34,5 +39,49 @@ struct GhosttyCLITests {
         let c = cli(candidates: ["/a", "/b"], executable: [])
         #expect(c.resolveBinDir() == nil)
         #expect(!c.isInstalled)
+    }
+
+    @Test
+    func ssh_wrapper_bin_dir_requires_ssh_support() {
+        // Binary present and supports `+ssh` → usable for the wrappers.
+        let capable = cli(
+            candidates: ["/a"],
+            executable: ["/a/ghostty"],
+            sshCapable: ["/a/ghostty"]
+        )
+        #expect(capable.resolveSSHWrapperBinDir() == "/a")
+    }
+
+    @Test
+    func ssh_wrapper_bin_dir_nil_when_cli_too_old() {
+        // Binary present but no `+ssh` action (e.g. Ghostty 1.3.1) → not usable;
+        // the wrappers must be disabled so ssh falls through to plain ssh.
+        let old = cli(
+            candidates: ["/a"],
+            executable: ["/a/ghostty"],
+            sshCapable: []
+        )
+        #expect(old.resolveBinDir() == "/a") // still "installed"
+        #expect(old.isInstalled)
+        #expect(old.resolveSSHWrapperBinDir() == nil) // but not ssh-capable
+    }
+
+    @Test
+    func ssh_wrapper_bin_dir_nil_when_not_installed() {
+        let none = cli(candidates: ["/a"], executable: [], sshCapable: ["/a/ghostty"])
+        #expect(none.resolveSSHWrapperBinDir() == nil)
+    }
+
+    @Test
+    func ssh_support_probed_against_resolved_bin_dir() {
+        // The probe must run against the *resolved* binary, not a lower-priority
+        // candidate that happens to be ssh-capable.
+        let c = cli(
+            candidates: ["/a", "/b"],
+            executable: ["/a/ghostty", "/b/ghostty"],
+            sshCapable: ["/b/ghostty"] // only the lower-priority one is capable
+        )
+        #expect(c.resolveBinDir() == "/a")
+        #expect(c.resolveSSHWrapperBinDir() == nil)
     }
 }

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ A few settings are overridden because Macterm handles that chrome itself: `backg
 
 Ghostty keybinds work normally unless they conflict with a Macterm shortcut — on conflict, Macterm wins. Every Macterm shortcut is rebindable in **Settings → Keymaps**. Note that Ghostty app-level actions (`new_split`, `new_tab`, etc.) do nothing in Macterm; use Macterm's own keybinds for those.
 
-Shell integration works standalone — no Ghostty.app needed. The one exception is `ssh-env`, `ssh-terminfo`, and `path` features, which require the `ghostty` CLI; install Ghostty.app to enable them.
+Shell integration works standalone — no Ghostty.app needed. The one exception is the `ssh-env`, `ssh-terminfo`, and `path` features, which require the `ghostty` CLI; install Ghostty.app to enable them. The `ssh` features additionally need a Ghostty new enough to provide the `+ssh` action (Ghostty 1.4.0 / tip); against an older install they stay disabled and `ssh` runs normally.
 
 ## Project Layouts
 


### PR DESCRIPTION
## Problem

Running `ssh <host>` in Macterm failed with:

```
Ghostty failed to initialize! If you're executing Ghostty from the command line
then this is usually because an invalid action or multiple actions were specified.
Actions start with the `+` character.
```

— even with Ghostty.app installed.

## Root cause

The bundled shell-integration `ssh` wrapper (from `thdxg/ghostty`) runs `ghostty +ssh -- <args>`. The `+ssh` action only exists in newer ghostty builds. When an **older** Ghostty.app is installed (e.g. **1.3.1**, whose CLI has `+ssh-cache` but no `+ssh`), `MactermConfig` still pointed `GHOSTTY_BIN_DIR` at it because the only check was "is a CLI present?". The wrapper then invoked an unknown action and ghostty bailed out — strictly worse than not wrapping `ssh` at all (with no CLI, the wrappers are disabled and `ssh` falls through to the real binary).

## Fix

- **`GhosttyCLI`** — add an injected `supportsSSHAction` probe (runs `ghostty +help` and looks for the `+ssh` action line) and a new `resolveSSHWrapperBinDir()` that returns the bin dir only when the CLI actually supports `+ssh`. `resolveBinDir()`/`isInstalled` keep their plain-presence semantics.
- **`MactermConfig`** — gate the ssh wrappers (`no-ssh-env,no-ssh-terminfo`) on `+ssh` support, independently of `no-path`. A present-but-too-old CLI still gets `GHOSTTY_BIN_DIR` set (so the `path` feature works) but ssh falls through to plain `ssh`.
- **`SettingsView`** — the "some features disabled" banner gains a `tooOldForSSH` variant telling the user to update Ghostty.app.
- **`GhosttyCLITests`** — cover the version-gated resolution (capable / too-old / not-installed / probe-runs-against-resolved-binary).

## Notes for reviewer

- The probe uses `+help` rather than invoking `+ssh` directly, so a feature check never risks attempting a real connection.
- Verified against a real Ghostty 1.3.1 install: the detector correctly disables the wrappers, so `ssh <host>` uses plain `ssh`. Updating Ghostty.app to a build with `+ssh` re-enables the terminfo-forwarding path automatically (config is regenerated on launch).
- `mise run test`, `format`, and `lint` all pass.