### PR TITLE
Merge user's shell-integration-features into overrides instead of replacing it (#75)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,16 +187,17 @@ A tab's auto-title (`Workspace.autoTitle` → each pane's `Pane.processTitle`) i
 
 ### Config (`Macterm/Config/`)
 
-| File                  | Purpose                                                                             |
-| --------------------- | ----------------------------------------------------------------------------------- |
-| `MactermConfig.swift` | Generates the two wrapper ghostty config files Macterm sandwiches around the user's |
+| File                             | Purpose                                                                                                         |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `MactermConfig.swift`            | Generates the two wrapper ghostty config files Macterm sandwiches around the user's                              |
+| `ShellIntegrationFeatures.swift` | Pure merger for the `shell-integration-features` override — user's flags + Macterm's forced `no-*` flags (#75)   |
 
 Macterm reads the user's `~/.config/ghostty/config` (path configurable in Settings → General → Ghostty Config). The user is the source of truth for every ghostty setting — themes, fonts, palettes, keybinds, etc. `MactermConfig.regenerate()` writes two private files in App Support:
 
 - **`macterm-defaults.conf`** — first-launch tasteful defaults (Rose Pine, 16pt, padding, `macos-option-as-alt = true`). User's Ghostty config overrides each line.
-- **`macterm-overrides.conf`** — keys Macterm absolutely needs to lock. Currently just `background-opacity = 0` and `background-blur = 0` so ghostty renders fully transparent and `WindowAppearance` can composite translucency itself without double-tinting.
+- **`macterm-overrides.conf`** — keys Macterm absolutely needs to lock: `background-opacity = 0` and `background-blur = 0` so ghostty renders fully transparent and `WindowAppearance` can composite translucency itself without double-tinting, plus (when the external ghostty CLI is missing/too old) `GHOSTTY_BIN_DIR` and a `shell-integration-features` line disabling the CLI-dependent features. The latter can't be written bare — libghostty re-parses that key from defaults on every occurrence, so a bare line would wipe the user's own flags (e.g. `no-cursor`); `ShellIntegrationFeatures.overrideValue` re-emits the user's effective value with our `no-*` flags appended (#75). Because the override depends on the user's config content, `GhosttyApp.loadConfig` calls `regenerate()` before every load.
 
-`GhosttyApp.loadConfig` loads them in order: `defaults → user's Ghostty config → overrides`. libghostty does last-wins merge, so the user's config overrides our defaults and our overrides override the user. See the README's "For Ghostty Users" section for the user-facing version of what's overridden vs honored.
+`GhosttyApp.loadConfig` loads them in order: `defaults → user's Ghostty config → overrides`. libghostty does last-wins merge, so the user's config overrides our defaults and our overrides override the user. See the README's "Configuration" section for the user-facing version of what's overridden vs honored.
 
 Macterm-specific UI state (window opacity/blur, quick terminal, hotkeys, auto-tile) lives in `Preferences` and never touches the ghostty config pipeline.
 
@@ -230,6 +231,7 @@ Mirror the production tree. Use `@testable import Macterm` and `@MainActor` on t
 | `Ghostty/GhosttyResourceResolverTests.swift`                                                                                | Resource dir selection (`GhosttyResourceResolver`)                                                         |
 | `Ghostty/BundledResourcesTests.swift`                                                                                       | Bundle layout: terminfo is a sibling of `ghostty/`, has `78/xterm-ghostty`, shells, themes (#39/#40 guard) |
 | `Ghostty/ThemeResolverTests.swift`                                                                                          | `theme = light:X,dark:Y` split parsing + side selection (`ThemeResolver`, #38)                             |
+| `Config/ShellIntegrationFeaturesTests.swift`                                                                                | `shell-integration-features` user-value extraction + override merge (`ShellIntegrationFeatures`, #75)      |
 | `Persistence/WorkspaceSerializerTests.swift`                                                                                | Snapshot/restore round-trip + on-disk via `WorkspaceStore`                                                 |
 | `Persistence/LayoutFileTests.swift`                                                                                         | YAML parse/encode round-trip, tab-is-a-node + nested `split:` format, cwd resolution                       |
 | `Persistence/LayoutSerializerTests.swift`                                                                                   | Live workspace → layout file (topology, project-relative cwd, `run`, non-default `shell:`)                 |

--- a/Macterm/Config/MactermConfig.swift
+++ b/Macterm/Config/MactermConfig.swift
@@ -4,8 +4,11 @@ import Foundation
 /// own Ghostty config. The user is the source of truth for every Ghostty
 /// setting; Macterm provides first-launch defaults that the user overrides,
 /// and a minimal must-win overrides file for keys Macterm can't let the
-/// renderer control (currently: background-opacity, background-blur — both
-/// required for the window-level translucency in `WindowAppearance`).
+/// renderer control (background-opacity and background-blur — both required
+/// for the window-level translucency in `WindowAppearance` — plus, when the
+/// external ghostty CLI is missing, a shell-integration-features line that
+/// merges the user's own value with the features Macterm must disable; see
+/// `ShellIntegrationFeatures`).
 ///
 /// `GhosttyApp.loadConfig` loads them in this order:
 ///   defaults → user's Ghostty config → overrides
@@ -33,7 +36,9 @@ final class MactermConfig {
 
     /// Rewrite both wrapper config files. Cheap and idempotent; safe to call
     /// on launch and whenever Macterm-side state changes that's reflected in
-    /// either file.
+    /// either file. The overrides also depend on the *user's* config content
+    /// (the shell-integration-features merge), so `GhosttyApp.loadConfig`
+    /// calls this before every load to pick up user edits.
     func regenerate() {
         let defaults = [
             // First-launch tasteful UX. User's Ghostty config overrides any of
@@ -83,10 +88,30 @@ final class MactermConfig {
             disabledFeatures.append(contentsOf: ["no-ssh-env", "no-ssh-terminfo"])
         }
         if !disabledFeatures.isEmpty {
-            overrides.append("shell-integration-features = \(disabledFeatures.joined(separator: ","))")
+            // A bare `shell-integration-features = <ours>` would replace the
+            // user's own value entirely — libghostty re-parses the key from
+            // defaults on every occurrence — wiping user flags like
+            // `no-cursor`. Re-emit the user's effective value with our forced
+            // flags appended so only those change. (#75)
+            let value = ShellIntegrationFeatures.overrideValue(
+                userConfigText: userGhosttyConfigText(),
+                disabled: disabledFeatures
+            )
+            if let value {
+                overrides.append("shell-integration-features = \(value)")
+            }
         }
 
         let body = overrides.joined(separator: "\n") + "\n"
         try? Data(body.utf8).write(to: overridesURL, options: .atomic)
+    }
+
+    /// The user's Ghostty config text, read for merging their
+    /// `shell-integration-features` value into the overrides. nil when the
+    /// user has disabled loading (empty path) or the file is unreadable.
+    private func userGhosttyConfigText() -> String? {
+        let path = Preferences.shared.expandedUserGhosttyConfigPath
+        guard !path.isEmpty else { return nil }
+        return try? String(contentsOfFile: path, encoding: .utf8)
     }
 }

--- a/Macterm/Config/ShellIntegrationFeatures.swift
+++ b/Macterm/Config/ShellIntegrationFeatures.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Composes the `shell-integration-features` line Macterm writes into
+/// `macterm-overrides.conf` so it *merges with* the user's own value instead
+/// of replacing it (issue #75).
+///
+/// libghostty parses this key with replace semantics: every occurrence of the
+/// key re-parses the comma list into a fresh default struct
+/// (`parsePackedStruct` in ghostty's `src/cli/args.zig`). A bare
+/// `shell-integration-features = no-ssh-env` in the overrides file — loaded
+/// last — would therefore silently wipe user flags like `no-cursor` from
+/// `~/.config/ghostty/config`. So Macterm re-emits the user's effective value
+/// first and appends its own forced `no-*` flags; ghostty applies the
+/// comma-separated parts left to right with later parts winning per-flag, so
+/// the forced flags take precedence while every other user flag survives.
+///
+/// Pure selection logic — the user's config text is passed in so this is
+/// unit-testable without touching disk. Limitation: only the main config file
+/// is scanned; a value set in a `config-file` include isn't seen.
+enum ShellIntegrationFeatures {
+    /// Every flag the bundled libghostty's `ShellIntegrationFeatures` struct
+    /// knows (ghostty `src/config/Config.zig`). Needed to expand a bare
+    /// `shell-integration-features = true` ("all on") into an explicit list
+    /// the forced `no-*` flags can be appended to — ghostty accepts a bool
+    /// literal only as the *entire* value, never as one comma part. Must
+    /// track the bundled GhosttyKit when the feature set changes.
+    static let allFeatures = ["cursor", "sudo", "title", "ssh-env", "ssh-terminfo", "path"]
+
+    /// The bool literals ghostty's `parseBool` accepts (`src/cli/args.zig`).
+    private static let trueLiterals: Set<String> = ["1", "t", "T", "true"]
+    private static let falseLiterals: Set<String> = ["0", "f", "F", "false"]
+
+    /// The user's effective `shell-integration-features` value in raw ghostty
+    /// config text. Last occurrence wins and an empty value resets the key to
+    /// its defaults ("not set"), mirroring libghostty's own semantics.
+    /// Comments and blank lines are ignored; a matched pair of surrounding
+    /// double quotes is stripped. nil when the key is never set.
+    static func userValue(inConfigText text: String) -> String? {
+        var result: String?
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            let key = line[line.startIndex ..< eq].trimmingCharacters(in: .whitespaces)
+            guard key == "shell-integration-features" else { continue }
+            var value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            if value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") {
+                value = String(value.dropFirst().dropLast())
+            }
+            result = value.isEmpty ? nil : value
+        }
+        return result
+    }
+
+    /// The value to write after `shell-integration-features = ` in
+    /// macterm-overrides.conf, or nil when no override line is needed.
+    /// `disabled` are the `no-*` flags Macterm must force (see
+    /// `MactermConfig.regenerate`).
+    static func overrideValue(userConfigText: String?, disabled: [String]) -> String? {
+        guard !disabled.isEmpty else { return nil }
+        let ours = disabled.joined(separator: ",")
+        guard let text = userConfigText, let user = userValue(inConfigText: text) else { return ours }
+        // A bool literal flips every flag at once and is only valid as the
+        // whole value: expand "all on" to the explicit list so our flags can
+        // follow; "all off" already includes everything we'd disable.
+        if trueLiterals.contains(user) {
+            return (allFeatures + disabled).joined(separator: ",")
+        }
+        if falseLiterals.contains(user) {
+            return "false"
+        }
+        return "\(user),\(ours)"
+    }
+}

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -234,6 +234,11 @@ final class GhosttyApp {
         var result = ReloadResult(diagnostics: [])
         guard let cfg = ghostty_config_new() else { return (nil, result) }
 
+        // Recompute the wrapper files against the user's config as it exists
+        // right now: the overrides' shell-integration-features line merges the
+        // user's own value (#75), which may have changed since the last load.
+        MactermConfig.shared.regenerate()
+
         // Three-layer ghostty config:
         //   1. Macterm defaults — tasteful first-launch values.
         //   2. User's Ghostty config — overrides any default. Source of truth

--- a/MactermTests/Config/ShellIntegrationFeaturesTests.swift
+++ b/MactermTests/Config/ShellIntegrationFeaturesTests.swift
@@ -1,0 +1,137 @@
+@testable import Macterm
+import Testing
+
+struct ShellIntegrationFeaturesTests {
+    // MARK: - userValue(inConfigText:)
+
+    @Test
+    func reads_features_line() {
+        let text = "font-size = 16\nshell-integration-features = no-cursor\ntheme = Rose Pine\n"
+        #expect(ShellIntegrationFeatures.userValue(inConfigText: text) == "no-cursor")
+    }
+
+    @Test
+    func last_line_wins() {
+        let text = "shell-integration-features = no-cursor\nshell-integration-features = no-title,sudo\n"
+        #expect(ShellIntegrationFeatures.userValue(inConfigText: text) == "no-title,sudo")
+    }
+
+    @Test
+    func empty_value_resets_to_unset() {
+        let text = "shell-integration-features = no-cursor\nshell-integration-features = \n"
+        #expect(ShellIntegrationFeatures.userValue(inConfigText: text) == nil)
+    }
+
+    @Test
+    func ignores_comments_and_blanks() {
+        let text = "# shell-integration-features = ignored\n\n  shell-integration-features = no-cursor  \n"
+        #expect(ShellIntegrationFeatures.userValue(inConfigText: text) == "no-cursor")
+    }
+
+    @Test
+    func strips_surrounding_quotes() {
+        let text = "shell-integration-features = \"no-cursor,sudo\"\n"
+        #expect(ShellIntegrationFeatures.userValue(inConfigText: text) == "no-cursor,sudo")
+    }
+
+    @Test
+    func no_line_returns_nil() {
+        #expect(ShellIntegrationFeatures.userValue(inConfigText: "font-size = 16\n") == nil)
+    }
+
+    @Test
+    func does_not_match_other_keys() {
+        #expect(ShellIntegrationFeatures.userValue(inConfigText: "shell-integration = zsh\n") == nil)
+    }
+
+    // MARK: - overrideValue(userConfigText:disabled:)
+
+    @Test
+    func no_disabled_features_needs_no_override() {
+        let text = "shell-integration-features = no-cursor\n"
+        #expect(ShellIntegrationFeatures.overrideValue(userConfigText: text, disabled: []) == nil)
+    }
+
+    @Test
+    func no_user_config_emits_only_disabled() {
+        let value = ShellIntegrationFeatures.overrideValue(
+            userConfigText: nil,
+            disabled: ["no-ssh-env", "no-ssh-terminfo"]
+        )
+        #expect(value == "no-ssh-env,no-ssh-terminfo")
+    }
+
+    @Test
+    func no_user_line_emits_only_disabled() {
+        let value = ShellIntegrationFeatures.overrideValue(
+            userConfigText: "font-size = 16\n",
+            disabled: ["no-path"]
+        )
+        #expect(value == "no-path")
+    }
+
+    @Test
+    func user_flags_are_preserved_before_disabled() {
+        // The issue #75 case: user's no-cursor must survive the override.
+        let value = ShellIntegrationFeatures.overrideValue(
+            userConfigText: "shell-integration-features = no-cursor\n",
+            disabled: ["no-ssh-env", "no-ssh-terminfo"]
+        )
+        #expect(value == "no-cursor,no-ssh-env,no-ssh-terminfo")
+    }
+
+    @Test
+    func disabled_flags_come_last_so_they_win() {
+        // ghostty applies parts left to right; a user-enabled ssh-env must
+        // still lose to our forced no-ssh-env.
+        let value = ShellIntegrationFeatures.overrideValue(
+            userConfigText: "shell-integration-features = ssh-env,no-cursor\n",
+            disabled: ["no-ssh-env"]
+        )
+        #expect(value == "ssh-env,no-cursor,no-ssh-env")
+    }
+
+    @Test
+    func bare_true_expands_to_all_features() {
+        // A bool literal is only valid as the whole value, so "all on" has to
+        // become an explicit list before our flags can be appended.
+        let value = ShellIntegrationFeatures.overrideValue(
+            userConfigText: "shell-integration-features = true\n",
+            disabled: ["no-path"]
+        )
+        #expect(value == "cursor,sudo,title,ssh-env,ssh-terminfo,path,no-path")
+    }
+
+    @Test
+    func bare_false_stays_false() {
+        // Everything off already includes everything we'd disable.
+        for literal in ["false", "0", "f", "F"] {
+            let value = ShellIntegrationFeatures.overrideValue(
+                userConfigText: "shell-integration-features = \(literal)\n",
+                disabled: ["no-ssh-env"]
+            )
+            #expect(value == "false")
+        }
+    }
+
+    @Test
+    func true_literal_variants_expand() {
+        for literal in ["1", "t", "T", "true"] {
+            let value = ShellIntegrationFeatures.overrideValue(
+                userConfigText: "shell-integration-features = \(literal)\n",
+                disabled: ["no-ssh-env"]
+            )
+            #expect(value == "cursor,sudo,title,ssh-env,ssh-terminfo,path,no-ssh-env")
+        }
+    }
+
+    @Test
+    func last_user_line_is_the_one_merged() {
+        let text = "shell-integration-features = no-title\nshell-integration-features = no-cursor\n"
+        let value = ShellIntegrationFeatures.overrideValue(
+            userConfigText: text,
+            disabled: ["no-path"]
+        )
+        #expect(value == "no-cursor,no-path")
+    }
+}


### PR DESCRIPTION
Fixes #75 — a user's `shell-integration-features` setting (e.g. `no-cursor`) was completely wiped by Macterm's overrides.

libghostty re-parses `shell-integration-features` from a fresh default struct on every occurrence of the key, so the bare line Macterm wrote into `macterm-overrides.conf` (loaded last) replaced any flags the user set in their own Ghostty config instead of merging with them.

The override now re-emits the user's effective value first with Macterm's forced `no-*` flags appended — ghostty applies comma parts left to right, so the forced flags still win per-flag while every other user flag survives. The wrapper files are regenerated on every config load so an edited user config gets re-merged.

- New pure `ShellIntegrationFeatures` helper (user-value extraction + override merge, incl. bare `true`/`false` literal handling) with unit tests
- `MactermConfig.regenerate()` reads the user's config and writes the merged value
- `GhosttyApp.loadConfig()` regenerates the wrapper files before every load
- CLAUDE.md updated to document the actual override set (and a stale reference to a nonexistent README section fixed)