### PR TITLE
Unzoom when switching focus to a different pane

### DIFF
--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -19,6 +19,7 @@ final class TerminalTab: Identifiable {
     /// Record a focus change, pushing the previous pane onto history.
     func focusPane(_ paneID: UUID) {
         guard paneID != focusedPaneID else { return }
+        if zoomedPaneID != nil, zoomedPaneID != paneID { zoomedPaneID = nil }
         if let current = focusedPaneID { paneFocusHistory.push(current) }
         paneFocusHistory.remove(paneID)
         focusedPaneID = paneID

--- a/MactermTests/Model/TerminalTabTests.swift
+++ b/MactermTests/Model/TerminalTabTests.swift
@@ -198,6 +198,30 @@ struct TerminalTabTests {
     }
 
     @Test
+    func focusPane_while_zoomed_clears_zoom() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        let aID = try #require(ids["a"])
+        let bID = try #require(ids["b"])
+        tab.toggleZoom(paneID: aID)
+        #expect(tab.zoomedPaneID == aID)
+        tab.focusPane(bID)
+        #expect(tab.zoomedPaneID == nil)
+        #expect(tab.focusedPaneID == bID)
+    }
+
+    @Test
+    func focusPane_on_zoomed_pane_keeps_zoom() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "b")
+        let aID = try #require(ids["a"])
+        tab.toggleZoom(paneID: aID)
+        #expect(tab.zoomedPaneID == aID)
+        // re-focusing the already-zoomed pane is a no-op (same pane)
+        tab.focusPane(aID)
+        #expect(tab.zoomedPaneID == aID)
+        #expect(tab.focusedPaneID == aID)
+    }
+
+    @Test
     func removing_zoomed_pane_clears_zoom() throws {
         let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
         let bID = try #require(ids["b"])


### PR DESCRIPTION
## Summary

Fixes #61. `focusPane()` now clears `zoomedPaneID` when switching to a different pane, so the full split layout is revealed at the new focus target — matching Ghostty's behaviour.

Two new tests: unzoom-on-focus-change and stay-zoomed when re-focusing the already-zoomed pane.

## Test plan

- [ ] Open multiple panes, zoom one, then use a focus-direction shortcut — layout should unzoom and focus should move to the target pane
- [ ] Zoom a pane and toggle zoom off — normal zoom toggle still works
- [ ] `mise run test` passes

https://claude.ai/code/session_01UeJb1TeSkoZwN3ts3N7824