### PR TITLE
Title-case all action titles (macOS menu convention)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ Mirror the production tree. Use `@testable import Macterm` and `@MainActor` on t
 
 ### Adding a New Action
 
-1. Add a case to `AppCommand` in `AppCommand.swift` with its title, category, and (if rebindable) linked `HotkeyAction`. The palette picks it up automatically via `AppCommand.allCases`.
+1. Add a case to `AppCommand` in `AppCommand.swift` with its title, category, and (if rebindable) linked `HotkeyAction`. The palette picks it up automatically via `AppCommand.allCases`. **All action titles must be Title Case** (the macOS menu convention) — capitalize principal words, leave minor words (`for`, `with`, `to`, `the`, etc.) lowercase unless first/last, e.g. "Check for Update", "Replace Project Path with Current Directory".
 2. If the command is keyboard-bindable, add the corresponding `HotkeyAction` case to `Hotkeys.swift` with its default shortcut.
 3. Add a handler in the appropriate `KeyResponder` in `Responders.swift` (or extend an existing one).
 4. The terminal's `isAppShortcut` automatically picks it up via `HotkeyAction.allCases`.

--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -42,6 +42,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
     case toggleCommandPalette
     case reloadGhosttyConfig
     case toggleQuickTerminal
+    case checkForUpdate
 
     var id: String { rawValue }
 
@@ -78,6 +79,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .toggleCommandPalette: "Command palette"
         case .reloadGhosttyConfig: "Reload Ghostty config"
         case .toggleQuickTerminal: "Toggle quick terminal"
+        case .checkForUpdate: "Check for update"
         }
     }
 
@@ -111,9 +113,10 @@ enum AppCommand: String, CaseIterable, Identifiable {
              .previousProject: .projects
         case .toggleSidebar,
              .closeWindow,
-             .toggleCommandPalette,
-             .reloadGhosttyConfig,
-             .toggleQuickTerminal: .window
+             .toggleCommandPalette: .window
+        case .reloadGhosttyConfig,
+             .toggleQuickTerminal,
+             .checkForUpdate: .other
         }
     }
 
@@ -151,7 +154,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .removeProject,
              .replaceProjectPathWithCurrentDir,
              .applyLayout,
-             .saveLayout: nil
+             .saveLayout,
+             .checkForUpdate: nil
         }
     }
 
@@ -160,6 +164,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case panes = "Panes"
         case projects = "Projects"
         case window = "Window"
+        case other = "Other"
     }
 }
 

--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Single source of truth for every user-invokable action — both palette
-/// commands and keyboard-bindable ones. Exposes a sentence-cased `title` and
-/// a `category` so the palette and Settings can render the same list without
+/// commands and keyboard-bindable ones. Exposes a title-cased `title` (macOS
+/// menu convention) and a `category` so the palette and Settings can render the same list without
 /// duplicated strings. The optional `hotkeyAction` link says whether a
 /// command is rebindable; palette-only commands (like renaming the current
 /// project) return nil.
@@ -48,38 +48,38 @@ enum AppCommand: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .newTab: "New tab"
-        case .closePane: "Close pane"
-        case .renameTab: "Rename current tab"
-        case .nextTab: "Next tab"
-        case .previousTab: "Previous tab"
-        case .recentTab: "Recent tab"
-        case .splitRight: "Split right"
-        case .splitDown: "Split down"
-        case .splitAuto: "Split automatically"
-        case .zoomPane: "Zoom pane"
-        case .focusLeft: "Focus left"
-        case .focusRight: "Focus right"
-        case .focusUp: "Focus up"
-        case .focusDown: "Focus down"
-        case .resizeLeft: "Resize pane left"
-        case .resizeRight: "Resize pane right"
-        case .resizeUp: "Resize pane up"
-        case .resizeDown: "Resize pane down"
-        case .openProject: "Open project"
-        case .renameProject: "Rename current project"
-        case .removeProject: "Remove current project"
-        case .replaceProjectPathWithCurrentDir: "Replace project path with current directory"
-        case .applyLayout: "Apply layout"
-        case .saveLayout: "Save layout"
-        case .nextProject: "Next project"
-        case .previousProject: "Previous project"
-        case .toggleSidebar: "Toggle sidebar"
-        case .closeWindow: "Close window"
-        case .toggleCommandPalette: "Command palette"
-        case .reloadGhosttyConfig: "Reload Ghostty config"
-        case .toggleQuickTerminal: "Toggle quick terminal"
-        case .checkForUpdate: "Check for update"
+        case .newTab: "New Tab"
+        case .closePane: "Close Pane"
+        case .renameTab: "Rename Current Tab"
+        case .nextTab: "Next Tab"
+        case .previousTab: "Previous Tab"
+        case .recentTab: "Recent Tab"
+        case .splitRight: "Split Right"
+        case .splitDown: "Split Down"
+        case .splitAuto: "Split Automatically"
+        case .zoomPane: "Zoom Pane"
+        case .focusLeft: "Focus Left"
+        case .focusRight: "Focus Right"
+        case .focusUp: "Focus Up"
+        case .focusDown: "Focus Down"
+        case .resizeLeft: "Resize Pane Left"
+        case .resizeRight: "Resize Pane Right"
+        case .resizeUp: "Resize Pane Up"
+        case .resizeDown: "Resize Pane Down"
+        case .openProject: "Open Project"
+        case .renameProject: "Rename Current Project"
+        case .removeProject: "Remove Current Project"
+        case .replaceProjectPathWithCurrentDir: "Replace Project Path with Current Directory"
+        case .applyLayout: "Apply Layout"
+        case .saveLayout: "Save Layout"
+        case .nextProject: "Next Project"
+        case .previousProject: "Previous Project"
+        case .toggleSidebar: "Toggle Sidebar"
+        case .closeWindow: "Close Window"
+        case .toggleCommandPalette: "Command Palette"
+        case .reloadGhosttyConfig: "Reload Ghostty Config"
+        case .toggleQuickTerminal: "Toggle Quick Terminal"
+        case .checkForUpdate: "Check for Update"
         }
     }
 

--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -137,6 +137,13 @@ extension AppCommand {
             return { GhosttyApp.shared.reloadAndReport() }
         case .toggleQuickTerminal:
             return { QuickTerminalService.shared.toggle() }
+        case .checkForUpdate:
+            // Always present in the palette; the guard only no-ops when a check
+            // is already in flight (canCheckForUpdates flips false during one).
+            return {
+                guard Updater.shared.canCheckForUpdates else { return }
+                Updater.shared.checkForUpdates()
+            }
         }
     }
 }

--- a/Macterm/Palette/CommandSource.swift
+++ b/Macterm/Palette/CommandSource.swift
@@ -2,7 +2,7 @@ import AppKit
 
 /// Palette source for action commands. Iterates `AppCommand.allCases` so the
 /// palette, Settings, and keyboard bindings all read from the same list.
-/// Titles come from `AppCommand.title` (sentence case); keybind overlays
+/// Titles come from `AppCommand.title` (Title Case); keybind overlays
 /// come from the associated `HotkeyAction` when the command is bindable.
 @MainActor
 struct CommandSource: PaletteSource {


### PR DESCRIPTION
## What

Converts every `AppCommand.title` to macOS-native **Title Case** (e.g. "Split right" → "Split Right", "Replace project path with current directory" → "Replace Project Path with Current Directory"), keeping minor words like *for* / *with* lowercase. Documents the convention in CLAUDE.md's "Adding a New Action" section and updates the `AppCommand` / `CommandSource` doc comments.

## Why

macOS menus and command surfaces use Title Case; the action titles were sentence case, which looked off in the command palette and menu bar.

## Notes for reviewers

- No test assertions referenced the old sentence-cased titles (only comments), so no test changes were needed.

## Stacked PR

This is **PR 2 of 3**, based on the "Check for Update + Other category" branch (#69), not on `main`. Review/merge that one first. The diff shown here is title-case-only once the base merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
