### PR TITLE
Add Unload Project action to free resources of unused projects

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -30,6 +30,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
     // Projects
     case openProject
     case renameProject
+    case unloadProject
     case removeProject
     case replaceProjectPathWithCurrentDir
     case applyLayout
@@ -68,6 +69,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .resizeDown: "Resize Pane Down"
         case .openProject: "Open Project"
         case .renameProject: "Rename Current Project"
+        case .unloadProject: "Unload Current Project"
         case .removeProject: "Remove Current Project"
         case .replaceProjectPathWithCurrentDir: "Replace Project Path with Current Directory"
         case .applyLayout: "Apply Layout"
@@ -105,6 +107,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
              .resizeDown: .panes
         case .openProject,
              .renameProject,
+             .unloadProject,
              .removeProject,
              .replaceProjectPathWithCurrentDir,
              .applyLayout,
@@ -151,7 +154,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .toggleQuickTerminal: .toggleQuickTerminal
         case .renameTab: .renameTab
         case .renameProject: .renameProject
-        case .removeProject,
+        case .unloadProject,
+             .removeProject,
              .replaceProjectPathWithCurrentDir,
              .applyLayout,
              .saveLayout,

--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -96,6 +96,9 @@ extension AppCommand {
                 // See .renameTab: defer so the sidebar row exists first.
                 DispatchQueue.main.async { ctx.appState.renamingProjectID = projectID }
             }
+        case .unloadProject:
+            guard let projectID, ctx.appState.isProjectLoaded(projectID) else { return nil }
+            return { ctx.appState.unloadProject(projectID) }
         case .removeProject:
             guard let projectID else { return nil }
             return {

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -262,6 +262,35 @@ final class AppState {
         projectStore.setPath(id: projectID, to: pwd)
     }
 
+    /// Whether any pane in the project's workspace has a live terminal view —
+    /// i.e. there's something for `unloadProject(_:)` to tear down.
+    func isProjectLoaded(_ projectID: UUID) -> Bool {
+        guard let ws = workspaces[projectID] else { return false }
+        return ws.tabs.flatMap { $0.splitRoot.allPanes() }.contains { $0.nsView != nil }
+    }
+
+    /// Tear down a project's terminal surfaces (ending their shell processes)
+    /// while keeping its tab/split layout — returning it to the lazy state an
+    /// unfocused project is in right after launch, where the workspace exists
+    /// in memory but no pane spawns a shell until the project is selected
+    /// again. Implemented as the same snapshot → restore round-trip a
+    /// quit/relaunch performs, so each pane's live cwd is captured before its
+    /// surface dies. Unloading the active project deselects it; leaving it
+    /// active would let SwiftUI respawn the shells immediately.
+    func unloadProject(_ projectID: UUID) {
+        guard let ws = workspaces[projectID] else { return }
+        logger.debug("unloadProject: \(projectID, privacy: .public)")
+        let snapshot = WorkspaceSerializer.snapshot([projectID: ws])
+        for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {
+            pane.destroySurface()
+        }
+        if let restored = WorkspaceSerializer.restore(from: snapshot, validIDs: [projectID]).first {
+            workspaces[projectID] = restored
+        }
+        if activeProjectID == projectID { activeProjectID = nil }
+        saveWorkspaces()
+    }
+
     func removeProject(_ projectID: UUID) {
         logger.debug("removeProject: \(projectID, privacy: .public)")
         if let ws = workspaces[projectID] {

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -123,6 +123,7 @@ struct MactermApp: App {
                     projectStore: projectStore,
                     titleOverride: "Rename Project…"
                 )
+                AppCommandMenuItem(command: .unloadProject, appState: appState, projectStore: projectStore, titleOverride: "Unload Project")
                 AppCommandMenuItem(command: .removeProject, appState: appState, projectStore: projectStore, titleOverride: "Remove Project")
                 AppCommandMenuItem(
                     command: .replaceProjectPathWithCurrentDir,

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -104,7 +104,10 @@ final class Pane: Identifiable {
         // finished unwinding.
         DispatchQueue.main.async {
             _ = view
-            _ = scroll
+            // Detach the scroll view from whatever still hosts it — notably the
+            // SurfaceIncubator's hidden window, which never removes warmed
+            // views itself — so the dead view pair can actually deallocate.
+            scroll?.removeFromSuperview()
         }
     }
 

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -47,6 +47,8 @@ struct SidebarContent: View {
                         expandedProjects.insert(project.id)
                     } onRename: {
                         projectStore.rename(id: project.id, to: $0)
+                    } onUnload: {
+                        appState.unloadProject(project.id)
                     } onRemove: {
                         expandedProjects.remove(project.id)
                         appState.removeProject(project.id)
@@ -139,6 +141,7 @@ private struct SidebarProjectRow: View {
     let index: Int
     let onNewTab: () -> Void
     let onRename: (String) -> Void
+    let onUnload: () -> Void
     let onRemove: () -> Void
     @Environment(AppState.self)
     private var appState
@@ -188,6 +191,8 @@ private struct SidebarProjectRow: View {
             Divider()
             Button("Rename Project") { beginRename() }
             Divider()
+            Button("Unload Project", action: onUnload)
+                .disabled(!appState.isProjectLoaded(project.id))
             Button("Remove Project", role: .destructive, action: onRemove)
         }
         .task(id: appState.renamingProjectID) {

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -159,6 +159,82 @@ struct AppStateTests {
         #expect(state.activeProjectID == p2.id)
     }
 
+    // MARK: - Unload project
+
+    @Test
+    func unloadProject_keeps_tab_structure_with_fresh_panes() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        state.splitPane(direction: .horizontal, projectID: p.id)
+        ws.createTab(projectPath: "/tmp")
+        ws.tabs[1].customTitle = "build"
+        let beforePaneIDs = Set(ws.tabs.flatMap { $0.splitRoot.allPanes().map(\.id) })
+        let beforeTabIDs = ws.tabs.map(\.id)
+
+        state.unloadProject(p.id)
+
+        let after = try #require(state.workspaces[p.id])
+        #expect(after.tabs.map(\.id) == beforeTabIDs)
+        #expect(after.tabs[0].splitRoot.allPanes().count == 2)
+        #expect(after.tabs[1].customTitle == "build")
+        // Panes are rebuilt fresh (no surfaces), like a launch restore.
+        let afterPaneIDs = Set(after.tabs.flatMap { $0.splitRoot.allPanes().map(\.id) })
+        #expect(afterPaneIDs.isDisjoint(with: beforePaneIDs))
+    }
+
+    @Test
+    func unloadProject_destroys_pane_views() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let pane = try #require(state.workspaces[p.id]?.activeTab?.splitRoot.allPanes().first)
+        _ = pane.ensureNSView()
+        #expect(state.isProjectLoaded(p.id))
+
+        state.unloadProject(p.id)
+
+        #expect(pane.nsView == nil)
+        #expect(!state.isProjectLoaded(p.id))
+    }
+
+    @Test
+    func unloadProject_active_project_is_deselected_but_kept() {
+        let state = makeAppState()
+        let p = seedProject(state)
+        #expect(state.activeProjectID == p.id)
+        state.unloadProject(p.id)
+        #expect(state.activeProjectID == nil)
+        #expect(state.workspaces[p.id] != nil)
+    }
+
+    @Test
+    func unloadProject_other_project_keeps_active() {
+        let state = makeAppState()
+        let p1 = seedProject(state, name: "p1", path: "/tmp1")
+        let p2 = seedProject(state, name: "p2", path: "/tmp2")
+        state.unloadProject(p1.id)
+        #expect(state.activeProjectID == p2.id)
+        #expect(state.workspaces[p1.id] != nil)
+    }
+
+    @Test
+    func unloadProject_unknown_project_is_noop() {
+        let state = makeAppState()
+        let p = seedProject(state)
+        state.unloadProject(UUID())
+        #expect(state.activeProjectID == p.id)
+        #expect(state.workspaces.count == 1)
+    }
+
+    @Test
+    func isProjectLoaded_false_without_views_or_workspace() {
+        let state = makeAppState()
+        #expect(!state.isProjectLoaded(UUID()))
+        let p = seedProject(state)
+        // Workspace exists but no pane has a view yet (nothing ever rendered).
+        #expect(!state.isProjectLoaded(p.id))
+    }
+
     // MARK: - Rename state
 
     @Test


### PR DESCRIPTION
## Why

When Macterm launches, every unfocused project sits in an unloaded state — its workspace exists in memory but no shells run until the project is focused. This PR lets users put a project back into that state manually, so an unused project's processes can be killed without removing the project or losing its layout.

## What

- **`AppState.unloadProject(_:)`** — performs the same snapshot → restore round-trip that quit/relaunch does: snapshots the workspace first (capturing each pane's live cwd), destroys every pane's surface, then swaps in the workspace rebuilt from that snapshot. Tab/split structure, custom titles, and tab IDs survive; shells respawn only when the project is selected again. Unloading the active project deselects it — leaving it active would let SwiftUI respawn the shells immediately.
- **`AppState.isProjectLoaded(_:)`** — predicate for whether there's anything to unload; drives the disabled/hidden state of all entry points.
- **Entry points** — sidebar project context menu ("Unload Project", above "Remove Project"), command palette ("Unload Current Project"), and the Project menu. All render from the new `AppCommand.unloadProject` case, so they can't drift.
- **Incubator leak fix** — `Pane.destroySurface()` now detaches the destroyed scroll view from its superview after the one-tick callback drain. Panes warmed off-screen by `SurfaceIncubator` were never removed from its hidden window, so their dead views couldn't deallocate — a pre-existing leak that would have quietly defeated unload's purpose.

## Tests

Six new `AppStateTests` cases: structure preserved with fresh pane IDs, view destruction + `isProjectLoaded` flip, active-project deselection, non-active unload leaving selection alone, unknown-ID no-op, and the predicate's false cases. Full suite passes; swiftformat/swiftlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)