### PR TITLE
Add Check for Update action + Other command category

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -42,6 +42,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
     case toggleCommandPalette
     case reloadGhosttyConfig
     case toggleQuickTerminal
+    case checkForUpdate
 
     var id: String { rawValue }
 
@@ -78,6 +79,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .toggleCommandPalette: "Command palette"
         case .reloadGhosttyConfig: "Reload Ghostty config"
         case .toggleQuickTerminal: "Toggle quick terminal"
+        case .checkForUpdate: "Check for update"
         }
     }
 
@@ -111,9 +113,10 @@ enum AppCommand: String, CaseIterable, Identifiable {
              .previousProject: .projects
         case .toggleSidebar,
              .closeWindow,
-             .toggleCommandPalette,
-             .reloadGhosttyConfig,
-             .toggleQuickTerminal: .window
+             .toggleCommandPalette: .window
+        case .reloadGhosttyConfig,
+             .toggleQuickTerminal,
+             .checkForUpdate: .other
         }
     }
 
@@ -151,7 +154,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .removeProject,
              .replaceProjectPathWithCurrentDir,
              .applyLayout,
-             .saveLayout: nil
+             .saveLayout,
+             .checkForUpdate: nil
         }
     }
 
@@ -160,6 +164,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case panes = "Panes"
         case projects = "Projects"
         case window = "Window"
+        case other = "Other"
     }
 }
 

--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -137,6 +137,13 @@ extension AppCommand {
             return { GhosttyApp.shared.reloadAndReport() }
         case .toggleQuickTerminal:
             return { QuickTerminalService.shared.toggle() }
+        case .checkForUpdate:
+            // Always present in the palette; the guard only no-ops when a check
+            // is already in flight (canCheckForUpdates flips false during one).
+            return {
+                guard Updater.shared.canCheckForUpdates else { return }
+                Updater.shared.checkForUpdates()
+            }
         }
     }
 }


### PR DESCRIPTION
## What

- Adds a palette-invokable **"Check for Update"** command that reuses the existing Sparkle `Updater.shared`.
- Introduces an **"Other"** command category for actions that aren't true window operations — reload config, toggle quick terminal, check for update — so **"Window"** holds only window-scoped commands.

## Why

The Check for Update action was requested. It needed a home; lumping it (and reload-config / quick-terminal) under "Window" was inaccurate, so this adds an "Other" category. The palette groups sections dynamically, so the new section shows up automatically.

## Notes for reviewers

- The `checkForUpdate` action always returns a closure (so it's always visible in the palette); the `canCheckForUpdates` guard lives *inside* the closure so it only no-ops while a check is already in flight — mirroring how the menu item uses `.disabled(!canCheckForUpdates)`.
- **In DEBUG builds the action is visible but no-ops**: Sparkle's updater is intentionally not started in debug ([Updater.swift](Macterm/App/Updater.swift)) because it can't verify the unsigned dev binary against the production EdDSA key. It works fully in release builds.
- The menu bar hardcodes individual commands rather than iterating by category, so the new category needed no menu changes.

## Stacked PRs

This is the **base** of a 3-PR stack split out from the original combined PR:
1. **This PR** — Check for Update action + Other category
2. Title-case all action titles → base = this branch
3. Palette UI fixes (highlight radius + padding) → base = the title-case branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
