### PR TITLE
Lower minimum macOS to 14 (Sonoma)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ mise run build        # Release build + DMG
 
 `format`, `lint`, and `test` show a spinner and print output only on failure. **Always pass `--verbose`** (e.g. `mise run test --verbose`) to stream the raw output.
 
-Requires macOS 26+, Swift 6.0+. GhosttyKit is a pre-built xcframework from `thdxg/ghostty` (a fork that adds CI builds); no zig toolchain needed.
+Requires macOS 14+, Swift 6.0+. Liquid glass and a few chrome refinements are macOS 26 (Tahoe) features that degrade gracefully on older systems (gated behind `WindowAppearance.glassSupported` / `#available`). GhosttyKit is a pre-built xcframework from `thdxg/ghostty` (a fork that adds CI builds); no zig toolchain needed.
 
 `GhosttyKit.xcframework` and the `Macterm/Resources/{ghostty,terminfo,…}` contents are gitignored artifacts downloaded by `mise run setup` — **every fresh checkout, including a git worktree, must run `mise run setup`** before it can build. Don't symlink them from another checkout: `setup.sh` only re-downloads when the artifact is _absent_ (presence check, not version check), so a symlinked copy silently goes stale. To refresh a stale artifact, delete it and re-run setup.
 
@@ -121,7 +121,7 @@ One `XxxTests.swift` per production type, mirroring the source path. `@testable 
 
 - **Always use native SwiftUI/AppKit components.** Never mimic native behavior with custom implementations. If a native component has a limitation, accept it rather than building a workaround.
 - All colors come from `MactermTheme` (derived from the ghostty theme config). No hardcoded colors.
-- Targets macOS 26 (Tahoe) with liquid glass appearance.
+- Minimum target is macOS 14; the liquid glass appearance is a macOS 26 (Tahoe) enhancement, gated so older systems fall back to native materials/blur. Gate any new Tahoe-only API behind `#available(macOS 26.0, *)` and, for user-facing controls, `WindowAppearance.glassSupported`.
 
 ### Terminal Surface Rules
 

--- a/Macterm/Info.plist
+++ b/Macterm/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>26.0</string>
+	<string>14.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -202,21 +202,26 @@ private struct AppearanceSettings: View {
                     Preferences.shared.windowOpacity = v
                 }
 
-                Toggle("Liquid Glass", isOn: $liquidGlass)
-                    .onChange(of: liquidGlass) { _, v in
-                        Preferences.shared.windowGlassEnabled = v
-                    }
-                    .disabled(backgroundOpacity >= 0.999)
+                // Liquid glass (NSGlassEffectView) exists only on macOS 26+;
+                // hide the controls entirely on older systems where they'd be
+                // inert rather than show dead toggles.
+                if WindowAppearance.glassSupported {
+                    Toggle("Liquid Glass", isOn: $liquidGlass)
+                        .onChange(of: liquidGlass) { _, v in
+                            Preferences.shared.windowGlassEnabled = v
+                        }
+                        .disabled(backgroundOpacity >= 0.999)
 
-                Picker("Glass Style", selection: $liquidGlassStyle) {
-                    ForEach(WindowGlassStyle.allCases) { style in
-                        Text(style.displayName).tag(style)
+                    Picker("Glass Style", selection: $liquidGlassStyle) {
+                        ForEach(WindowGlassStyle.allCases) { style in
+                            Text(style.displayName).tag(style)
+                        }
                     }
+                    .onChange(of: liquidGlassStyle) { _, v in
+                        Preferences.shared.windowGlassStyle = v
+                    }
+                    .disabled(backgroundOpacity >= 0.999 || !liquidGlass)
                 }
-                .onChange(of: liquidGlassStyle) { _, v in
-                    Preferences.shared.windowGlassStyle = v
-                }
-                .disabled(backgroundOpacity >= 0.999 || !liquidGlass)
 
                 HStack {
                     Text("Background Blur")
@@ -276,7 +281,9 @@ private struct AppearanceSettings: View {
 
     private var blurFootnote: String {
         if backgroundOpacity >= 0.999 {
-            return "Blur and Liquid Glass only take effect when opacity is below 100%."
+            return WindowAppearance.glassSupported
+                ? "Blur and Liquid Glass only take effect when opacity is below 100%."
+                : "Blur only takes effect when opacity is below 100%."
         }
         if liquidGlass {
             return "Liquid Glass uses the macOS material (blur slider ignored). Regular is frostier; Clear is more transparent."

--- a/Macterm/Views/CommandPalette.swift
+++ b/Macterm/Views/CommandPalette.swift
@@ -26,7 +26,7 @@ struct CommandPaletteOverlay: View {
 
                 CommandPalettePanel()
                     .frame(width: 500)
-                    .glassEffect(in: .rect(cornerRadius: Self.cornerRadius))
+                    .paletteBackground(cornerRadius: Self.cornerRadius)
                     .overlay(
                         RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
                             .strokeBorder(MactermTheme.border, lineWidth: 1)
@@ -35,6 +35,18 @@ struct CommandPaletteOverlay: View {
                     .padding(.top, geo.size.height * 0.15)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+private extension View {
+    /// Liquid glass on macOS 26; the closest native material on older systems.
+    @ViewBuilder
+    func paletteBackground(cornerRadius: CGFloat) -> some View {
+        if #available(macOS 26.0, *) {
+            glassEffect(in: .rect(cornerRadius: cornerRadius))
+        } else {
+            background(.regularMaterial, in: .rect(cornerRadius: cornerRadius))
         }
     }
 }

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -242,7 +242,9 @@ enum WindowAppearance {
     private static func syncToolbar(window: NSWindow) {
         guard let toolbar = window.toolbar else { return }
         if toolbar.displayMode != .iconOnly { toolbar.displayMode = .iconOnly }
-        toolbar.allowsDisplayModeCustomization = false
+        if #available(macOS 15.0, *) {
+            toolbar.allowsDisplayModeCustomization = false
+        }
     }
 
     /// Update the inactive-glass tint when the window gains/loses key status.
@@ -255,7 +257,9 @@ enum WindowAppearance {
         }
     }
 
-    private static var glassSupported: Bool {
+    /// Liquid glass (`NSGlassEffectView`) exists only on macOS 26+. Drives both
+    /// the runtime appearance path and the Settings UI's glass controls.
+    static var glassSupported: Bool {
         if #available(macOS 26.0, *) { return true }
         return false
     }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://github.com/thdxg/macterm/actions/workflows/checks.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/thdxg/macterm/checks.yml?branch=main&label=checks" alt="CI status" />
   </a>
-  <img src="https://img.shields.io/badge/macOS-26%2B-black?logo=apple" alt="macOS 26+" />
+  <img src="https://img.shields.io/badge/macOS-14%2B-black?logo=apple" alt="macOS 14+" />
 </p>
 
 ![screenshot](./assets/screenshot.png)

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: Macterm
 options:
   bundleIdPrefix: com.thdxg
   deploymentTarget:
-    macOS: "26.0"
+    macOS: "14.0"
   createIntermediateGroups: true
   defaultConfig: Release
   generateEmptyDirectories: true
@@ -15,7 +15,7 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     SDKROOT: macosx
-    MACOSX_DEPLOYMENT_TARGET: "26.0"
+    MACOSX_DEPLOYMENT_TARGET: "14.0"
     ARCHS: arm64
     ONLY_ACTIVE_ARCH: NO
     SWIFT_STRICT_CONCURRENCY: complete

--- a/scripts/publish-appcast.sh
+++ b/scripts/publish-appcast.sh
@@ -78,7 +78,7 @@ for dmg in "$DMG_DIR"/*.dmg; do
       <pubDate>${PUB_DATE}</pubDate>
       <sparkle:version>${VERSION}</sparkle:version>
       <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
       <sparkle:releaseNotesLink>${NOTES_URL}</sparkle:releaseNotesLink>
       <link>${REPO_URL}/releases/tag/${TAG}</link>
       <enclosure url="${url}" type="application/octet-stream" ${sig} />


### PR DESCRIPTION
## What

Drops Macterm's minimum macOS from 26 (Tahoe) to **14 (Sonoma)** by gating the few Tahoe-only APIs that were used ungated. The deployment target, `LSMinimumSystemVersion`, Sparkle appcast floor, and docs all move to 14.

## Why

The app required macOS 26 only incidentally — a handful of Tahoe APIs were called without availability guards. The core (terminal surface, splits, persistence, hotkeys) has no real 26 dependency. macOS 14 is the practical floor: `@Observable`, which the entire state layer uses, needs 14, and below that the build fails with ~87 errors. (GhosttyKit's prebuilt binary itself allows 13.)

## Changes

- **`.glassEffect`** on the command palette → falls back to `.regularMaterial` below macOS 26.
- **`NSToolbar.allowsDisplayModeCustomization`** (macOS 15+) → gated behind `#available`.
- **Liquid Glass settings** (toggle + style picker) → hidden below macOS 26 via the newly-exposed `WindowAppearance.glassSupported`. Hidden rather than disabled, since the feature doesn't exist on older systems rather than being temporarily off. Blur footnote adjusted to match.
- **Deployment target** 26 → 14 (`project.yml`, `Info.plist`).
- **Metadata**: Sparkle appcast `minimumSystemVersion` → 14 (so 14 users get updates), README badge, CLAUDE.md.

## Verification

- Built and **run on a real macOS 14 VM** — launches, terminal works, command palette / split-pane drag / quick terminal / tabs all render natively. The dangling Liquid Glass setting was caught here and fixed.
- `format`, `lint`, `test` all pass at the 14.0 target.

## Reviewer notes

- **CI runners stay on `macos-26`** — that's the build *host*, which needs the 26 SDK to compile the gated glass paths. The deployment target is independent and back-deploys to 14. Downgrading the runner would break the build.
- **macOS 14-only caveat**: the toolbar-lock fix from #85 uses a macOS 15 API, so on 14 a user picking "Icon and Text" from the toolbar context menu can re-trigger that bug. Harmless and self-inflicted; the lock is active on 15+. Flagged and accepted when choosing the 14 floor.
- The Tahoe titlebar-tree walk in `WindowAppearance` is gated to 26, so it's a no-op on 14/15 and already works on Tahoe — untested on those VMs only because it doesn't run there.