### PR TITLE
fix: lock the toolbar to icon-only so the sidebar toggle can't fold into the overflow menu

### DIFF
--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -228,6 +228,21 @@ enum WindowAppearance {
         // window is). Without this the titlebar paints its own material
         // and you get a visible seam at y=titlebarHeight.
         syncTitlebar(window: window, isTransparent: effectiveTransparent)
+
+        syncToolbar(window: window)
+    }
+
+    /// Lock the toolbar to icon-only rendering. SwiftUI's NavigationSplitView
+    /// toolbar doesn't survive the label display modes: picking "Icon and
+    /// Text" from the toolbar's context menu makes AppKit fold the system
+    /// sidebar-toggle item into the overflow (») menu at the trailing edge
+    /// and grows the titlebar without showing any useful labels. Disabling
+    /// display-mode customization removes those context-menu items; forcing
+    /// `.iconOnly` repairs a mode picked before the lock existed.
+    private static func syncToolbar(window: NSWindow) {
+        guard let toolbar = window.toolbar else { return }
+        if toolbar.displayMode != .iconOnly { toolbar.displayMode = .iconOnly }
+        toolbar.allowsDisplayModeCustomization = false
     }
 
     /// Update the inactive-glass tint when the window gains/loses key status.


### PR DESCRIPTION
## What

Right-clicking the toolbar offered **Icon and Text** / **Icon Only** / **Text Only** display modes. Picking *Icon and Text* broke the toolbar: the sidebar toggle disappeared from its top-left spot and folded into the overflow (») menu at the trailing edge, and the titlebar grew taller without showing any useful labels.

This locks the toolbar to icon-only rendering and removes those context-menu options via `NSToolbar.allowsDisplayModeCustomization = false`.

## Why

The breakage is a framework-level issue, not something we can style around: `NavigationSplitView` owns the sidebar-toggle toolbar item, and SwiftUI's toolbar items misreport their size in the label display modes, so AppKit folds the toggle into overflow even with plenty of room. Reproduced and confirmed by opening the overflow menu — “Hide Sidebar” was inside it.

`allowsDisplayModeCustomization` is the macOS 15+ API Apple added for exactly this case (apps whose unified toolbars don't support text labels opt out — Notes, Reminders, etc. don't offer the menu at all). Forcing `displayMode = .iconOnly` additionally repairs the state for anyone who already switched modes before the lock existed.

## How

A new `syncToolbar(window:)` in `WindowAppearance`, called from `WindowAppearance.sync` — which already re-applies window chrome idempotently on launch, become-main, fullscreen transitions, and config changes, so the lock applies once the toolbar exists and stays applied if AppKit rebuilds it.

## Verified

- Reproduced the bug pre-fix via the toolbar context menu (toggle folded into », taller titlebar).
- Post-fix: toolbar renders icon-only, right-clicking the toolbar shows no display-mode menu, and the sidebar toggle still collapses/expands the sidebar from its normal spot.
- `mise run format`, `lint`, and `test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)