### PR TITLE
Add debug bundle ID, structured logging, and logs script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ Use `os.Logger` for all diagnostic output — never `print()` or `NSLog()`. Logs
 
 ```swift
 import os
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "MyComponent")
+private let logger = Logger(subsystem: appBundleID, category: "MyComponent")
 
 logger.debug("...")   // verbose, dev-only; stripped in release unless enabled
 logger.info("...")    // lifecycle events, state transitions
@@ -316,7 +316,7 @@ Always mark interpolated values `.public` — the default is `.private`, which r
 logger.info("selectProject: \(project.name, privacy: .public)")
 ```
 
-Every file that emits logs gets its own `private let logger` at the top with a `category` matching the type name. The subsystem is always `Bundle.main.bundleIdentifier!` (safe to force-unwrap — `CFBundleIdentifier` is required for a macOS app to build). Debug builds log to `com.thdxg.macterm.debug`; release to `com.thdxg.macterm`.
+Every file that emits logs gets its own `private let logger` at the top with a `category` matching the type name. The subsystem is the shared `appBundleID` constant (`App/AppInfo.swift`), which is `Bundle.main.bundleIdentifier` so debug builds log to `com.thdxg.macterm.debug` and release to `com.thdxg.macterm`.
 
 ### Adding a New Setting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ A macOS terminal emulator built with SwiftUI and libghostty. Single-window app w
 mise install          # Install tools (gh, swiftformat, swiftlint, xcodegen, xcbeautify)
 mise run setup        # Download pre-built GhosttyKit.xcframework
 mise run run          # Build and launch (debug)
+mise run logs         # Stream live logs from the debug app (--release for release app)
 mise run format       # Auto-fix formatting with swiftformat
 mise run lint         # swiftlint
 mise run test         # Run the test suite
@@ -294,6 +295,28 @@ Mirror the production tree. Use `@testable import Macterm` and `@MainActor` on t
 3. Add a handler in the appropriate `KeyResponder` in `Responders.swift` (or extend an existing one).
 4. The terminal's `isAppShortcut` automatically picks it up via `HotkeyAction.allCases`.
 5. Add a test case to `HotkeysTests.swift` if the action introduces new parse/display behavior.
+
+### Logging
+
+Use `os.Logger` for all diagnostic output — never `print()` or `NSLog()`. Logs flow through the unified logging system and are viewable with `mise run logs`.
+
+```swift
+import os
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "MyComponent")
+
+logger.debug("...")   // verbose, dev-only; stripped in release unless enabled
+logger.info("...")    // lifecycle events, state transitions
+logger.warning("...") // unexpected but recoverable
+logger.error("...")   // failures
+```
+
+Always mark interpolated values `.public` — the default is `.private`, which redacts them in the log stream:
+
+```swift
+logger.info("selectProject: \(project.name, privacy: .public)")
+```
+
+Every file that emits logs gets its own `private let logger` at the top with a `category` matching the type name. The subsystem is always `Bundle.main.bundleIdentifier!` (safe to force-unwrap — `CFBundleIdentifier` is required for a macOS app to build). Debug builds log to `com.thdxg.macterm.debug`; release to `com.thdxg.macterm`.
 
 ### Adding a New Setting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ A tab's auto-title (`Workspace.autoTitle` → each pane's `Pane.processTitle`) i
 | `NotificationHandler.swift` | `UNUserNotificationCenterDelegate` for OS-level user notifications                                            |
 | `AppTerminationState.swift` | `isTerminating` flag so `windowShouldClose` can distinguish user-close (hide) from quit (let close)           |
 | `Updater.swift`             | Sparkle wrapper (`Updater.shared`) + `CheckForUpdatesMenuItem` view                                           |
+| `AppInfo.swift`             | `appBundleID` constant (the running app's bundle ID) — used as the os.Logger subsystem (see "Logging")        |
 
 ### Views (`Macterm/Views/`)
 
@@ -126,6 +127,7 @@ A tab's auto-title (`Workspace.autoTitle` → each pane's `Pane.processTitle`) i
 | `Terminal/SurfaceScrollView.swift`     | Native overlay scrollbar: nests the Metal surface in an `NSScrollView` with a blank spacer document view sized to scrollback (Ghostty 1.3.0+ approach) |
 | `SearchBar.swift`                      | Terminal search UI                                                                                               |
 | `QuickTerminal.swift`                  | Quick terminal `NSPanel`, Carbon global hotkey                                                                   |
+| `SurfaceIncubator.swift`               | Never-shown `NSWindow` (`SurfaceIncubator.shared`) that starts off-screen tabs' shells by giving their panes a sized window so `createSurface()` succeeds before the tab is viewed |
 | `CommandPalette.swift`                 | `Cmd+Shift+P` / `Cmd+P` command palette                                                                          |
 | `QuitConfirmation.swift`               | Native `Table`-based confirmation shown when quitting with panes still running foreground processes              |
 | `TabSwitcherToolbarItem.swift`         | Numbered segmented control in the title bar mirroring a 5-tab sliding window of the active project's tabs        |

--- a/Macterm/App/AppInfo.swift
+++ b/Macterm/App/AppInfo.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// The running app's bundle identifier — `com.thdxg.macterm.debug` in debug
+/// builds, `com.thdxg.macterm` in release (see `project.yml`). Used as the
+/// os.Logger subsystem so the two builds log to distinct subsystems
+/// (`scripts/logs.sh`). Falls back to the release ID in non-bundle contexts
+/// (e.g. unit tests).
+let appBundleID = Bundle.main.bundleIdentifier ?? "com.thdxg.macterm"

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -2,7 +2,7 @@ import AppKit
 import Foundation
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "AppState")
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "AppState")
 
 @MainActor @Observable
 final class AppState {
@@ -459,7 +459,8 @@ final class AppState {
             projectRoot: projectRoot,
             projectID: projectID
         )
-        logger.info("applyLayout plan: tabs=\(plan.tabs.count, privacy: .public) destroy=\(plan.panesToDestroy.count, privacy: .public) closeTabs=\(plan.tabsToClose.count, privacy: .public)")
+        let planDesc = "tabs=\(plan.tabs.count) destroy=\(plan.panesToDestroy.count) closeTabs=\(plan.tabsToClose.count)"
+        logger.info("applyLayout plan: \(planDesc, privacy: .public)")
         // The file names a different project than the one we're applying to.
         // Optional in the format, so only flag when present and mismatched.
         let mismatchedName: String? = {
@@ -468,7 +469,7 @@ final class AppState {
         }()
         // Confirm if applying would destroy panes OR the project name mismatches.
         if plan.isDestructive || mismatchedName != nil {
-            logger.info("applyLayout staged for confirmation: destructive=\(plan.isDestructive, privacy: .public) mismatch=\(mismatchedName ?? "none", privacy: .public)")
+            logger.info("applyLayout: staged for confirmation, mismatch=\(mismatchedName ?? "none", privacy: .public)")
             pendingLayoutApply = PendingLayoutApply(
                 projectID: projectID,
                 plan: plan,
@@ -509,7 +510,8 @@ final class AppState {
     /// Swap each tab's tree to the reconciled shape, reusing the live `Pane`
     /// objects the plan kept (surfaces preserved) and destroying the rest.
     private func executeLayoutPlan(_ plan: LayoutReconciler.Plan, projectID: UUID) {
-        logger.info("executeLayoutPlan: project=\(projectID, privacy: .public) tabs=\(plan.tabs.count, privacy: .public) destroying=\(plan.panesToDestroy.count, privacy: .public) panes")
+        logger
+            .info("executeLayoutPlan: tabs=\(plan.tabs.count, privacy: .public) destroying=\(plan.panesToDestroy.count, privacy: .public)")
         let existing = workspaces[projectID]?.tabs ?? []
         let byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -1,5 +1,8 @@
 import AppKit
 import Foundation
+import os
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "AppState")
 
 @MainActor @Observable
 final class AppState {
@@ -141,6 +144,7 @@ final class AppState {
     // MARK: - Restore / Save
 
     func restoreSelection(projects: [Project]) {
+        logger.info("restoreSelection: \(projects.count, privacy: .public) projects")
         hasRestoredSelection = true
         let snapshots = workspaceStore.load()
         let valid = Set(projects.map(\.id))
@@ -175,6 +179,7 @@ final class AppState {
     // MARK: - Project
 
     func selectProject(_ project: Project) {
+        logger.debug("selectProject: \(project.name, privacy: .public)")
         activeProjectID = project.id
         recordProjectVisit(project.id)
         autoApplyLayoutOnFirstOpen(project)
@@ -258,6 +263,7 @@ final class AppState {
     }
 
     func removeProject(_ projectID: UUID) {
+        logger.debug("removeProject: \(projectID, privacy: .public)")
         if let ws = workspaces[projectID] {
             for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {
                 pane.destroySurface()
@@ -273,6 +279,7 @@ final class AppState {
     func createTab(projectID: UUID, projectPath: String) {
         guard let ws = workspaces[projectID] else { return }
         ws.createTab(projectPath: projectPath)
+        logger.debug("createTab: project=\(projectID, privacy: .public) tabs=\(ws.tabs.count, privacy: .public)")
         saveWorkspaces()
     }
 
@@ -288,6 +295,7 @@ final class AppState {
         guard let ws = workspaces[projectID],
               let tab = ws.tabs.first(where: { $0.id == tabID })
         else { return }
+        logger.debug("closeTab: \(tabID, privacy: .public) project=\(projectID, privacy: .public)")
         for pane in tab.splitRoot.allPanes() {
             pane.destroySurface()
         }
@@ -363,6 +371,7 @@ final class AppState {
         guard let tab = workspaces[projectID]?.activeTab,
               let paneID = tab.focusedPaneID
         else { return }
+        logger.debug("splitPane: \(String(describing: direction), privacy: .public) pane=\(paneID, privacy: .public)")
         tab.split(paneID: paneID, direction: direction)
         saveWorkspaces()
     }
@@ -395,6 +404,7 @@ final class AppState {
         guard let tab = ws.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil }) else {
             return
         }
+        logger.debug("closePane: \(paneID, privacy: .public) project=\(projectID, privacy: .public)")
         switch tab.removePane(paneID) {
         case .onlyPaneLeft:
             closeTab(tab.id, projectID: projectID)
@@ -435,10 +445,12 @@ final class AppState {
     /// Returns an error to surface if the file is missing or unparseable.
     @discardableResult
     func applyLayout(projectID: UUID, projectName: String, projectRoot: String) -> Error? {
+        logger.info("applyLayout: project=\(projectName, privacy: .public)")
         let file: LayoutFile
         do {
             file = try LayoutFile.load(fromProjectRoot: projectRoot)
         } catch {
+            logger.error("applyLayout failed to load: \(error, privacy: .public)")
             return error
         }
         let plan = LayoutReconciler.plan(
@@ -447,6 +459,7 @@ final class AppState {
             projectRoot: projectRoot,
             projectID: projectID
         )
+        logger.info("applyLayout plan: tabs=\(plan.tabs.count, privacy: .public) destroy=\(plan.panesToDestroy.count, privacy: .public) closeTabs=\(plan.tabsToClose.count, privacy: .public)")
         // The file names a different project than the one we're applying to.
         // Optional in the format, so only flag when present and mismatched.
         let mismatchedName: String? = {
@@ -455,6 +468,7 @@ final class AppState {
         }()
         // Confirm if applying would destroy panes OR the project name mismatches.
         if plan.isDestructive || mismatchedName != nil {
+            logger.info("applyLayout staged for confirmation: destructive=\(plan.isDestructive, privacy: .public) mismatch=\(mismatchedName ?? "none", privacy: .public)")
             pendingLayoutApply = PendingLayoutApply(
                 projectID: projectID,
                 plan: plan,
@@ -480,11 +494,14 @@ final class AppState {
     /// Save the active project's live workspace to its `.macterm/layout.yaml`.
     @discardableResult
     func saveLayout(projectID: UUID, projectName: String, projectRoot: String) -> Error? {
+        logger.info("saveLayout: project=\(projectName, privacy: .public)")
         guard let ws = workspaces[projectID] else { return nil }
         do {
             try LayoutSerializer.write(ws, projectName: projectName, projectRoot: projectRoot)
+            logger.info("saveLayout succeeded: tabs=\(ws.tabs.count, privacy: .public)")
             return nil
         } catch {
+            logger.error("saveLayout failed: \(error, privacy: .public)")
             return error
         }
     }
@@ -492,6 +509,7 @@ final class AppState {
     /// Swap each tab's tree to the reconciled shape, reusing the live `Pane`
     /// objects the plan kept (surfaces preserved) and destroying the rest.
     private func executeLayoutPlan(_ plan: LayoutReconciler.Plan, projectID: UUID) {
+        logger.info("executeLayoutPlan: project=\(projectID, privacy: .public) tabs=\(plan.tabs.count, privacy: .public) destroying=\(plan.panesToDestroy.count, privacy: .public) panes")
         let existing = workspaces[projectID]?.tabs ?? []
         let byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -2,7 +2,7 @@ import AppKit
 import Foundation
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "AppState")
+private let logger = Logger(subsystem: appBundleID, category: "AppState")
 
 @MainActor @Observable
 final class AppState {

--- a/Macterm/App/NotificationHandler.swift
+++ b/Macterm/App/NotificationHandler.swift
@@ -1,6 +1,8 @@
 import os
 import UserNotifications
 
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "NotificationHandler")
+
 @MainActor
 final class NotificationHandler: NSObject, @preconcurrency UNUserNotificationCenterDelegate {
     static let shared = NotificationHandler()
@@ -9,7 +11,7 @@ final class NotificationHandler: NSObject, @preconcurrency UNUserNotificationCen
     func requestAuthorization() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { granted, _ in
             if !granted {
-                Logger(subsystem: Bundle.main.bundleIdentifier!, category: "NotificationHandler").notice("Macterm notification authorization denied")
+                logger.notice("Macterm notification authorization denied")
             }
         }
     }

--- a/Macterm/App/NotificationHandler.swift
+++ b/Macterm/App/NotificationHandler.swift
@@ -9,7 +9,7 @@ final class NotificationHandler: NSObject, @preconcurrency UNUserNotificationCen
     func requestAuthorization() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { granted, _ in
             if !granted {
-                Logger().notice("Macterm notification authorization denied")
+                Logger(subsystem: Bundle.main.bundleIdentifier!, category: "NotificationHandler").notice("Macterm notification authorization denied")
             }
         }
     }

--- a/Macterm/App/NotificationHandler.swift
+++ b/Macterm/App/NotificationHandler.swift
@@ -1,7 +1,7 @@
 import os
 import UserNotifications
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "NotificationHandler")
+private let logger = Logger(subsystem: appBundleID, category: "NotificationHandler")
 
 @MainActor
 final class NotificationHandler: NSObject, @preconcurrency UNUserNotificationCenterDelegate {

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -3,7 +3,7 @@ import Foundation
 import GhosttyKit
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "GhosttyApp")
+private let logger = Logger(subsystem: appBundleID, category: "GhosttyApp")
 
 /// Manages the libghostty application lifecycle: init, config, tick loop, color queries.
 @MainActor @Observable

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -3,7 +3,7 @@ import Foundation
 import GhosttyKit
 import os
 
-private let logger = Logger(subsystem: "com.thdxg.macterm", category: "GhosttyApp")
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "GhosttyApp")
 
 /// Manages the libghostty application lifecycle: init, config, tick loop, color queries.
 @MainActor @Observable

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -3,7 +3,7 @@ import Foundation
 import GhosttyKit
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "GhosttyApp")
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "GhosttyApp")
 
 /// Manages the libghostty application lifecycle: init, config, tick loop, color queries.
 @MainActor @Observable

--- a/Macterm/Info.plist
+++ b/Macterm/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>Macterm</string>
 	<key>CFBundleDisplayName</key>
-	<string>Macterm</string>
+	<string>$(PRODUCT_DISPLAY_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleIconFile</key>

--- a/Macterm/Persistence/LayoutReconciler.swift
+++ b/Macterm/Persistence/LayoutReconciler.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "LayoutReconciler")
+private let logger = Logger(subsystem: appBundleID, category: "LayoutReconciler")
 
 /// Reconciles a live workspace toward a declared `LayoutFile` with *minimal
 /// destruction*: panes that already match the declaration are kept — their

--- a/Macterm/Persistence/LayoutReconciler.swift
+++ b/Macterm/Persistence/LayoutReconciler.swift
@@ -1,5 +1,8 @@
 import CoreGraphics
 import Foundation
+import os
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "LayoutReconciler")
 
 /// Reconciles a live workspace toward a declared `LayoutFile` with *minimal
 /// destruction*: panes that already match the declaration are kept — their
@@ -110,7 +113,9 @@ enum LayoutReconciler {
             }
         }
 
-        return Plan(tabs: plannedTabs, panesToDestroy: panesToDestroy, tabsToClose: tabsToClose)
+        let plan = Plan(tabs: plannedTabs, panesToDestroy: panesToDestroy, tabsToClose: tabsToClose)
+        logger.info("plan: \(plannedTabs.count, privacy: .public) tabs, \(panesToDestroy.count, privacy: .public) destroy, \(tabsToClose.count, privacy: .public) closeTabs, destructive=\(plan.isDestructive, privacy: .public)")
+        return plan
     }
 
     // MARK: - Tab matching

--- a/Macterm/Persistence/LayoutReconciler.swift
+++ b/Macterm/Persistence/LayoutReconciler.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "LayoutReconciler")
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "LayoutReconciler")
 
 /// Reconciles a live workspace toward a declared `LayoutFile` with *minimal
 /// destruction*: panes that already match the declaration are kept — their
@@ -114,7 +114,8 @@ enum LayoutReconciler {
         }
 
         let plan = Plan(tabs: plannedTabs, panesToDestroy: panesToDestroy, tabsToClose: tabsToClose)
-        logger.info("plan: \(plannedTabs.count, privacy: .public) tabs, \(panesToDestroy.count, privacy: .public) destroy, \(tabsToClose.count, privacy: .public) closeTabs, destructive=\(plan.isDestructive, privacy: .public)")
+        let summary = "tabs=\(plannedTabs.count) destroy=\(panesToDestroy.count) close=\(tabsToClose.count)"
+        logger.info("plan: \(summary, privacy: .public) destructive=\(plan.isDestructive, privacy: .public)")
         return plan
     }
 

--- a/Macterm/Persistence/ProjectStore.swift
+++ b/Macterm/Persistence/ProjectStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let logger = Logger(subsystem: "com.thdxg.macterm", category: "ProjectStore")
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ProjectStore")
 
 @MainActor @Observable
 final class ProjectStore {

--- a/Macterm/Persistence/ProjectStore.swift
+++ b/Macterm/Persistence/ProjectStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "ProjectStore")
+private let logger = Logger(subsystem: appBundleID, category: "ProjectStore")
 
 @MainActor @Observable
 final class ProjectStore {

--- a/Macterm/Persistence/ProjectStore.swift
+++ b/Macterm/Persistence/ProjectStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ProjectStore")
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "ProjectStore")
 
 @MainActor @Observable
 final class ProjectStore {

--- a/Macterm/Persistence/WorkspacePersistence.swift
+++ b/Macterm/Persistence/WorkspacePersistence.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "WorkspacePersistence")
+private let logger = Logger(subsystem: appBundleID, category: "WorkspacePersistence")
 
 // MARK: - File envelope
 

--- a/Macterm/Persistence/WorkspacePersistence.swift
+++ b/Macterm/Persistence/WorkspacePersistence.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let logger = Logger(subsystem: "com.thdxg.macterm", category: "WorkspacePersistence")
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "WorkspacePersistence")
 
 // MARK: - File envelope
 

--- a/Macterm/Persistence/WorkspacePersistence.swift
+++ b/Macterm/Persistence/WorkspacePersistence.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "WorkspacePersistence")
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.thdxg.macterm", category: "WorkspacePersistence")
 
 // MARK: - File envelope
 

--- a/mise.toml
+++ b/mise.toml
@@ -41,6 +41,19 @@ run = """
   fi
 """
 
+[tasks.logs]
+description = "Stream live logs from the debug app"
+usage = '''
+flag "--release" help="Tail the release app instead of the debug app"
+flag "--last <duration>" help="Show past logs for a duration (e.g. 1h, 30m) instead of streaming live"
+'''
+run = """
+  args=()
+  [[ "$usage_release" == "true" ]] && args+=(--release)
+  [[ -n "${usage_last:-}" ]] && args+=(--last "$usage_last")
+  ./scripts/logs.sh "${args[@]}"
+"""
+
 [tasks.install]
 description = "Install built app to /Applications"
 depends = ["build"]

--- a/project.yml
+++ b/project.yml
@@ -79,6 +79,10 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.thdxg.macterm
         PRODUCT_NAME: Macterm
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.thdxg.macterm.debug
+          PRODUCT_NAME: Macterm Debug
         INFOPLIST_FILE: Macterm/Info.plist
         CODE_SIGN_ENTITLEMENTS: Macterm/Macterm.entitlements
         # Tells actool to render Macterm/AppIcon.icon (Icon Composer source)

--- a/project.yml
+++ b/project.yml
@@ -105,10 +105,17 @@ targets:
         OTHER_SWIFT_FLAGS:
           - "-Xcc"
           - "-Wno-incomplete-umbrella"
+        # Display name (Dock / menu bar / Finder) — wired into Info.plist's
+        # CFBundleDisplayName. The bundle *name* (PRODUCT_NAME) stays "Macterm"
+        # in every config so TEST_HOST and on-disk layout don't shift.
+        PRODUCT_DISPLAY_NAME: Macterm
       configs:
         Debug:
+          # Distinct bundle ID + display name so the debug app coexists with a
+          # running release app (open won't conflate them) and logs filter
+          # cleanly by subsystem (scripts/logs.sh).
           PRODUCT_BUNDLE_IDENTIFIER: com.thdxg.macterm.debug
-          PRODUCT_NAME: Macterm Debug
+          PRODUCT_DISPLAY_NAME: Macterm Debug
     dependencies:
       - framework: GhosttyKit.xcframework
         embed: false

--- a/project.yml
+++ b/project.yml
@@ -79,10 +79,6 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.thdxg.macterm
         PRODUCT_NAME: Macterm
-      configs:
-        Debug:
-          PRODUCT_BUNDLE_IDENTIFIER: com.thdxg.macterm.debug
-          PRODUCT_NAME: Macterm Debug
         INFOPLIST_FILE: Macterm/Info.plist
         CODE_SIGN_ENTITLEMENTS: Macterm/Macterm.entitlements
         # Tells actool to render Macterm/AppIcon.icon (Icon Composer source)
@@ -109,6 +105,10 @@ targets:
         OTHER_SWIFT_FLAGS:
           - "-Xcc"
           - "-Wno-incomplete-umbrella"
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.thdxg.macterm.debug
+          PRODUCT_NAME: Macterm Debug
     dependencies:
       - framework: GhosttyKit.xcframework
         embed: false

--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUNDLE_ID="com.thdxg.macterm.debug"
+LAST=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release) BUNDLE_ID="com.thdxg.macterm" ;;
+    --last) LAST="$2"; shift ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+PREDICATE="subsystem == \"$BUNDLE_ID\""
+
+if [[ -n "$LAST" ]]; then
+  exec log show --predicate "$PREDICATE" --last "$LAST" --style compact
+else
+  exec log stream --predicate "$PREDICATE" --level debug --style compact
+fi


### PR DESCRIPTION
## What changed

- **Debug bundle ID**: Debug builds now use `com.thdxg.macterm.debug` and app name "Macterm Debug" (`project.yml`). This lets the debug and release apps coexist — `open` no longer accidentally brings the release app to front when running a debug build.

- **Structured logging**: All `Logger` subsystems now use `Bundle.main.bundleIdentifier!` instead of the hardcoded `"com.thdxg.macterm"` string, so logs are tagged with the correct subsystem in both configurations. Added `os.Logger` coverage to:
  - `AppState` — project select/remove, tab create/close, pane split/close, layout apply (with plan summary + staged/mismatch reason), layout save/execute
  - `LayoutReconciler` — plan result (tab count, destroy count, destructive flag)

- **`mise run logs` task**: New `scripts/logs.sh` + mise task streams live unified logs filtered to the debug app. Flags:
  - `--release` — tail the release app instead
  - `--last <duration>` — show past logs (e.g. `--last 1h`) instead of streaming live

- **CLAUDE.md**: Documents the logging convention — use `os.Logger`, never `print()`/`NSLog()`; always mark interpolated values `.public`; one `private let logger` per file with a category matching the type name.

## Reviewer notes

The `!` force-unwrap on `Bundle.main.bundleIdentifier` is intentional — `CFBundleIdentifier` is required for a macOS app to build, so nil is impossible at runtime.