### PR TITLE
Clear command palette query after executing a command

### DIFF
--- a/Macterm/Views/CommandPalette.swift
+++ b/Macterm/Views/CommandPalette.swift
@@ -310,6 +310,9 @@ struct CommandPalettePanel: View {
     private func execute() {
         guard selectedIndex >= 0, selectedIndex < flatItems.count else { return }
         let item = flatItems[selectedIndex]
+        // Executing a command finishes the task, so the next open should start
+        // fresh — only a dismissal (Escape / click-outside) preserves the query.
+        query = ""
         appState.isCommandPaletteVisible = false
         item.action()
     }


### PR DESCRIPTION
## What

Clears the command palette's search text once a command is actually executed, so the next time the palette opens it starts from a blank field.

## Why

Follow-up to #67, which made the palette preserve its query across close/reopen. Preserving only makes sense when the palette is **dismissed** (Escape / click-outside) — the user stepped away mid-task and reopening should resume where they left off. But once they **execute** something, that task is finished; carrying the stale query into the next open is just noise.

All three execution paths — Enter (`.onSubmit`), the row button tap, and the explicit `Button` — funnel through `execute()`, so clearing there covers every case. Dismissal paths are untouched and still preserve the query.

## Testing

`mise run format` / `lint` pass; debug build succeeds.