### PR TITLE
fix: hide tab switcher when the window is too narrow instead of folding into the toolbar overflow menu

### DIFF
--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -8,6 +8,8 @@ struct MainWindow: View {
     private var projectStore
     @State
     private var columnVisibility: NavigationSplitViewVisibility = .automatic
+    @State
+    private var detailWidth: CGFloat = .infinity
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
@@ -34,12 +36,17 @@ struct MainWindow: View {
             }
             .navigationTitle(activeProject?.name ?? appDisplayName)
             .navigationSubtitle(activeTabTitle)
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { width in
+                detailWidth = width
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     UpdateAvailableToolbarButton()
                 }
                 ToolbarItem(placement: .primaryAction) {
-                    TabSwitcherToolbarItem()
+                    TabSwitcherToolbarItem(availableWidth: detailWidth)
                 }
             }
         }

--- a/Macterm/Views/TabSwitcherToolbarItem.swift
+++ b/Macterm/Views/TabSwitcherToolbarItem.swift
@@ -22,11 +22,19 @@ struct TabSwitcherToolbarItem: View {
     @AppStorage(Preferences.Keys.tabSwitcherVisibility)
     private var visibilityRaw: String = TabSwitcherVisibility.whenMultiple.rawValue
 
+    /// Width of the detail column, measured by `MainWindow`. The toolbar has
+    /// no "hide when clipped" mode — a control that doesn't fit folds into
+    /// the overflow (») menu, which is worse than no switcher at all. Below
+    /// `minimumDetailWidth` the switcher hides before AppKit would clip it.
+    var availableWidth: CGFloat = .infinity
+
     private static let windowSize = 5
+    private static let minimumDetailWidth: CGFloat = 420
 
     var body: some View {
         let visibility = TabSwitcherVisibility(rawValue: visibilityRaw) ?? .whenMultiple
         if visibility != .hidden,
+           availableWidth >= Self.minimumDetailWidth,
            let workspace = activeWorkspace,
            !workspace.tabs.isEmpty,
            visibility == .always || workspace.tabs.count > 1


### PR DESCRIPTION
## Why

When the window gets narrow, the toolbar clips the tab switcher into the system overflow (») chevron menu. A segmented control buried in a menu is useless — better to hide it entirely and let Cmd+1…9 keep working.

## How

SwiftUI offers no "hide when clipped" mode for toolbar items (`visibilityPriority` only reorders what folds into the overflow menu first), so the switcher hides itself before AppKit would clip it:

- `MainWindow` measures the detail column width via `.onGeometryChange` and passes it to `TabSwitcherToolbarItem`.
- The switcher's existing visibility check now also requires `availableWidth >= 420`. The 5-segment picker plus toolbar margins and the title's minimum start clipping around 300–340pt of detail width, so 420 hides it comfortably before the chevron ever appears (including when the update button is showing).

## Testing

- `mise run test` passes; format/lint clean.
- Verified manually: dragging the window narrow hides the switcher cleanly, no chevron.