### PR TITLE
Add a PR template matching the repo's What/Why/How/Verified convention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+PRs merge via squash — make the title a good squash subject (focus on the "why").
+Delete any section that doesn't apply. Keep it tight.
+-->
+
+## What
+
+<!-- What this PR changes, in a sentence or two. -->
+
+## Why
+
+<!-- The motivation. Link the issue this closes, if any. -->
+
+Closes #
+
+## How
+
+<!-- The approach, and anything non-obvious a reviewer needs to follow it.
+     Call out tradeoffs, framework limitations worked around, or design choices. -->
+
+## Verified
+
+<!-- How you confirmed this works. Tick what applies. -->
+
+- [ ] `mise run format`, `mise run lint`, and `mise run test` all pass
+- [ ] Built and ran the change in the app (`mise run run`) and confirmed the behavior
+- [ ] Added or updated tests for new model / persistence / palette / hotkey logic
+
+## Notes for reviewers
+
+<!-- Optional: anything to flag — branch history detours, follow-ups deferred,
+     screenshots / recordings for UI changes. -->


### PR DESCRIPTION
## What

Adds `.github/pull_request_template.md` so every new PR opens pre-filled with the **What / Why / How / Verified** structure the repo already uses by hand.

## Why

Recent merged PRs (#85, #84) all follow the same body shape, but nothing enforced it — each was written from scratch. A template makes that convention the default, and surfaces two project-specific reminders at PR-open time: that PRs **squash-merge** (so the title should be a good squash subject focused on the "why"), and that the `mise run format / lint / test` gate must pass.

## How

The template mirrors the observed convention:

- **What / Why / How / Verified** sections, with `Closes #` under Why (matching #84, which `release-drafter` uses to build the changelog).
- A **Verified** checklist hardcoding this app's gate: `format / lint / test`, running via `mise run run`, and adding tests for the unit-tested layers (model / persistence / palette / hotkey).
- An optional **Notes for reviewers** section for branch-history caveats and UI screenshots, which several PRs use.
- HTML comments guide each section and are stripped from the rendered PR.

No Claude Code footer baked in — the repo's commit convention forbids AI sign-offs, so a per-PR footer would be noise.

## Verified

- [x] Cross-checked the section layout against merged PRs #85 and #84.
- [ ] `mise run format / lint / test` — N/A, no Swift code changed (Markdown-only).
