### PR TITLE
feat: drag panes to reorganize splits, following Ghostty's grab-handle pattern

### DIFF
--- a/Macterm/Info.plist
+++ b/Macterm/Info.plist
@@ -68,5 +68,20 @@
 	<integer>86400</integer>
 	<key>SUAllowsAutomaticUpdates</key>
 	<true/>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.thdxg.macterm.pane-id</string>
+			<key>UTTypeDescription</key>
+			<string>Macterm Pane Identifier</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict/>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -4,6 +4,48 @@ import Foundation
 enum SplitDirection: String, Codable { case horizontal, vertical }
 enum SplitPosition { case first, second }
 
+/// Which edge of a pane a dragged pane is dropped onto. Determines how the
+/// destination is split and on which side the dragged pane lands.
+enum PaneDropZone: Equatable {
+    case left
+    case right
+    case top
+    case bottom
+
+    /// The drop zone for a cursor position inside a pane: the four triangular
+    /// regions formed by the pane's diagonals, i.e. whichever edge is closest.
+    static func calculate(at point: CGPoint, in size: CGSize) -> PaneDropZone {
+        guard size.width > 0, size.height > 0 else { return .right }
+        let distToLeft = point.x / size.width
+        let distToRight = 1 - distToLeft
+        let distToTop = point.y / size.height
+        let distToBottom = 1 - distToTop
+        let minDist = min(distToLeft, distToRight, distToTop, distToBottom)
+        if minDist == distToLeft { return .left }
+        if minDist == distToRight { return .right }
+        if minDist == distToTop { return .top }
+        return .bottom
+    }
+
+    var splitDirection: SplitDirection {
+        switch self {
+        case .left,
+             .right: .horizontal
+        case .top,
+             .bottom: .vertical
+        }
+    }
+
+    var splitPosition: SplitPosition {
+        switch self {
+        case .left,
+             .top: .first
+        case .right,
+             .bottom: .second
+        }
+    }
+}
+
 /// A pane is the leaf of the split tree — one terminal surface.
 @MainActor @Observable
 final class Pane: Identifiable {
@@ -273,6 +315,38 @@ extension SplitNode {
             )
             branch.second = newSecond
             return (.split(branch), id2)
+        }
+    }
+
+    /// Insert an existing pane next to the pane `destinationID`, wrapping the
+    /// destination in a new split with `pane` at `position`. The structural
+    /// counterpart of `splitting`, used to re-attach a pane during a
+    /// drag-and-drop move. Returns `inserted: false` (tree unchanged) when the
+    /// destination isn't in the tree.
+    func inserting(
+        pane: Pane,
+        at destinationID: UUID,
+        direction: SplitDirection,
+        position: SplitPosition
+    ) -> (node: SplitNode, inserted: Bool) {
+        switch self {
+        case let .pane(p) where p.id == destinationID:
+            let first: SplitNode = position == .first ? .pane(pane) : .pane(p)
+            let second: SplitNode = position == .first ? .pane(p) : .pane(pane)
+            return (.split(SplitBranch(direction: direction, first: first, second: second)), true)
+        case .pane:
+            return (self, false)
+        case let .split(branch):
+            let (newFirst, ok1) = branch.first.inserting(
+                pane: pane, at: destinationID, direction: direction, position: position
+            )
+            branch.first = newFirst
+            if ok1 { return (.split(branch), true) }
+            let (newSecond, ok2) = branch.second.inserting(
+                pane: pane, at: destinationID, direction: direction, position: position
+            )
+            branch.second = newSecond
+            return (.split(branch), ok2)
         }
     }
 

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -118,6 +118,30 @@ final class TerminalTab: Identifiable {
         splitRoot = splitRoot.resizing(paneID: paneID, direction: direction, delta: delta)
     }
 
+    /// Move a pane next to another pane (drag-and-drop reorganization):
+    /// detach it from its current spot — the tree collapses around it — and
+    /// split the destination, placing the moved pane on the `zone` side. The
+    /// `Pane` object is reused as-is, so its surface and shell are untouched.
+    /// Returns false (tree unchanged) for a self-drop, a pane the tree doesn't
+    /// contain, or the only pane in the tab.
+    @discardableResult
+    func movePane(_ paneID: UUID, onto destinationID: UUID, zone: PaneDropZone) -> Bool {
+        guard paneID != destinationID,
+              let pane = splitRoot.findPane(id: paneID),
+              splitRoot.findPane(id: destinationID) != nil,
+              let detached = splitRoot.removing(paneID: paneID)
+        else { return false }
+        let (newRoot, inserted) = detached.inserting(
+            pane: pane, at: destinationID, direction: zone.splitDirection, position: zone.splitPosition
+        )
+        guard inserted else { return false }
+        splitRoot = newRoot
+        zoomedPaneID = nil
+        focusPane(paneID)
+        if Preferences.shared.autoTilingEnabled { splitRoot.rebalanced() }
+        return true
+    }
+
     /// Remove a pane from the tree. Returns `.onlyPaneLeft` if the caller should
     /// close the whole tab (the pane was the last one), otherwise `.removed`.
     /// The pane's surface is destroyed in both cases.

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -215,7 +215,12 @@ struct WorkspaceView: View {
                     appState.saveWorkspaces()
                 },
                 onClosePane: { appState.requestClosePane($0, projectID: project.id) },
-                onToggleZoom: { tab.toggleZoom(paneID: $0) }
+                onToggleZoom: { tab.toggleZoom(paneID: $0) },
+                onMovePane: { source, destination, zone in
+                    if tab.movePane(source, onto: destination, zone: zone) {
+                        appState.saveWorkspaces()
+                    }
+                }
             )
             .id(renderedNode.id)
             .overlay(alignment: .topTrailing) {

--- a/Macterm/Views/PaneDragDrop.swift
+++ b/Macterm/Views/PaneDragDrop.swift
@@ -1,0 +1,360 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+// Drag-and-drop pane reorganization, following Ghostty's pattern: each pane
+// shows a small grab handle at its top center (revealed while the pointer is
+// in the pane's top band). Dragging the handle starts an `NSDraggingSession`
+// carrying the pane's UUID; every other pane is a drop target split into four
+// triangular edge zones, highlighting the half where the dragged pane will
+// land. The drop is handled by `TerminalTab.movePane` — the `Pane` object
+// (and its live surface) is reused, only the tree is reshaped.
+
+extension UTType {
+    /// In-app drag payload identifying the pane being moved: its UUID bytes.
+    static let mactermPaneID = UTType(exportedAs: "com.thdxg.macterm.pane-id")
+}
+
+extension NSPasteboard.PasteboardType {
+    static let mactermPaneID = NSPasteboard.PasteboardType(UTType.mactermPaneID.identifier)
+}
+
+/// Propagates the ID of the pane currently being dragged (nil when idle) from
+/// the grab handle up to its own leaf, so the source pane can disable its drop
+/// target — a drop on itself is meaningless, and an invalid drop should
+/// animate back to where it started.
+struct DraggingPaneKey: PreferenceKey {
+    static let defaultValue: UUID? = nil
+
+    static func reduce(value: inout UUID?, nextValue: () -> UUID?) {
+        value = nextValue() ?? value
+    }
+}
+
+// MARK: - Grab handle
+
+/// The grab handle overlay for one pane. Only the small pill itself is
+/// hit-testable; the reveal band underneath passes all clicks through to the
+/// terminal (see `PaneHoverSensor`).
+struct PaneGrabHandle: View {
+    private static let handleSize = CGSize(width: 80, height: 12)
+    /// Reveal the handle while the pointer is in the top fraction of the pane.
+    private static let hoverBandFactor: CGFloat = 0.2
+
+    let pane: Pane
+
+    @State private var inRevealBand = false
+    @State private var isHovering = false
+    @State private var isDragging = false
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .top) {
+                PaneHoverSensor(isInside: $inRevealBand)
+                    .frame(height: min(geo.size.height, max(Self.handleSize.height, geo.size.height * Self.hoverBandFactor)))
+                    .frame(maxHeight: .infinity, alignment: .top)
+
+                ZStack {
+                    PaneDragSource(pane: pane, isDragging: $isDragging, isHovering: $isHovering)
+                        .frame(width: Self.handleSize.width, height: Self.handleSize.height)
+
+                    if inRevealBand || isHovering || isDragging {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(MactermTheme.fg.opacity(isHovering || isDragging ? 0.8 : 0.35))
+                            .allowsHitTesting(false)
+                            .transition(.opacity)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+        .preference(key: DraggingPaneKey.self, value: isDragging ? pane.id : nil)
+    }
+}
+
+/// An invisible band that reports pointer presence without participating in
+/// hit testing: `hitTest` returns nil so clicks reach the terminal underneath,
+/// while the tracking area still delivers entered/exited events (tracking
+/// areas bypass hit testing).
+private struct PaneHoverSensor: NSViewRepresentable {
+    @Binding var isInside: Bool
+
+    func makeNSView(context _: Context) -> SensorView {
+        let view = SensorView()
+        view.onChange = { isInside = $0 }
+        return view
+    }
+
+    func updateNSView(_ view: SensorView, context _: Context) {
+        view.onChange = { isInside = $0 }
+    }
+
+    final class SensorView: NSView {
+        var onChange: ((Bool) -> Void)?
+
+        override func hitTest(_: NSPoint) -> NSView? {
+            nil
+        }
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            trackingAreas.forEach { removeTrackingArea($0) }
+            addTrackingArea(NSTrackingArea(
+                rect: .zero,
+                options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            ))
+        }
+
+        override func mouseEntered(with _: NSEvent) {
+            onChange?(true)
+        }
+
+        override func mouseExited(with _: NSEvent) {
+            onChange?(false)
+        }
+    }
+}
+
+// MARK: - Drag source
+
+/// AppKit-backed drag source: starting the drag through an `NSDraggingSession`
+/// (instead of SwiftUI's `.onDrag`) lets us consume the mouseDown so the grab
+/// handle doesn't move the window, show open/closed-hand cursors, and use a
+/// live snapshot of the pane as the drag image.
+private struct PaneDragSource: NSViewRepresentable {
+    let pane: Pane
+    @Binding var isDragging: Bool
+    @Binding var isHovering: Bool
+
+    func makeNSView(context _: Context) -> DragSourceView {
+        let view = DragSourceView()
+        configure(view)
+        return view
+    }
+
+    func updateNSView(_ view: DragSourceView, context _: Context) {
+        configure(view)
+    }
+
+    private func configure(_ view: DragSourceView) {
+        view.pane = pane
+        view.onDragStateChanged = { dragging in
+            withAnimation(.easeInOut(duration: 0.15)) { isDragging = dragging }
+        }
+        view.onHoverChanged = { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) { isHovering = hovering }
+        }
+    }
+
+    final class DragSourceView: NSView, NSDraggingSource {
+        /// Scale applied to the pane snapshot for the drag preview image.
+        private static let previewScale: CGFloat = 0.2
+
+        var pane: Pane?
+        var onDragStateChanged: ((Bool) -> Void)?
+        var onHoverChanged: ((Bool) -> Void)?
+
+        /// True while a drag session is in flight; drives the cursor rect.
+        private var isTracking = false
+
+        override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+            true
+        }
+
+        override func mouseDown(with _: NSEvent) {
+            // Consume the press so it can't fall through to the window's drag
+            // region (which would move the window instead of the pane). The
+            // drag itself starts in mouseDragged.
+        }
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            trackingAreas.forEach { removeTrackingArea($0) }
+            addTrackingArea(NSTrackingArea(
+                rect: .zero,
+                options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            ))
+        }
+
+        override func resetCursorRects() {
+            addCursorRect(bounds, cursor: isTracking ? .closedHand : .openHand)
+        }
+
+        override func mouseEntered(with _: NSEvent) {
+            onHoverChanged?(true)
+        }
+
+        override func mouseExited(with _: NSEvent) {
+            onHoverChanged?(false)
+        }
+
+        override func mouseDragged(with event: NSEvent) {
+            guard !isTracking, let pane else { return }
+
+            let pasteboardItem = NSPasteboardItem()
+            pasteboardItem.setData(
+                withUnsafeBytes(of: pane.id.uuid) { Data($0) },
+                forType: .mactermPaneID
+            )
+            let item = NSDraggingItem(pasteboardWriter: pasteboardItem)
+
+            let image = dragPreviewImage(for: pane)
+            // Center the image on the cursor, matching native macOS tab drags.
+            let mouse = convert(event.locationInWindow, from: nil)
+            item.setDraggingFrame(
+                NSRect(
+                    x: mouse.x - image.size.width / 2,
+                    y: mouse.y - image.size.height / 2,
+                    width: image.size.width,
+                    height: image.size.height
+                ),
+                contents: image
+            )
+
+            onDragStateChanged?(true)
+            beginDraggingSession(with: [item], event: event, source: self)
+        }
+
+        /// A scaled live snapshot of the pane's surface; falls back to a plain
+        /// theme-colored card if the view can't render one.
+        private func dragPreviewImage(for pane: Pane) -> NSImage {
+            if let view = pane.nsView, !view.bounds.isEmpty,
+               let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds)
+            {
+                view.cacheDisplay(in: view.bounds, to: rep)
+                let snapshot = NSImage(size: view.bounds.size)
+                snapshot.addRepresentation(rep)
+                let size = NSSize(
+                    width: snapshot.size.width * Self.previewScale,
+                    height: snapshot.size.height * Self.previewScale
+                )
+                return NSImage(size: size, flipped: false) { rect in
+                    snapshot.draw(in: rect, from: NSRect(origin: .zero, size: snapshot.size), operation: .copy, fraction: 1)
+                    return true
+                }
+            }
+            let bg = MactermTheme.nsBg
+            return NSImage(size: NSSize(width: 160, height: 100), flipped: false) { rect in
+                let path = NSBezierPath(roundedRect: rect.insetBy(dx: 1, dy: 1), xRadius: 6, yRadius: 6)
+                bg.setFill()
+                path.fill()
+                NSColor.separatorColor.setStroke()
+                path.stroke()
+                return true
+            }
+        }
+
+        // MARK: NSDraggingSource
+
+        nonisolated func draggingSession(
+            _: NSDraggingSession,
+            sourceOperationMaskFor context: NSDraggingContext
+        ) -> NSDragOperation {
+            context == .withinApplication ? .move : []
+        }
+
+        nonisolated func draggingSession(_: NSDraggingSession, willBeginAt _: NSPoint) {
+            MainActor.assumeIsolated {
+                isTracking = true
+                window?.invalidateCursorRects(for: self)
+            }
+        }
+
+        nonisolated func draggingSession(_: NSDraggingSession, movedTo _: NSPoint) {
+            MainActor.assumeIsolated { NSCursor.closedHand.set() }
+        }
+
+        nonisolated func draggingSession(_: NSDraggingSession, endedAt _: NSPoint, operation _: NSDragOperation) {
+            MainActor.assumeIsolated {
+                isTracking = false
+                window?.invalidateCursorRects(for: self)
+                onDragStateChanged?(false)
+            }
+        }
+    }
+}
+
+// MARK: - Drop target
+
+enum PaneDropState: Equatable {
+    case idle
+    case dropping(PaneDropZone)
+}
+
+/// Per-pane drop target. The zone follows the cursor; the actual move is
+/// performed by `onMove(sourcePaneID, destinationPaneID, zone)`.
+struct PaneDropDelegate: DropDelegate {
+    @Binding var dropState: PaneDropState
+    let viewSize: CGSize
+    let destinationPaneID: UUID
+    let onMove: @MainActor (UUID, UUID, PaneDropZone) -> Void
+
+    func validateDrop(info: DropInfo) -> Bool {
+        info.hasItemsConforming(to: [.mactermPaneID])
+    }
+
+    func dropEntered(info: DropInfo) {
+        dropState = .dropping(.calculate(at: info.location, in: viewSize))
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        // dropUpdated can fire after performDrop; without this guard it would
+        // re-show the zone highlight on a completed drop.
+        guard case .dropping = dropState else { return DropProposal(operation: .forbidden) }
+        dropState = .dropping(.calculate(at: info.location, in: viewSize))
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info _: DropInfo) {
+        dropState = .idle
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let zone = PaneDropZone.calculate(at: info.location, in: viewSize)
+        dropState = .idle
+
+        // This drag never leaves the app (sourceOperationMask is .move only
+        // within the application), so the payload can be read synchronously
+        // off the drag pasteboard instead of round-tripping through the
+        // NSItemProvider's background-queue loader.
+        guard let data = NSPasteboard(name: .drag).pasteboardItems?
+            .compactMap({ $0.data(forType: .mactermPaneID) })
+            .first, data.count == 16
+        else { return false }
+        let sourceID = data.withUnsafeBytes { UUID(uuid: $0.loadUnaligned(as: uuid_t.self)) }
+        guard sourceID != destinationPaneID else { return false }
+
+        MainActor.assumeIsolated {
+            onMove(sourceID, destinationPaneID, zone)
+        }
+        return true
+    }
+}
+
+extension PaneDropZone {
+    /// The half of the destination pane the dragged pane would occupy.
+    @MainActor
+    func highlight(in size: CGSize) -> some View {
+        Rectangle()
+            .fill(MactermTheme.accent.opacity(0.3))
+            .frame(
+                width: splitDirection == .horizontal ? size.width / 2 : nil,
+                height: splitDirection == .vertical ? size.height / 2 : nil
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
+    }
+
+    private var alignment: Alignment {
+        switch self {
+        case .left: .leading
+        case .right: .trailing
+        case .top: .top
+        case .bottom: .bottom
+        }
+    }
+}

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -418,7 +418,10 @@ private struct QuickTerminalView: View {
             onFocusPane: { state.focusPane($0) },
             onSplit: { paneID, dir in state.split(paneID: paneID, direction: dir) },
             onClosePane: { state.closePane($0) },
-            onToggleZoom: { state.tab.toggleZoom(paneID: $0) }
+            onToggleZoom: { state.tab.toggleZoom(paneID: $0) },
+            onMovePane: { source, destination, zone in
+                state.tab.movePane(source, onto: destination, zone: zone)
+            }
         )
         .id(renderedNode.id)
         .background(MactermTheme.bgWithOpacity)

--- a/Macterm/Views/SplitTreeView.swift
+++ b/Macterm/Views/SplitTreeView.swift
@@ -13,6 +13,7 @@ struct SplitTreeView: View {
     let onSplit: (UUID, SplitDirection) -> Void
     let onClosePane: (UUID) -> Void
     let onToggleZoom: (UUID) -> Void
+    let onMovePane: @MainActor (UUID, UUID, PaneDropZone) -> Void
 
     init(
         node: SplitNode,
@@ -24,7 +25,8 @@ struct SplitTreeView: View {
         onFocusPane: @escaping (UUID) -> Void,
         onSplit: @escaping (UUID, SplitDirection) -> Void,
         onClosePane: @escaping (UUID) -> Void,
-        onToggleZoom: @escaping (UUID) -> Void = { _ in }
+        onToggleZoom: @escaping (UUID) -> Void = { _ in },
+        onMovePane: @escaping @MainActor (UUID, UUID, PaneDropZone) -> Void = { _, _, _ in }
     ) {
         self.node = node
         self.focusedPaneID = focusedPaneID
@@ -36,27 +38,23 @@ struct SplitTreeView: View {
         self.onSplit = onSplit
         self.onClosePane = onClosePane
         self.onToggleZoom = onToggleZoom
+        self.onMovePane = onMovePane
     }
 
     var body: some View {
         switch node {
         case let .pane(pane):
-            let isFocused = focusedPaneID == pane.id && isActiveProject
-            TerminalPane(
+            SplitLeafView(
                 pane: pane,
-                focused: isFocused,
+                isFocused: focusedPaneID == pane.id && isActiveProject,
                 isZoomed: zoomedPaneID == pane.id,
+                isSplit: isSplit,
                 onFocus: { onFocusPane(pane.id) },
                 onProcessExit: { onClosePane(pane.id) },
-                onSplitRequest: { dir, _ in onSplit(pane.id, dir) },
-                onZoomRequest: { onToggleZoom(pane.id) }
+                onSplitRequest: { dir in onSplit(pane.id, dir) },
+                onZoomRequest: { onToggleZoom(pane.id) },
+                onMovePane: onMovePane
             )
-            .overlay {
-                if !isFocused, isSplit {
-                    Color.black.opacity(0.2)
-                        .allowsHitTesting(false)
-                }
-            }
 
         case let .split(branch):
             SplitDividerView(branch: branch) {
@@ -70,7 +68,8 @@ struct SplitTreeView: View {
                     onFocusPane: onFocusPane,
                     onSplit: onSplit,
                     onClosePane: onClosePane,
-                    onToggleZoom: onToggleZoom
+                    onToggleZoom: onToggleZoom,
+                    onMovePane: onMovePane
                 )
                 .id(branch.first.id)
             } second: {
@@ -84,9 +83,83 @@ struct SplitTreeView: View {
                     onFocusPane: onFocusPane,
                     onSplit: onSplit,
                     onClosePane: onClosePane,
-                    onToggleZoom: onToggleZoom
+                    onToggleZoom: onToggleZoom,
+                    onMovePane: onMovePane
                 )
                 .id(branch.second.id)
+            }
+        }
+    }
+}
+
+/// One leaf of the split tree: the terminal pane plus its drag-and-drop
+/// chrome — the grab handle that starts a pane drag, and the drop target that
+/// highlights which half of this pane a dragged pane would land in.
+private struct SplitLeafView: View {
+    let pane: Pane
+    let isFocused: Bool
+    let isZoomed: Bool
+    let isSplit: Bool
+    let onFocus: () -> Void
+    let onProcessExit: () -> Void
+    let onSplitRequest: (SplitDirection) -> Void
+    let onZoomRequest: () -> Void
+    let onMovePane: @MainActor (UUID, UUID, PaneDropZone) -> Void
+
+    @State private var dropState: PaneDropState = .idle
+    @State private var draggingPaneID: UUID?
+
+    /// True while this pane's own grab handle is being dragged. The source
+    /// pane is not a drop target: dropping a pane on itself is meaningless,
+    /// and leaving it invalid lets a released drag animate back to its origin.
+    private var isSelfDragging: Bool { draggingPaneID == pane.id }
+
+    var body: some View {
+        GeometryReader { geo in
+            TerminalPane(
+                pane: pane,
+                focused: isFocused,
+                isZoomed: isZoomed,
+                onFocus: onFocus,
+                onProcessExit: onProcessExit,
+                onSplitRequest: { dir, _ in onSplitRequest(dir) },
+                onZoomRequest: onZoomRequest
+            )
+            .overlay {
+                if !isFocused, isSplit {
+                    Color.black.opacity(0.2)
+                        .allowsHitTesting(false)
+                }
+            }
+            .background {
+                if !isSelfDragging {
+                    Color.clear
+                        .onDrop(of: [.mactermPaneID], delegate: PaneDropDelegate(
+                            dropState: $dropState,
+                            viewSize: geo.size,
+                            destinationPaneID: pane.id,
+                            onMove: onMovePane
+                        ))
+                }
+            }
+            .overlay {
+                if !isSelfDragging, case let .dropping(zone) = dropState {
+                    zone.highlight(in: geo.size)
+                        .allowsHitTesting(false)
+                }
+            }
+            .overlay {
+                // Dragging the only pane of a tab has nowhere to go — the
+                // handle only exists once the tab is split.
+                if isSplit {
+                    PaneGrabHandle(pane: pane)
+                }
+            }
+            .onPreferenceChange(DraggingPaneKey.self) { value in
+                MainActor.assumeIsolated {
+                    draggingPaneID = value
+                    if value == pane.id { dropState = .idle }
+                }
             }
         }
     }

--- a/MactermTests/Model/SplitNodeTests.swift
+++ b/MactermTests/Model/SplitNodeTests.swift
@@ -116,6 +116,78 @@ struct SplitNodeTests {
         #expect(try render(#require(after), ids: ids) == "H(a, b)")
     }
 
+    // MARK: - inserting
+
+    @Test
+    func inserting_first_position_places_pane_before_destination() throws {
+        let (tree, builtIDs) = build(H(pane("a"), pane("b")))
+        let moved = Pane(projectPath: "/", projectID: UUID())
+        var ids = builtIDs
+        ids["m"] = moved.id
+        let (after, inserted) = try tree.inserting(
+            pane: moved, at: #require(ids["b"]), direction: .vertical, position: .first
+        )
+        #expect(inserted)
+        #expect(render(after, ids: ids) == "H(a, V(m, b))")
+    }
+
+    @Test
+    func inserting_second_position_places_pane_after_destination() throws {
+        let (tree, builtIDs) = build(H(pane("a"), pane("b")))
+        let moved = Pane(projectPath: "/", projectID: UUID())
+        var ids = builtIDs
+        ids["m"] = moved.id
+        let (after, inserted) = try tree.inserting(
+            pane: moved, at: #require(ids["a"]), direction: .horizontal, position: .second
+        )
+        #expect(inserted)
+        #expect(render(after, ids: ids) == "H(H(a, m), b)")
+    }
+
+    @Test
+    func inserting_reuses_pane_instance() throws {
+        let (tree, ids) = build(pane("a"))
+        let moved = Pane(projectPath: "/", projectID: UUID())
+        let (after, _) = try tree.inserting(
+            pane: moved, at: #require(ids["a"]), direction: .horizontal, position: .second
+        )
+        #expect(after.findPane(id: moved.id) === moved)
+    }
+
+    @Test
+    func inserting_at_missing_destination_is_noop() {
+        let (tree, ids) = build(H(pane("a"), pane("b")))
+        let moved = Pane(projectPath: "/", projectID: UUID())
+        let (after, inserted) = tree.inserting(
+            pane: moved, at: UUID(), direction: .horizontal, position: .second
+        )
+        #expect(!inserted)
+        #expect(render(after, ids: ids) == "H(a, b)")
+    }
+
+    // MARK: - PaneDropZone
+
+    @Test
+    func dropZone_picks_nearest_edge() {
+        let size = CGSize(width: 100, height: 100)
+        #expect(PaneDropZone.calculate(at: CGPoint(x: 10, y: 50), in: size) == .left)
+        #expect(PaneDropZone.calculate(at: CGPoint(x: 90, y: 50), in: size) == .right)
+        #expect(PaneDropZone.calculate(at: CGPoint(x: 50, y: 10), in: size) == .top)
+        #expect(PaneDropZone.calculate(at: CGPoint(x: 50, y: 90), in: size) == .bottom)
+    }
+
+    @Test
+    func dropZone_maps_to_split_direction_and_position() {
+        #expect(PaneDropZone.left.splitDirection == .horizontal)
+        #expect(PaneDropZone.left.splitPosition == .first)
+        #expect(PaneDropZone.right.splitDirection == .horizontal)
+        #expect(PaneDropZone.right.splitPosition == .second)
+        #expect(PaneDropZone.top.splitDirection == .vertical)
+        #expect(PaneDropZone.top.splitPosition == .first)
+        #expect(PaneDropZone.bottom.splitDirection == .vertical)
+        #expect(PaneDropZone.bottom.splitPosition == .second)
+    }
+
     // MARK: - findPane / contains / allPanes
 
     @Test

--- a/MactermTests/Model/TerminalTabTests.swift
+++ b/MactermTests/Model/TerminalTabTests.swift
@@ -240,6 +240,71 @@ struct TerminalTabTests {
         #expect(try !tab.paneFocusHistory.items.contains(#require(ids["b"])))
     }
 
+    // MARK: - movePane
+
+    @Test
+    func movePane_detaches_and_splits_destination() throws {
+        let (tab, ids) = makeTab(H(pane("a"), V(pane("b"), pane("c"))), focused: "a")
+        #expect(try tab.movePane(#require(ids["a"]), onto: #require(ids["c"]), zone: .right))
+        #expect(render(tab.splitRoot, ids: ids) == "V(b, H(c, a))")
+    }
+
+    @Test
+    func movePane_top_zone_places_pane_before_destination() throws {
+        let (tab, ids) = makeTab(H(pane("a"), V(pane("b"), pane("c"))), focused: "a")
+        #expect(try tab.movePane(#require(ids["a"]), onto: #require(ids["b"]), zone: .top))
+        #expect(render(tab.splitRoot, ids: ids) == "V(V(a, b), c)")
+    }
+
+    @Test
+    func movePane_reuses_pane_instance() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        let aID = try #require(ids["a"])
+        let before = try #require(tab.splitRoot.findPane(id: aID))
+        #expect(try tab.movePane(aID, onto: #require(ids["b"]), zone: .bottom))
+        #expect(tab.splitRoot.findPane(id: aID) === before)
+    }
+
+    @Test
+    func movePane_onto_sibling_swaps_sides() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        #expect(try tab.movePane(#require(ids["a"]), onto: #require(ids["b"]), zone: .right))
+        #expect(render(tab.splitRoot, ids: ids) == "H(b, a)")
+    }
+
+    @Test
+    func movePane_focuses_moved_pane_and_clears_zoom() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "b")
+        let aID = try #require(ids["a"])
+        try tab.toggleZoom(paneID: #require(ids["b"]))
+        #expect(try tab.movePane(aID, onto: #require(ids["b"]), zone: .top))
+        #expect(tab.focusedPaneID == aID)
+        #expect(tab.zoomedPaneID == nil)
+    }
+
+    @Test
+    func movePane_onto_self_is_noop() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        let aID = try #require(ids["a"])
+        #expect(!tab.movePane(aID, onto: aID, zone: .left))
+        #expect(render(tab.splitRoot, ids: ids) == "H(a, b)")
+    }
+
+    @Test
+    func movePane_only_pane_is_noop() throws {
+        let (tab, ids) = makeTab(pane("a"), focused: "a")
+        #expect(try !tab.movePane(#require(ids["a"]), onto: UUID(), zone: .left))
+        #expect(render(tab.splitRoot, ids: ids) == "a")
+    }
+
+    @Test
+    func movePane_unknown_source_or_destination_is_noop() throws {
+        let (tab, ids) = makeTab(H(pane("a"), pane("b")), focused: "a")
+        #expect(try !tab.movePane(UUID(), onto: #require(ids["b"]), zone: .left))
+        #expect(try !tab.movePane(#require(ids["a"]), onto: UUID(), zone: .left))
+        #expect(render(tab.splitRoot, ids: ids) == "H(a, b)")
+    }
+
     // MARK: - autoTitle / sidebarTitle / customTitle
 
     @Test


### PR DESCRIPTION
Adds Ghostty-style drag-and-drop pane reorganization: hovering the top band of a pane reveals a small grab handle (`⋯`) at its top center; dragging it onto another pane highlights the half where the pane will land (nearest-edge left/right/top/bottom zones) and dropping moves it there. The moved `Pane` object is reused as-is, so its surface and shell process are untouched — only the split tree is reshaped.

## How it works

- **Model** — `PaneDropZone` (nearest-edge zone math, mapped to split direction/position) and `SplitNode.inserting(pane:at:...)`, the structural counterpart of `splitting` that re-attaches an existing pane. `TerminalTab.movePane(_:onto:zone:)` detaches the pane (tree collapses around it), splits the destination with the pane on the zone's side, focuses the moved pane, clears zoom, and respects auto-tiling.
- **Views** (`PaneDragDrop.swift`) — mirrors Ghostty's implementation:
  - Grab handle revealed by a hover band that passes clicks through to the terminal (a `hitTest`-nil tracking view), shown only when the tab is split (single-window app: dragging the only pane has nowhere to go).
  - AppKit `NSDraggingSession` drag source carrying the pane UUID on the pasteboard, with a scaled live snapshot as the drag image; consumes mouseDown so the handle can't drag the window.
  - Per-pane drop targets with triangular edge zones and an accent half-pane highlight. The source pane disables its own drop target during the drag, so an invalid drop animates back to its origin.
- **Wiring** — `SplitTreeView` leaves gained the handle + drop chrome; the main window persists after a successful move, the quick terminal gets the same behavior without persistence.
- **Info.plist** — the drag payload UTI (`com.thdxg.macterm.pane-id`) must be declared in `UTExportedTypeDeclarations` (conforming to `public.data`), or the drop targets' type-conformance check never matches and every pane refuses the drop. Ghostty does the same for `ghosttySurfaceId`.

The terminal NSView's existing `draggingEntered` guard already returns `[]` for non-text pasteboards, so pane drags fall through to the SwiftUI drop target underneath.

## Testing

- Unit tests for `SplitNode.inserting`, `PaneDropZone` zone math/mapping, and `TerminalTab.movePane` (move, sibling swap, focus/zoom behavior, self-drop and only-pane no-ops).
- Verified manually: handle reveal, drag preview, zone highlights, drops in all four zones, cross-subtree moves, quick terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)