### PR TITLE
Add sidebar indicators for terminal status

### DIFF
--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -116,6 +116,7 @@ final class AppState {
             for tab in ws.tabs {
                 for pane in tab.splitRoot.allPanes() {
                     pane.refreshForegroundProcess()
+                    pane.settleTerminalActivityIfQuiet()
                     acknowledgeFinishedCommandIfActive(paneID: pane.id, projectID: projectID)
                 }
             }

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -715,10 +715,15 @@ final class AppState {
     }
 
     func acknowledgeFinishedCommandIfActive(paneID: UUID, projectID: UUID) {
+        // The sidebar shows the *entire* active tab as idle (displayState masks
+        // `.done` for the tab the user is looking at), so every pane in that tab
+        // must actually be cleared — not just the focused one. Otherwise a
+        // non-focused split pane that finished a command stays `.done` under the
+        // hood, gets persisted on quit, and reappears as a checkmark after
+        // restart even though the user saw an empty circle.
         guard NSApp.isActive,
               projectID == activeProjectID,
               let tab = workspaces[projectID]?.activeTab,
-              tab.focusedPaneID == paneID,
               let pane = tab.splitRoot.findPane(id: paneID)
         else { return }
         pane.acknowledgeCommandCompletion()

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -116,7 +116,7 @@ final class AppState {
         // and the quiet-settle only matter when the status indicator is shown;
         // skip them in icon mode so the default poll stays as cheap as before
         // this feature.
-        let trackExecution = Preferences.shared.tabIndicatorMode == .status
+        let trackExecution = Preferences.shared.showTabStatusIndicator
         var didAcknowledgeCompletion = false
         for (projectID, ws) in workspaces {
             for tab in ws.tabs {

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -117,6 +117,7 @@ final class AppState {
         // skip them in icon mode so the default poll stays as cheap as before
         // this feature.
         let trackExecution = Preferences.shared.tabIndicatorMode == .status
+        var didAcknowledgeCompletion = false
         for (projectID, ws) in workspaces {
             for tab in ws.tabs {
                 for pane in tab.splitRoot.allPanes() {
@@ -124,10 +125,15 @@ final class AppState {
                     if trackExecution {
                         pane.settleTerminalActivityIfQuiet()
                     }
-                    acknowledgeFinishedCommandIfActive(paneID: pane.id, projectID: projectID)
+                    didAcknowledgeCompletion = acknowledgeFinishedCommandIfActive(
+                        paneID: pane.id,
+                        projectID: projectID,
+                        saveImmediately: false
+                    ) || didAcknowledgeCompletion
                 }
             }
         }
+        if didAcknowledgeCompletion { saveWorkspaces() }
     }
 
     private func recordProjectVisit(_ projectID: UUID) {
@@ -179,6 +185,7 @@ final class AppState {
             // and `ensureWorkspace` only creates a default when neither exists.
             autoApplyLayoutOnFirstOpen(project)
             ensureWorkspace(projectID: id, path: project.path)
+            acknowledgeActiveTab(projectID: id)
             warmFocusedProject()
         }
     }
@@ -195,6 +202,7 @@ final class AppState {
         recordProjectVisit(project.id)
         autoApplyLayoutOnFirstOpen(project)
         ensureWorkspace(projectID: project.id, path: project.path)
+        acknowledgeActiveTab(projectID: project.id)
         warmFocusedProject()
     }
 
@@ -344,7 +352,12 @@ final class AppState {
     }
 
     func selectTab(_ tabID: UUID, projectID: UUID) {
-        workspaces[projectID]?.selectTab(tabID)
+        guard let ws = workspaces[projectID] else { return }
+        let before = ws.activeTabID
+        let didAcknowledgeCompletion = ws.selectTab(tabID)
+        if ws.activeTabID != before || didAcknowledgeCompletion {
+            saveWorkspaces()
+        }
     }
 
     /// Move a tab — with its live panes and running shells intact — from one
@@ -371,11 +384,21 @@ final class AppState {
     }
 
     func selectNextTab(projectID: UUID) {
-        workspaces[projectID]?.selectNextTab()
+        guard let ws = workspaces[projectID] else { return }
+        let before = ws.activeTabID
+        let didAcknowledgeCompletion = ws.selectNextTab()
+        if ws.activeTabID != before || didAcknowledgeCompletion {
+            saveWorkspaces()
+        }
     }
 
     func selectPreviousTab(projectID: UUID) {
-        workspaces[projectID]?.selectPreviousTab()
+        guard let ws = workspaces[projectID] else { return }
+        let before = ws.activeTabID
+        let didAcknowledgeCompletion = ws.selectPreviousTab()
+        if ws.activeTabID != before || didAcknowledgeCompletion {
+            saveWorkspaces()
+        }
     }
 
     func cycleRecentTab(projectID: UUID) {
@@ -418,14 +441,27 @@ final class AppState {
             case .previous: (currentIndex - 1 + allTabs.count) % allTabs.count
             }
         let (project, tab) = allTabs[newIndex]
+        let beforeProjectID = activeProjectID
+        let beforeTabID = workspaces[project.id]?.activeTabID
 
         activeProjectID = project.id
         ensureWorkspace(projectID: project.id, path: project.path)
-        workspaces[project.id]?.selectTab(tab.id)
+        let didAcknowledgeCompletion = workspaces[project.id]?.selectTab(tab.id) ?? false
+        if activeProjectID != beforeProjectID
+            || workspaces[project.id]?.activeTabID != beforeTabID
+            || didAcknowledgeCompletion
+        {
+            saveWorkspaces()
+        }
     }
 
     func selectTabByIndex(_ index: Int, projectID: UUID) {
-        workspaces[projectID]?.selectTabByIndex(index)
+        guard let ws = workspaces[projectID] else { return }
+        let before = ws.activeTabID
+        let didAcknowledgeCompletion = ws.selectTabByIndex(index)
+        if ws.activeTabID != before || didAcknowledgeCompletion {
+            saveWorkspaces()
+        }
     }
 
     // MARK: - Splits
@@ -640,8 +676,16 @@ final class AppState {
         activeProjectID = projectID
         recordProjectVisit(projectID)
         if let tab = workspaces[projectID]?.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil }) {
-            workspaces[projectID]?.selectTab(tab.id)
+            let beforeTabID = workspaces[projectID]?.activeTabID
+            let beforeFocusedPaneID = tab.focusedPaneID
+            let didAcknowledgeCompletion = workspaces[projectID]?.selectTab(tab.id) ?? false
             tab.focusPane(paneID)
+            if workspaces[projectID]?.activeTabID != beforeTabID
+                || tab.focusedPaneID != beforeFocusedPaneID
+                || didAcknowledgeCompletion
+            {
+                saveWorkspaces()
+            }
         }
         if let appDelegate = NSApp.delegate as? AppDelegate {
             appDelegate.reopenIfNeeded()
@@ -714,19 +758,36 @@ final class AppState {
         )
     }
 
-    func acknowledgeFinishedCommandIfActive(paneID: UUID, projectID: UUID) {
+    @discardableResult
+    private func acknowledgeActiveTab(projectID: UUID, saveImmediately: Bool = true) -> Bool {
+        guard projectID == activeProjectID,
+              let tab = workspaces[projectID]?.activeTab
+        else { return false }
+        let didAcknowledgeCompletion = tab.acknowledgeCommandCompletion()
+        if didAcknowledgeCompletion, saveImmediately {
+            saveWorkspaces()
+        }
+        return didAcknowledgeCompletion
+    }
+
+    @discardableResult
+    func acknowledgeFinishedCommandIfActive(
+        paneID: UUID,
+        projectID: UUID,
+        saveImmediately: Bool = true
+    ) -> Bool {
         // The sidebar shows the *entire* active tab as idle (displayState masks
         // `.done` for the tab the user is looking at), so every pane in that tab
         // must actually be cleared — not just the focused one. Otherwise a
         // non-focused split pane that finished a command stays `.done` under the
-        // hood, gets persisted on quit, and reappears as a checkmark after
-        // restart even though the user saw an empty circle.
+        // hood, gets persisted, and reappears as a checkmark after restart even
+        // though the user saw an empty circle.
         guard NSApp.isActive,
               projectID == activeProjectID,
               let tab = workspaces[projectID]?.activeTab,
-              let pane = tab.splitRoot.findPane(id: paneID)
-        else { return }
-        pane.acknowledgeCommandCompletion()
+              tab.splitRoot.findPane(id: paneID) != nil
+        else { return false }
+        return acknowledgeActiveTab(projectID: projectID, saveImmediately: saveImmediately)
     }
 
     // MARK: - Private

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -112,9 +112,12 @@ final class AppState {
     /// workspaces. Each pane only republishes (and triggers a tab re-render)
     /// when its name actually changes, so this is cheap when nothing's moving.
     func refreshAllForegroundProcesses() {
-        for ws in workspaces.values {
-            for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {
-                pane.refreshForegroundProcess()
+        for (projectID, ws) in workspaces {
+            for tab in ws.tabs {
+                for pane in tab.splitRoot.allPanes() {
+                    pane.refreshForegroundProcess()
+                    acknowledgeFinishedCommandIfActive(paneID: pane.id, projectID: projectID)
+                }
             }
         }
     }
@@ -678,6 +681,16 @@ final class AppState {
             in: tab.splitRoot,
             window: NSApp.keyWindow ?? NSApp.mainWindow
         )
+    }
+
+    func acknowledgeFinishedCommandIfActive(paneID: UUID, projectID: UUID) {
+        guard NSApp.isActive,
+              projectID == activeProjectID,
+              let tab = workspaces[projectID]?.activeTab,
+              tab.focusedPaneID == paneID,
+              let pane = tab.splitRoot.findPane(id: paneID)
+        else { return }
+        pane.acknowledgeCommandCompletion()
     }
 
     // MARK: - Private

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -112,11 +112,18 @@ final class AppState {
     /// workspaces. Each pane only republishes (and triggers a tab re-render)
     /// when its name actually changes, so this is cheap when nothing's moving.
     func refreshAllForegroundProcesses() {
+        // Shell/raw-mode detection (KERN_PROCARGS2 + open/tcgetattr per pane)
+        // and the quiet-settle only matter when the status indicator is shown;
+        // skip them in icon mode so the default poll stays as cheap as before
+        // this feature.
+        let trackExecution = Preferences.shared.tabIndicatorMode == .status
         for (projectID, ws) in workspaces {
             for tab in ws.tabs {
                 for pane in tab.splitRoot.allPanes() {
-                    pane.refreshForegroundProcess()
-                    pane.settleTerminalActivityIfQuiet()
+                    pane.refreshForegroundProcess(trackExecution: trackExecution)
+                    if trackExecution {
+                        pane.settleTerminalActivityIfQuiet()
+                    }
                     acknowledgeFinishedCommandIfActive(paneID: pane.id, projectID: projectID)
                 }
             }

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -35,6 +35,20 @@ enum WindowGlassStyle: String, CaseIterable, Identifiable {
     }
 }
 
+enum TabIndicatorMode: String, CaseIterable, Identifiable {
+    case icon
+    case status
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .icon: "Icon"
+        case .status: "Status"
+        }
+    }
+}
+
 /// Single observable source of truth for UserDefaults-backed preferences.
 ///
 /// Macterm only stores app-shaped state here (window opacity/blur, quick
@@ -69,6 +83,10 @@ final class Preferences {
 
     var tabIconSymbol: String {
         didSet { defaults.set(tabIconSymbol, forKey: Keys.tabIconSymbol) }
+    }
+
+    var tabIndicatorMode: TabIndicatorMode {
+        didSet { defaults.set(tabIndicatorMode.rawValue, forKey: Keys.tabIndicatorMode) }
     }
 
     var showNewProjectButton: Bool {
@@ -247,6 +265,8 @@ final class Preferences {
         activeProjectID = (defaults.string(forKey: Keys.activeProjectID)).flatMap(UUID.init)
         projectIconSymbol = defaults.string(forKey: Keys.projectIconSymbol) ?? "folder"
         tabIconSymbol = defaults.string(forKey: Keys.tabIconSymbol) ?? "terminal"
+        tabIndicatorMode = (defaults.string(forKey: Keys.tabIndicatorMode))
+            .flatMap(TabIndicatorMode.init(rawValue:)) ?? .icon
         showNewProjectButton = defaults.object(forKey: Keys.showNewProjectButton) as? Bool ?? true
         tabSwitcherVisibility = (defaults.string(forKey: Keys.tabSwitcherVisibility))
             .flatMap(TabSwitcherVisibility.init(rawValue:)) ?? .whenMultiple
@@ -295,6 +315,7 @@ final class Preferences {
         static let activeProjectID = "macterm.activeProjectID"
         static let projectIconSymbol = "macterm.sidebar.projectIcon"
         static let tabIconSymbol = "macterm.sidebar.tabIcon"
+        static let tabIndicatorMode = "macterm.sidebar.tabIndicatorMode"
         static let showNewProjectButton = "macterm.sidebar.showNewProjectButton"
         static let tabSwitcherVisibility = "macterm.toolbar.tabSwitcherVisibility"
         static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -35,20 +35,6 @@ enum WindowGlassStyle: String, CaseIterable, Identifiable {
     }
 }
 
-enum TabIndicatorMode: String, CaseIterable, Identifiable {
-    case icon
-    case status
-
-    var id: String { rawValue }
-
-    var displayName: String {
-        switch self {
-        case .icon: "Icon"
-        case .status: "Status"
-        }
-    }
-}
-
 /// Single observable source of truth for UserDefaults-backed preferences.
 ///
 /// Macterm only stores app-shaped state here (window opacity/blur, quick
@@ -85,8 +71,11 @@ final class Preferences {
         didSet { defaults.set(tabIconSymbol, forKey: Keys.tabIconSymbol) }
     }
 
-    var tabIndicatorMode: TabIndicatorMode {
-        didSet { defaults.set(tabIndicatorMode.rawValue, forKey: Keys.tabIndicatorMode) }
+    /// Show a status badge over each tab icon: a spinner while a command is
+    /// running (replacing the icon) and a small status dot when a command has
+    /// finished and awaits attention. Off = pure icons, no status tracking.
+    var showTabStatusIndicator: Bool {
+        didSet { defaults.set(showTabStatusIndicator, forKey: Keys.showTabStatusIndicator) }
     }
 
     var showNewProjectButton: Bool {
@@ -265,8 +254,7 @@ final class Preferences {
         activeProjectID = (defaults.string(forKey: Keys.activeProjectID)).flatMap(UUID.init)
         projectIconSymbol = defaults.string(forKey: Keys.projectIconSymbol) ?? "folder"
         tabIconSymbol = defaults.string(forKey: Keys.tabIconSymbol) ?? "terminal"
-        tabIndicatorMode = (defaults.string(forKey: Keys.tabIndicatorMode))
-            .flatMap(TabIndicatorMode.init(rawValue:)) ?? .icon
+        showTabStatusIndicator = defaults.object(forKey: Keys.showTabStatusIndicator) as? Bool ?? false
         showNewProjectButton = defaults.object(forKey: Keys.showNewProjectButton) as? Bool ?? true
         tabSwitcherVisibility = (defaults.string(forKey: Keys.tabSwitcherVisibility))
             .flatMap(TabSwitcherVisibility.init(rawValue:)) ?? .whenMultiple
@@ -291,12 +279,6 @@ final class Preferences {
             defaults.removeObject(forKey: "macterm.input.optionAsAlt")
             defaults.set(true, forKey: Keys.migrationV2GhosttyConfigOwned)
         }
-        // The original "number" sentinel was replaced by per-variant tokens.
-        // Map any user who was on it to the filled-circle variant so their
-        // sidebar doesn't silently lose its number icons on upgrade.
-        for key in [Keys.projectIconSymbol, Keys.tabIconSymbol] where defaults.string(forKey: key) == "number" {
-            defaults.set(numberIconCircleFill, forKey: key)
-        }
     }
 
     // MARK: - UserDefaults keys
@@ -315,7 +297,7 @@ final class Preferences {
         static let activeProjectID = "macterm.activeProjectID"
         static let projectIconSymbol = "macterm.sidebar.projectIcon"
         static let tabIconSymbol = "macterm.sidebar.tabIcon"
-        static let tabIndicatorMode = "macterm.sidebar.tabIndicatorMode"
+        static let showTabStatusIndicator = "macterm.sidebar.showTabStatusIndicator"
         static let showNewProjectButton = "macterm.sidebar.showNewProjectButton"
         static let tabSwitcherVisibility = "macterm.toolbar.tabSwitcherVisibility"
         static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"

--- a/Macterm/Ghostty/GhosttyCallbacks.swift
+++ b/Macterm/Ghostty/GhosttyCallbacks.swift
@@ -57,10 +57,16 @@ final class GhosttyCallbacks: @unchecked Sendable {
             let duration = action.action.command_finished.duration
             DispatchQueue.main.async { view.onCommandFinished?(exitCode, duration) }
             return true
+        case GHOSTTY_ACTION_PROGRESS_REPORT:
+            guard let view = surfaceView(from: target) else { return true }
+            let state = action.action.progress_report.state
+            let running = state == GHOSTTY_PROGRESS_STATE_SET || state == GHOSTTY_PROGRESS_STATE_INDETERMINATE
+            DispatchQueue.main.async { view.surfaceDidReportProgress(running: running) }
+            return true
         case GHOSTTY_ACTION_SCROLLBAR:
             guard let view = surfaceView(from: target) else { return true }
             let s = action.action.scrollbar
-            DispatchQueue.main.async { view.onScrollbarUpdate?(s.total, s.offset, s.len) }
+            DispatchQueue.main.async { view.surfaceDidUpdateScrollbar(total: s.total, offset: s.offset, len: s.len) }
             return true
         case GHOSTTY_ACTION_RELOAD_CONFIG:
             // libghostty fires this (with soft = true) when a surface's

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -289,7 +289,7 @@ final class Pane: Identifiable {
     /// the pref is read once; the default reads `Preferences` for ad-hoc
     /// callers (OSC title, output/progress callbacks) so they stay gated too.
     func refreshForegroundProcess(trackExecution: Bool? = nil) {
-        let track = trackExecution ?? (Preferences.shared.tabIndicatorMode == .status)
+        let track = trackExecution ?? Preferences.shared.showTabStatusIndicator
         applyForegroundRefresh(
             name: ProcessInspector.runningProcessName(forPane: self),
             foregroundPID: nsView?.foregroundPID,

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -260,29 +260,41 @@ final class Pane: Identifiable {
     /// Re-read the foreground process name from the process table and publish it
     /// only when it changed (so a steady poll doesn't churn `@Observable` and
     /// re-render the sidebar every tick). Driven by `AppState`'s poll.
-    func refreshForegroundProcess() {
+    ///
+    /// `trackExecution` gates the expensive shell/raw-mode syscalls
+    /// (`foregroundProcessIsShell` / `terminalInputIsRaw`) that only feed the
+    /// status indicator. Callers on the hot poll pass a precomputed value so
+    /// the pref is read once; the default reads `Preferences` for ad-hoc
+    /// callers (OSC title, output/progress callbacks) so they stay gated too.
+    func refreshForegroundProcess(trackExecution: Bool? = nil) {
+        let track = trackExecution ?? (Preferences.shared.tabIndicatorMode == .status)
         applyForegroundRefresh(
             name: ProcessInspector.runningProcessName(forPane: self),
             foregroundPID: nsView?.foregroundPID,
-            foregroundIsShell: ProcessInspector.foregroundProcessIsShell(forPane: self),
-            terminalInputIsRaw: ProcessInspector.terminalInputIsRaw(forPane: self)
+            foregroundIsShell: track ? ProcessInspector.foregroundProcessIsShell(forPane: self) : false,
+            terminalInputIsRaw: track ? ProcessInspector.terminalInputIsRaw(forPane: self) : false,
+            applyExecutionState: track
         )
     }
 
     /// Testable core of `refreshForegroundProcess`: publish a changed process
     /// name, and expire `programTitle` when the pid that set it no longer
-    /// holds the foreground.
+    /// holds the foreground. When `applyExecutionState` is false (the status
+    /// indicator is off), the expensive execution-state path is skipped — only
+    /// the process name / title provenance update runs.
     func applyForegroundRefresh(
         name: String?,
         foregroundPID: pid_t?,
         foregroundIsShell: Bool = false,
-        terminalInputIsRaw: Bool = false
+        terminalInputIsRaw: Bool = false,
+        applyExecutionState: Bool = true
     ) {
         if name != foregroundProcessName { foregroundProcessName = name }
         if programTitle != nil, programTitlePID != foregroundPID {
             programTitle = nil
             programTitlePID = nil
         }
+        guard applyExecutionState else { return }
         applyForegroundExecutionState(
             name: name,
             foregroundPID: foregroundPID,

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -52,6 +52,163 @@ enum TerminalExecutionState: Equatable {
     case done
 }
 
+private struct ForegroundProcessKey: Equatable {
+    let name: String
+    let pid: pid_t?
+
+    init?(name: String?, pid: pid_t?) {
+        let normalizedName = name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        guard !normalizedName.isEmpty else { return nil }
+        self.name = normalizedName
+        self.pid = pid
+    }
+}
+
+private struct TerminalExecutionTracker {
+    /// The foreground process seen on the last poll (nil = shell / none).
+    /// Transitions are driven by *changes* to this, not by re-deriving state
+    /// on every poll — so a settled idle process never flip-flops back to
+    /// running just because it's still foreground.
+    private var lastForeground: ForegroundProcessKey?
+    /// Timestamp of the most recent terminal output. nil while running is owed
+    /// to a foreground command or explicit progress (which don't quiet-settle).
+    /// Its presence/absence is the only record of whether running is
+    /// "output-sourced" (settles when quiet) or not — no separate source enum.
+    private var lastActivityAt: Date?
+    /// True while an OSC 9;4 progress report owns the pane; output and
+    /// foreground changes are ignored while it's active.
+    private var progressActive = false
+    /// After progress clears, the foreground process that owned it is
+    /// "quiesced": its own output and re-polls are ignored until the
+    /// foreground moves away, so a settled program that reported progress
+    /// doesn't flip back to running on its own render output.
+    /// `pendingProgressQuiesce` covers the race where progress started and
+    /// cleared before any foreground poll — the first process to appear is
+    /// quiesced instead of marked running.
+    private var progressQuiesced: ForegroundProcessKey?
+    private var pendingProgressQuiesce = false
+    /// Output is ignored until the user has interacted with the pane, so a
+    /// freshly-restored shell's startup prompt doesn't show as activity.
+    private var hasUserInteraction = false
+
+    mutating func recordUserInteraction() {
+        hasUserInteraction = true
+    }
+
+    mutating func markProgressStarted() -> TerminalExecutionState {
+        progressActive = true
+        lastActivityAt = nil
+        return .running
+    }
+
+    mutating func markCommandFinished() -> TerminalExecutionState {
+        progressActive = false
+        progressQuiesced = nil
+        pendingProgressQuiesce = false
+        lastActivityAt = nil
+        return .done
+    }
+
+    mutating func markProgressFinished(currentState: TerminalExecutionState) -> TerminalExecutionState {
+        progressActive = false
+        if let lastForeground {
+            progressQuiesced = lastForeground
+        } else {
+            pendingProgressQuiesce = true
+        }
+        lastActivityAt = nil
+        return currentState == .running ? .done : currentState
+    }
+
+    mutating func markTerminalActivity(
+        at date: Date,
+        currentState: TerminalExecutionState
+    ) -> TerminalExecutionState {
+        guard !progressActive else { return currentState }
+        if let progressQuiesced, progressQuiesced == lastForeground { return currentState }
+        // Output while a command is in the foreground always counts; output
+        // while at a shell prompt only counts after the user has interacted,
+        // so a freshly-restored shell's startup banner doesn't show as work.
+        guard lastForeground != nil || hasUserInteraction else { return currentState }
+        lastActivityAt = date
+        return .running
+    }
+
+    mutating func settleIfQuiet(
+        now: Date,
+        quietInterval: TimeInterval,
+        currentState: TerminalExecutionState
+    ) -> TerminalExecutionState {
+        guard currentState == .running,
+              !progressActive,
+              let lastActivityAt,
+              now.timeIntervalSince(lastActivityAt) >= quietInterval
+        else { return currentState }
+        self.lastActivityAt = nil
+        return .done
+    }
+
+    mutating func refreshForeground(
+        name: String?,
+        pid: pid_t?,
+        foregroundIsShell: Bool,
+        terminalInputIsRaw: Bool,
+        currentState: TerminalExecutionState
+    ) -> TerminalExecutionState {
+        let newKey = foregroundIsShell ? nil : ForegroundProcessKey(name: name, pid: pid)
+
+        // Resolve a pending progress quiesce: the first foreground process
+        // after a progress race (progress cleared before any poll) is quiesced
+        // rather than marked running. A shell arriving first cancels it.
+        if pendingProgressQuiesce {
+            if let newKey {
+                progressQuiesced = newKey
+                pendingProgressQuiesce = false
+                lastForeground = newKey
+                return currentState
+            }
+            pendingProgressQuiesce = false
+        }
+
+        // Drop the quiesce once the foreground moves off the quiesced process.
+        if let progressQuiesced, progressQuiesced != newKey {
+            self.progressQuiesced = nil
+        }
+
+        let changed = newKey != lastForeground
+        lastForeground = newKey
+
+        // Foreground returned to the shell: a running command exited.
+        if newKey == nil {
+            guard changed, currentState == .running else { return currentState }
+            lastActivityAt = nil
+            return .done
+        }
+
+        // Non-shell foreground. Explicit progress owns the state while active.
+        if progressActive { return currentState }
+
+        if terminalInputIsRaw {
+            // A raw/cbreak-mode program (full-screen editors, multiplexers,
+            // interactive CLIs) shouldn't hold a foreground-only spinner just
+            // because it's the foreground process. If we were running only
+            // because of a prior canonical command (no recent output), settle
+            // now; output-sourced running is left to quiet-settle on its own.
+            if currentState == .running, lastActivityAt == nil {
+                return .done
+            }
+            return currentState
+        }
+
+        // Canonical non-shell command (a build, `sleep`, …) → running until
+        // it returns to the shell. Only act on a change so a settled idle
+        // process doesn't flip back to running on every poll.
+        guard changed else { return currentState }
+        lastActivityAt = nil
+        return .running
+    }
+}
+
 /// A pane is the leaf of the split tree — one terminal surface.
 @MainActor @Observable
 final class Pane: Identifiable {
@@ -97,6 +254,9 @@ final class Pane: Identifiable {
     let searchState = TerminalSearchState()
     var executionState: TerminalExecutionState = .idle
 
+    @ObservationIgnored
+    private var executionTracker = TerminalExecutionTracker()
+
     /// Re-read the foreground process name from the process table and publish it
     /// only when it changed (so a steady poll doesn't churn `@Observable` and
     /// re-render the sidebar every tick). Driven by `AppState`'s poll.
@@ -104,36 +264,91 @@ final class Pane: Identifiable {
         applyForegroundRefresh(
             name: ProcessInspector.runningProcessName(forPane: self),
             foregroundPID: nsView?.foregroundPID,
-            programPID: ProcessInspector.foregroundProgramPID(forPane: self)
+            foregroundIsShell: ProcessInspector.foregroundProcessIsShell(forPane: self),
+            terminalInputIsRaw: ProcessInspector.terminalInputIsRaw(forPane: self)
         )
     }
 
     /// Testable core of `refreshForegroundProcess`: publish a changed process
-    /// name, expire `programTitle` when the pid that set it no longer holds the
-    /// foreground, and surface the active execution state.
-    func applyForegroundRefresh(name: String?, foregroundPID: pid_t?, programPID: pid_t?) {
+    /// name, and expire `programTitle` when the pid that set it no longer
+    /// holds the foreground.
+    func applyForegroundRefresh(
+        name: String?,
+        foregroundPID: pid_t?,
+        foregroundIsShell: Bool = false,
+        terminalInputIsRaw: Bool = false
+    ) {
         if name != foregroundProcessName { foregroundProcessName = name }
         if programTitle != nil, programTitlePID != foregroundPID {
             programTitle = nil
             programTitlePID = nil
         }
-        if programPID != nil {
-            executionState = .running
-        } else if executionState == .running {
-            executionState = .done
-        }
+        applyForegroundExecutionState(
+            name: name,
+            foregroundPID: foregroundPID,
+            foregroundIsShell: foregroundIsShell,
+            terminalInputIsRaw: terminalInputIsRaw
+        )
     }
 
     func markCommandRunning() {
-        executionState = .running
+        executionState = executionTracker.markProgressStarted()
     }
 
     func markCommandFinished() {
-        executionState = .done
+        executionState = executionTracker.markCommandFinished()
+    }
+
+    func markProgressFinished() {
+        executionState = executionTracker.markProgressFinished(currentState: executionState)
+    }
+
+    func markTerminalActivity(at date: Date = Date()) {
+        executionState = executionTracker.markTerminalActivity(
+            at: date,
+            currentState: executionState
+        )
+    }
+
+    func settleTerminalActivityIfQuiet(now: Date = Date(), quietInterval: TimeInterval = 3) {
+        executionState = executionTracker.settleIfQuiet(
+            now: now,
+            quietInterval: quietInterval,
+            currentState: executionState
+        )
     }
 
     func acknowledgeCommandCompletion() {
         if executionState == .done { executionState = .idle }
+    }
+
+    /// Restore the persisted "done / needs attention" state after a relaunch.
+    /// Only the user-visible checkmark is restored; the live tracker starts
+    /// idle, so the first real foreground/output signal behaves normally and
+    /// a user interaction (or focusing the tab) clears it via
+    /// `acknowledgeCommandCompletion`.
+    func restoreNeedsAttention() {
+        executionState = .done
+    }
+
+    func recordUserInteraction() {
+        executionTracker.recordUserInteraction()
+        acknowledgeCommandCompletion()
+    }
+
+    private func applyForegroundExecutionState(
+        name: String?,
+        foregroundPID: pid_t?,
+        foregroundIsShell: Bool,
+        terminalInputIsRaw: Bool
+    ) {
+        executionState = executionTracker.refreshForeground(
+            name: name,
+            pid: foregroundPID,
+            foregroundIsShell: foregroundIsShell,
+            terminalInputIsRaw: terminalInputIsRaw,
+            currentState: executionState
+        )
     }
 
     /// Handle an OSC 0/2 title reported by the surface. Always refreshes the
@@ -204,6 +419,9 @@ final class Pane: Identifiable {
         view.onSplitRequest = nil
         view.onDesktopNotification = nil
         view.onCommandFinished = nil
+        view.onProgressStarted = nil
+        view.onProgressFinished = nil
+        view.onTerminalActivity = nil
         view.onScrollbarUpdate = nil
         view.destroySurface()
         let scroll = _scrollView

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -101,7 +101,14 @@ private struct TerminalExecutionTracker {
         return .running
     }
 
-    mutating func markCommandFinished() -> TerminalExecutionState {
+    mutating func markCommandFinished(currentState: TerminalExecutionState) -> TerminalExecutionState {
+        // Shell integration (OSC 133;D) fires on *every* precmd, including
+        // empty commands — pressing Enter, Ctrl-C, or Ctrl-L on an idle prompt
+        // emits COMMAND_FINISHED with no preceding command. Only treat it as a
+        // real completion when a command was actually running; from idle it's
+        // precmd noise and must not flip the pane to `.done` (which would
+        // persist as a spurious checkmark after restart).
+        guard currentState == .running else { return currentState }
         progressActive = false
         progressQuiesced = nil
         pendingProgressQuiesce = false
@@ -308,7 +315,7 @@ final class Pane: Identifiable {
     }
 
     func markCommandFinished() {
-        executionState = executionTracker.markCommandFinished()
+        executionState = executionTracker.markCommandFinished(currentState: executionState)
     }
 
     func markProgressFinished() {

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -65,6 +65,10 @@ private struct ForegroundProcessKey: Equatable {
 }
 
 private struct TerminalExecutionTracker {
+    init(hasUserInteraction: Bool = false) {
+        self.hasUserInteraction = hasUserInteraction
+    }
+
     /// The foreground process seen on the last poll (nil = shell / none).
     /// Transitions are driven by *changes* to this, not by re-deriving state
     /// on every poll — so a settled idle process never flip-flops back to
@@ -95,7 +99,8 @@ private struct TerminalExecutionTracker {
         hasUserInteraction = true
     }
 
-    mutating func markProgressStarted() -> TerminalExecutionState {
+    mutating func markProgressStarted(currentState: TerminalExecutionState) -> TerminalExecutionState {
+        guard hasUserInteraction else { return currentState }
         progressActive = true
         lastActivityAt = nil
         return .running
@@ -117,6 +122,7 @@ private struct TerminalExecutionTracker {
     }
 
     mutating func markProgressFinished(currentState: TerminalExecutionState) -> TerminalExecutionState {
+        guard hasUserInteraction || progressActive else { return currentState }
         progressActive = false
         if let lastForeground {
             progressQuiesced = lastForeground
@@ -133,10 +139,11 @@ private struct TerminalExecutionTracker {
     ) -> TerminalExecutionState {
         guard !progressActive else { return currentState }
         if let progressQuiesced, progressQuiesced == lastForeground { return currentState }
-        // Output while a command is in the foreground always counts; output
-        // while at a shell prompt only counts after the user has interacted,
-        // so a freshly-restored shell's startup banner doesn't show as work.
-        guard lastForeground != nil || hasUserInteraction else { return currentState }
+        // Output only counts after user interaction (or a declarative `run:`,
+        // which seeds `hasUserInteraction`). Fresh/restored shells can emit
+        // startup banners or shell-integration redraws before the user does
+        // anything; those must not become persisted completion indicators.
+        guard hasUserInteraction else { return currentState }
         lastActivityAt = date
         return .running
     }
@@ -194,6 +201,14 @@ private struct TerminalExecutionTracker {
 
         // Non-shell foreground. Explicit progress owns the state while active.
         if progressActive { return currentState }
+
+        // A newly-created/restored plain shell can briefly look like a
+        // non-shell foreground while its startup files and shell integration
+        // settle. Do not turn that launch noise into a persisted checkmark.
+        // Once the user has interacted, foreground transitions are real user
+        // work. Declarative layout `run:` panes seed `hasUserInteraction` so
+        // their startup command is still tracked.
+        guard hasUserInteraction else { return currentState }
 
         if terminalInputIsRaw {
             // A raw/cbreak-mode program (full-screen editors, multiplexers,
@@ -311,7 +326,7 @@ final class Pane: Identifiable {
     }
 
     func markCommandRunning() {
-        executionState = executionTracker.markProgressStarted()
+        executionState = executionTracker.markProgressStarted(currentState: executionState)
     }
 
     func markCommandFinished() {
@@ -337,8 +352,11 @@ final class Pane: Identifiable {
         )
     }
 
-    func acknowledgeCommandCompletion() {
-        if executionState == .done { executionState = .idle }
+    @discardableResult
+    func acknowledgeCommandCompletion() -> Bool {
+        guard executionState == .done else { return false }
+        executionState = .idle
+        return true
     }
 
     /// Restore the persisted "done / needs attention" state after a relaunch.
@@ -508,6 +526,7 @@ final class Pane: Identifiable {
         self.command = command
         self.shell = shell
         self.env = env
+        executionTracker = TerminalExecutionTracker(hasUserInteraction: command != nil)
     }
 }
 

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -46,6 +46,12 @@ enum PaneDropZone: Equatable {
     }
 }
 
+enum TerminalExecutionState: Equatable {
+    case idle
+    case running
+    case done
+}
+
 /// A pane is the leaf of the split tree — one terminal surface.
 @MainActor @Observable
 final class Pane: Identifiable {
@@ -89,6 +95,7 @@ final class Pane: Identifiable {
     private var programTitlePID: pid_t?
 
     let searchState = TerminalSearchState()
+    var executionState: TerminalExecutionState = .idle
 
     /// Re-read the foreground process name from the process table and publish it
     /// only when it changed (so a steady poll doesn't churn `@Observable` and
@@ -96,19 +103,37 @@ final class Pane: Identifiable {
     func refreshForegroundProcess() {
         applyForegroundRefresh(
             name: ProcessInspector.runningProcessName(forPane: self),
-            foregroundPID: nsView?.foregroundPID
+            foregroundPID: nsView?.foregroundPID,
+            programPID: ProcessInspector.foregroundProgramPID(forPane: self)
         )
     }
 
     /// Testable core of `refreshForegroundProcess`: publish a changed process
-    /// name, and expire `programTitle` when the pid that set it no longer
-    /// holds the foreground.
-    func applyForegroundRefresh(name: String?, foregroundPID: pid_t?) {
+    /// name, expire `programTitle` when the pid that set it no longer holds the
+    /// foreground, and surface the active execution state.
+    func applyForegroundRefresh(name: String?, foregroundPID: pid_t?, programPID: pid_t?) {
         if name != foregroundProcessName { foregroundProcessName = name }
         if programTitle != nil, programTitlePID != foregroundPID {
             programTitle = nil
             programTitlePID = nil
         }
+        if programPID != nil {
+            executionState = .running
+        } else if executionState == .running {
+            executionState = .done
+        }
+    }
+
+    func markCommandRunning() {
+        executionState = .running
+    }
+
+    func markCommandFinished() {
+        executionState = .done
+    }
+
+    func acknowledgeCommandCompletion() {
+        if executionState == .done { executionState = .idle }
     }
 
     /// Handle an OSC 0/2 title reported by the surface. Always refreshes the
@@ -175,6 +200,7 @@ final class Pane: Identifiable {
         view.onSearchTotal = nil
         view.onSearchSelected = nil
         view.onFocus = nil
+        view.onInteraction = nil
         view.onSplitRequest = nil
         view.onDesktopNotification = nil
         view.onCommandFinished = nil

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -43,9 +43,22 @@ final class TerminalTab: Identifiable {
 
     var sidebarTitle: String { customTitle ?? autoTitle }
 
+    var executionState: TerminalExecutionState {
+        let panes = splitRoot.allPanes()
+        if panes.contains(where: { $0.executionState == .running }) { return .running }
+        if panes.contains(where: { $0.executionState == .done }) { return .done }
+        return .idle
+    }
+
     var focusedPane: Pane? {
         guard let focusedPaneID else { return nil }
         return splitRoot.findPane(id: focusedPaneID)
+    }
+
+    func acknowledgeCommandCompletion() {
+        for pane in splitRoot.allPanes() {
+            pane.acknowledgeCommandCompletion()
+        }
     }
 
     init(projectPath: String, projectID: UUID) {
@@ -229,9 +242,10 @@ final class Workspace: Identifiable {
     }
 
     func selectTab(_ tabID: UUID) {
-        guard tabs.contains(where: { $0.id == tabID }) else { return }
+        guard let tab = tabs.first(where: { $0.id == tabID }) else { return }
         if let current = activeTabID, current != tabID { tabHistory.push(current) }
         activeTabID = tabID
+        tab.acknowledgeCommandCompletion()
     }
 
     func selectNextTab() {

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -55,10 +55,13 @@ final class TerminalTab: Identifiable {
         return splitRoot.findPane(id: focusedPaneID)
     }
 
-    func acknowledgeCommandCompletion() {
+    @discardableResult
+    func acknowledgeCommandCompletion() -> Bool {
+        var didAcknowledge = false
         for pane in splitRoot.allPanes() {
-            pane.acknowledgeCommandCompletion()
+            didAcknowledge = pane.acknowledgeCommandCompletion() || didAcknowledge
         }
+        return didAcknowledge
     }
 
     init(projectPath: String, projectID: UUID) {
@@ -251,25 +254,28 @@ final class Workspace: Identifiable {
         }
     }
 
-    func selectTab(_ tabID: UUID) {
-        guard let tab = tabs.first(where: { $0.id == tabID }) else { return }
+    @discardableResult
+    func selectTab(_ tabID: UUID) -> Bool {
+        guard let tab = tabs.first(where: { $0.id == tabID }) else { return false }
         if let current = activeTabID, current != tabID { tabHistory.push(current) }
         activeTabID = tabID
-        tab.acknowledgeCommandCompletion()
+        return tab.acknowledgeCommandCompletion()
     }
 
-    func selectNextTab() {
+    @discardableResult
+    func selectNextTab() -> Bool {
         guard tabs.count > 1, let activeTabID,
               let i = tabs.firstIndex(where: { $0.id == activeTabID })
-        else { return }
-        selectTab(tabs[(i + 1) % tabs.count].id)
+        else { return false }
+        return selectTab(tabs[(i + 1) % tabs.count].id)
     }
 
-    func selectPreviousTab() {
+    @discardableResult
+    func selectPreviousTab() -> Bool {
         guard tabs.count > 1, let activeTabID,
               let i = tabs.firstIndex(where: { $0.id == activeTabID })
-        else { return }
-        selectTab(tabs[(i - 1 + tabs.count) % tabs.count].id)
+        else { return false }
+        return selectTab(tabs[(i - 1 + tabs.count) % tabs.count].id)
     }
 
     /// Builds a recency-ordered list of tab IDs: current tab first, then most-recent-first from history.
@@ -297,9 +303,10 @@ final class Workspace: Identifiable {
         activeTabID = tabID
     }
 
-    func selectTabByIndex(_ index: Int) {
-        guard index >= 0, index < tabs.count else { return }
-        selectTab(tabs[index].id)
+    @discardableResult
+    func selectTabByIndex(_ index: Int) -> Bool {
+        guard index >= 0, index < tabs.count else { return false }
+        return selectTab(tabs[index].id)
     }
 
     func reorderTabs(fromOffsets source: IndexSet, toOffset destination: Int) {

--- a/Macterm/Persistence/WorkspacePersistence.swift
+++ b/Macterm/Persistence/WorkspacePersistence.swift
@@ -64,6 +64,12 @@ indirect enum SplitNodeSnapshot: Codable {
 struct PaneSnapshot: Codable {
     let id: UUID
     let projectPath: String
+    /// Whether the pane was left in the "done / needs attention" state when the
+    /// app last quit, so the green checkmark survives a restart until the user
+    /// acknowledges it. Only `.done` is worth persisting: `.running` can't
+    /// outlive the shell process, and `.idle` is the default. Optional so older
+    /// snapshots (without the field) decode as nil / idle.
+    var needsAttention: Bool?
     // No `title`: the tab name is derived live from the pane's foreground
     // process, so there's nothing per-pane to persist. (An older snapshot's
     // `title` key is harmlessly ignored on decode.)
@@ -168,7 +174,11 @@ enum WorkspaceSerializer {
             // the user had navigated to. Falls back to projectPath when the
             // surface hasn't reported a pwd yet.
             let path = p.nsView?.currentPwd ?? p.projectPath
-            return .pane(PaneSnapshot(id: p.id, projectPath: path))
+            return .pane(PaneSnapshot(
+                id: p.id,
+                projectPath: path,
+                needsAttention: p.executionState == .done
+            ))
         case let .split(b):
             return .split(SplitBranchSnapshot(
                 direction: b.direction,
@@ -183,6 +193,7 @@ enum WorkspaceSerializer {
         switch snap {
         case let .pane(p):
             let pane = Pane(projectPath: p.projectPath, projectID: projectID)
+            if p.needsAttention == true { pane.restoreNeedsAttention() }
             return .pane(pane)
         case let .split(b):
             return .split(SplitBranch(

--- a/Macterm/Persistence/WorkspacePersistence.swift
+++ b/Macterm/Persistence/WorkspacePersistence.swift
@@ -8,7 +8,7 @@ private let logger = Logger(subsystem: appBundleID, category: "WorkspacePersiste
 /// Current schema version. Bump when the snapshot types change shape.
 /// Adding an optional field does NOT require a bump — Codable decodes
 /// missing fields as nil / default. Removing or renaming fields does.
-private let currentSchemaVersion = 3
+private let currentSchemaVersion = 4
 
 /// Top-level on-disk representation. Wraps the workspace array so we can
 /// evolve the file format (add fields, do migrations) without renaming the
@@ -102,7 +102,7 @@ final class WorkspaceStore {
             }
             // Fallback: pre-envelope format where the file was a bare array
             // of WorkspaceSnapshot. Upgrade on next save.
-            return try decoder.decode([WorkspaceSnapshot].self, from: data)
+            return try clearPersistedAttention(in: decoder.decode([WorkspaceSnapshot].self, from: data))
         } catch {
             logger.error("Failed to load workspaces: \(error)")
             return []
@@ -120,15 +120,48 @@ final class WorkspaceStore {
         }
     }
 
-    /// Apply any needed in-memory migrations. Currently a no-op — future
-    /// schema bumps add cases here.
+    /// Apply any needed in-memory migrations.
     private func migrate(_ file: WorkspacesFile) -> WorkspacesFile {
-        // switch file.version {
-        // case 3: return file
-        // case 4: return migrateV4(file)
-        // ...
-        // }
-        file
+        if file.version < 4 {
+            // v3 could persist spurious completion checkmarks for tabs that had
+            // already been visually cleared. Drop the old attention bits once;
+            // v4+ saves them only after the false-start and clear/save fixes.
+            logger.info("Migrating workspaces v\(file.version, privacy: .public)→4: clearing persisted attention bits")
+            return WorkspacesFile(version: 4, workspaces: clearPersistedAttention(in: file.workspaces))
+        }
+        return file
+    }
+
+    private func clearPersistedAttention(in snapshots: [WorkspaceSnapshot]) -> [WorkspaceSnapshot] {
+        snapshots.map { ws in
+            WorkspaceSnapshot(
+                projectID: ws.projectID,
+                activeTabID: ws.activeTabID,
+                tabs: ws.tabs.map { tab in
+                    TabSnapshot(
+                        id: tab.id,
+                        customTitle: tab.customTitle,
+                        focusedPaneID: tab.focusedPaneID,
+                        splitRoot: clearPersistedAttention(in: tab.splitRoot)
+                    )
+                }
+            )
+        }
+    }
+
+    private func clearPersistedAttention(in node: SplitNodeSnapshot) -> SplitNodeSnapshot {
+        switch node {
+        case var .pane(p):
+            p.needsAttention = nil
+            return .pane(p)
+        case let .split(b):
+            return .split(SplitBranchSnapshot(
+                direction: b.direction,
+                ratio: b.ratio,
+                first: clearPersistedAttention(in: b.first),
+                second: clearPersistedAttention(in: b.second)
+            ))
+        }
     }
 }
 
@@ -174,10 +207,11 @@ enum WorkspaceSerializer {
             // the user had navigated to. Falls back to projectPath when the
             // surface hasn't reported a pwd yet.
             let path = p.nsView?.currentPwd ?? p.projectPath
+            let needsAttention = p.executionState == .done
             return .pane(PaneSnapshot(
                 id: p.id,
                 projectPath: path,
-                needsAttention: p.executionState == .done
+                needsAttention: needsAttention
             ))
         case let .split(b):
             return .split(SplitBranchSnapshot(
@@ -193,7 +227,9 @@ enum WorkspaceSerializer {
         switch snap {
         case let .pane(p):
             let pane = Pane(projectPath: p.projectPath, projectID: projectID)
-            if p.needsAttention == true { pane.restoreNeedsAttention() }
+            if p.needsAttention == true {
+                pane.restoreNeedsAttention()
+            }
             return .pane(pane)
         case let .split(b):
             return .split(SplitBranch(

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -173,6 +173,10 @@ private struct GhosttyCLIBanner: View {
 private struct AppearanceSettings: View {
     @AppStorage(Preferences.Keys.projectIconSymbol)
     private var projectIconSymbol = "folder"
+    @AppStorage(Preferences.Keys.tabIconSymbol)
+    private var tabIconSymbol = "terminal"
+    @AppStorage(Preferences.Keys.tabIndicatorMode)
+    private var tabIndicatorMode = TabIndicatorMode.icon.rawValue
     @AppStorage(Preferences.Keys.showNewProjectButton)
     private var showNewProjectButton = true
     @AppStorage(Preferences.Keys.tabSwitcherVisibility)
@@ -245,6 +249,23 @@ private struct AppearanceSettings: View {
                     }
                 }
                 .onChange(of: projectIconSymbol) { _, v in Preferences.shared.projectIconSymbol = v }
+
+                Picker("Tab indicator", selection: $tabIndicatorMode) {
+                    ForEach(TabIndicatorMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode.rawValue)
+                    }
+                }
+                .onChange(of: tabIndicatorMode) { _, v in
+                    Preferences.shared.tabIndicatorMode = TabIndicatorMode(rawValue: v) ?? .icon
+                }
+
+                Picker("Tab icon", selection: $tabIconSymbol) {
+                    ForEach(Preferences.tabIconChoices, id: \.self) { name in
+                        iconPickerLabel(name).tag(name)
+                    }
+                }
+                .onChange(of: tabIconSymbol) { _, v in Preferences.shared.tabIconSymbol = v }
+                .disabled(tabIndicatorMode == TabIndicatorMode.status.rawValue)
 
                 Toggle("Show New Project button", isOn: $showNewProjectButton)
                     .onChange(of: showNewProjectButton) { _, v in Preferences.shared.showNewProjectButton = v }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -175,8 +175,8 @@ private struct AppearanceSettings: View {
     private var projectIconSymbol = "folder"
     @AppStorage(Preferences.Keys.tabIconSymbol)
     private var tabIconSymbol = "terminal"
-    @AppStorage(Preferences.Keys.tabIndicatorMode)
-    private var tabIndicatorMode = TabIndicatorMode.icon.rawValue
+    @AppStorage(Preferences.Keys.showTabStatusIndicator)
+    private var showTabStatusIndicator = false
     @AppStorage(Preferences.Keys.showNewProjectButton)
     private var showNewProjectButton = true
     @AppStorage(Preferences.Keys.tabSwitcherVisibility)
@@ -250,14 +250,16 @@ private struct AppearanceSettings: View {
                 }
                 .onChange(of: projectIconSymbol) { _, v in Preferences.shared.projectIconSymbol = v }
 
-                Picker("Tab indicator", selection: $tabIndicatorMode) {
-                    ForEach(TabIndicatorMode.allCases) { mode in
-                        Text(mode.displayName).tag(mode.rawValue)
+                Toggle("Show tab status indicator", isOn: $showTabStatusIndicator)
+                    .onChange(of: showTabStatusIndicator) { _, v in
+                        Preferences.shared.showTabStatusIndicator = v
                     }
-                }
-                .onChange(of: tabIndicatorMode) { _, v in
-                    Preferences.shared.tabIndicatorMode = TabIndicatorMode(rawValue: v) ?? .icon
-                }
+                Text(
+                    "Replaces a tab’s icon with a spinner while a command is running, " +
+                        "and adds a small checkmark badge when it finishes and awaits attention."
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
 
                 Picker("Tab icon", selection: $tabIconSymbol) {
                     ForEach(Preferences.tabIconChoices, id: \.self) { name in
@@ -265,7 +267,6 @@ private struct AppearanceSettings: View {
                     }
                 }
                 .onChange(of: tabIconSymbol) { _, v in Preferences.shared.tabIconSymbol = v }
-                .disabled(tabIndicatorMode == TabIndicatorMode.status.rawValue)
 
                 Toggle("Show New Project button", isOn: $showNewProjectButton)
                     .onChange(of: showNewProjectButton) { _, v in Preferences.shared.showNewProjectButton = v }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -173,8 +173,6 @@ private struct GhosttyCLIBanner: View {
 private struct AppearanceSettings: View {
     @AppStorage(Preferences.Keys.projectIconSymbol)
     private var projectIconSymbol = "folder"
-    @AppStorage(Preferences.Keys.tabIconSymbol)
-    private var tabIconSymbol = "terminal"
     @AppStorage(Preferences.Keys.showNewProjectButton)
     private var showNewProjectButton = true
     @AppStorage(Preferences.Keys.tabSwitcherVisibility)
@@ -247,13 +245,6 @@ private struct AppearanceSettings: View {
                     }
                 }
                 .onChange(of: projectIconSymbol) { _, v in Preferences.shared.projectIconSymbol = v }
-
-                Picker("Tab icon", selection: $tabIconSymbol) {
-                    ForEach(Preferences.tabIconChoices, id: \.self) { name in
-                        iconPickerLabel(name).tag(name)
-                    }
-                }
-                .onChange(of: tabIconSymbol) { _, v in Preferences.shared.tabIconSymbol = v }
 
                 Toggle("Show New Project button", isOn: $showNewProjectButton)
                     .onChange(of: showNewProjectButton) { _, v in Preferences.shared.showNewProjectButton = v }

--- a/Macterm/System/ProcessInspector.swift
+++ b/Macterm/System/ProcessInspector.swift
@@ -70,6 +70,47 @@ enum ProcessInspector {
         return pid
     }
 
+    /// Whether the pane's foreground process is a shell. Prefer the process's
+    /// executable/argv path over its display name; the shell set itself comes
+    /// from the host (`getusershell`, login shell, `$SHELL`) rather than a
+    /// Macterm-maintained list.
+    @MainActor
+    static func foregroundProcessIsShell(forPane pane: Pane) -> Bool {
+        guard let pid = pane.nsView?.foregroundPID else { return false }
+        return isShellProcess(pid: pid)
+    }
+
+    static func isShellProcess(pid: pid_t) -> Bool {
+        if let path = execPath(pid: pid), isShellProcessName(path) { return true }
+        if let firstArg = argv(pid: pid)?.first, isShellProcessName(firstArg) { return true }
+        if let name = comm(pid: pid), isShellProcessName(name) { return true }
+        return false
+    }
+
+    /// Whether the pane's tty is in raw/cbreak-style input mode. Full-screen and
+    /// interactive CLIs (editors, ssh, agent TUIs) commonly disable canonical
+    /// input and/or echo while they are idle at their own prompt. Plain shell
+    /// commands like `sleep 20` leave the tty in canonical mode, so this lets the
+    /// sidebar avoid treating every long-lived interactive foreground process as
+    /// perpetual work without app-specific process-name exclusions.
+    @MainActor
+    static func terminalInputIsRaw(forPane pane: Pane) -> Bool {
+        terminalInputIsRaw(ttyPath: pane.nsView?.ttyName)
+    }
+
+    static func terminalInputIsRaw(ttyPath: String?) -> Bool {
+        guard let ttyPath else { return false }
+        let fd = open(ttyPath, O_RDONLY | O_NOCTTY | O_NONBLOCK)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var attrs = termios()
+        guard tcgetattr(fd, &attrs) == 0 else { return false }
+        let canonical = attrs.c_lflag & tcflag_t(ICANON) != 0
+        let echo = attrs.c_lflag & tcflag_t(ECHO) != 0
+        return !canonical || !echo
+    }
+
     /// The kernel short accounting name (`p_comm` / `pbsi_comm`) of `pid` — a
     /// basename truncated to `MAXCOMLEN`, no path or arguments — or nil. Same
     /// field tmux uses for window names.
@@ -107,18 +148,29 @@ enum ProcessInspector {
         return first.hasPrefix("-") ? String(first.dropFirst()) : first
     }
 
+    /// Whether `name` names a shell according to the system user-shell database
+    /// (`/etc/shells` via `getusershell`) plus the current login/environment
+    /// shell. This keeps shell detection aligned with the host instead of a
+    /// hardcoded list that inevitably misses user-installed shells.
+    static func isShellProcessName(_ name: String?) -> Bool {
+        guard let name else { return false }
+        let basename = shellBasename(name)
+        guard !basename.isEmpty else { return false }
+        return knownShellBasenames.contains(basename)
+    }
+
     /// Basename of a shell argv/path with a leading login-shell `-` stripped.
     private static func shellBasename(_ s: String) -> String {
-        var name = s
+        var name = s.trimmingCharacters(in: .whitespacesAndNewlines)
         if name.hasPrefix("-") { name.removeFirst() }
-        return (name as NSString).lastPathComponent
+        return (name as NSString).lastPathComponent.lowercased()
     }
 
     /// Basename of the user's login shell (`getpwuid`), for distinguishing a
     /// deliberately-launched shell from the idle default.
     private static let loginShellBasename: String = {
         guard let loginShell = getpwuid(getuid())?.pointee.pw_shell.map({ String(cString: $0) }) else { return "" }
-        return (loginShell as NSString).lastPathComponent
+        return (loginShell as NSString).lastPathComponent.lowercased()
     }()
 
     /// The argument vector of `pid` (argv[0…argc-1]) via KERN_PROCARGS2, or nil.
@@ -166,12 +218,25 @@ enum ProcessInspector {
     /// idle prompt, not a command worth capturing). Matches the basename with a
     /// leading login-shell `-` stripped.
     private static func isShell(_ argv0: String) -> Bool {
-        knownShells.contains(shellBasename(argv0))
+        isShellProcessName(argv0)
     }
 
-    private static let knownShells: Set<String> = [
-        "sh", "bash", "zsh", "fish", "nu", "dash", "ksh", "tcsh", "csh", "ash", "xonsh", "elvish",
-    ]
+    private static let knownShellBasenames: Set<String> = {
+        var shells = Set<String>()
+        setusershell()
+        while let ptr = getusershell() {
+            let basename = shellBasename(String(cString: ptr))
+            if !basename.isEmpty { shells.insert(basename) }
+        }
+        endusershell()
+
+        if !loginShellBasename.isEmpty { shells.insert(loginShellBasename) }
+        if let envShell = ProcessInfo.processInfo.environment["SHELL"] {
+            let basename = shellBasename(envShell)
+            if !basename.isEmpty { shells.insert(basename) }
+        }
+        return shells
+    }()
 
     /// Join argv into a display command, stripping a leading login-shell `-`.
     private static func displayCommand(_ argv: [String]) -> String? {

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -215,6 +215,9 @@ struct WorkspaceView: View {
                     appState.saveWorkspaces()
                 },
                 onClosePane: { appState.requestClosePane($0, projectID: project.id) },
+                onCommandFinished: { paneID in
+                    appState.acknowledgeFinishedCommandIfActive(paneID: paneID, projectID: project.id)
+                },
                 onToggleZoom: { tab.toggleZoom(paneID: $0) },
                 onMovePane: { source, destination, zone in
                     if tab.movePane(source, onto: destination, zone: zone) {

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -418,6 +418,13 @@ private struct QuickTerminalView: View {
             onFocusPane: { state.focusPane($0) },
             onSplit: { paneID, dir in state.split(paneID: paneID, direction: dir) },
             onClosePane: { state.closePane($0) },
+            onCommandFinished: { paneID in
+                guard QuickTerminalService.shared.panelRef?.isKeyWindow == true,
+                      state.focusedPaneID == paneID,
+                      let pane = state.tab.splitRoot.findPane(id: paneID)
+                else { return }
+                pane.acknowledgeCommandCompletion()
+            },
             onToggleZoom: { state.tab.toggleZoom(paneID: $0) },
             onMovePane: { source, destination, zone in
                 state.tab.movePane(source, onto: destination, zone: zone)

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -322,6 +322,10 @@ private struct SidebarTabRow: View {
 
     private var displayState: TerminalExecutionState {
         if tab.executionState == .running { return .running }
+        // The tab the user is already looking at never needs an attention
+        // indicator; a background tab's `done` checkmark is shown until it's
+        // acknowledged (which focusing it does, via the poll's
+        // `acknowledgeFinishedCommandIfActive`).
         return isActive ? .idle : tab.executionState
     }
 

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -240,8 +240,8 @@ private struct SidebarTabRow: View {
     private var appState
     @AppStorage(Preferences.Keys.tabIconSymbol)
     private var tabIconSymbol = "terminal"
-    @AppStorage(Preferences.Keys.tabIndicatorMode)
-    private var tabIndicatorMode = TabIndicatorMode.icon.rawValue
+    @AppStorage(Preferences.Keys.showTabStatusIndicator)
+    private var showTabStatusIndicator = false
     @State
     private var isRenaming = false
     @State
@@ -268,21 +268,25 @@ private struct SidebarTabRow: View {
 
     var body: some View {
         Group {
-            if tabIndicatorMode == TabIndicatorMode.status.rawValue {
+            if tabIconSymbol == Preferences.noIcon {
                 Label {
                     titleContent
                 } icon: {
-                    TerminalStateIndicator(state: displayState)
+                    if showTabStatusIndicator {
+                        TabStatusGlyph(state: displayState, symbol: tabIconSymbol, index: index)
+                    }
                 }
-            } else if tabIconSymbol == Preferences.noIcon {
-                titleContent
-                    .padding(.leading, 6)
+                .labelStyle(.titleAndIcon)
             } else {
                 Label {
                     titleContent
                 } icon: {
-                    SidebarRowIcon(symbol: tabIconSymbol, index: index)
-                        .foregroundStyle(.secondary)
+                    if showTabStatusIndicator {
+                        TabStatusGlyph(state: displayState, symbol: tabIconSymbol, index: index)
+                    } else {
+                        SidebarRowIcon(symbol: tabIconSymbol, index: index)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }
@@ -337,35 +341,51 @@ private struct SidebarTabRow: View {
     }
 }
 
-private struct TerminalStateIndicator: View {
+/// The tab icon with a coexisting status indicator (the maintainer's
+/// suggestion): the user's chosen icon stays put, and status is additive.
+///
+/// - `running`: a small spinner replaces the icon (temporary prominence,
+///   Xcode-build-navigator style).
+/// - `done` (needs attention): the icon with a small solid status dot in the
+///   bottom-trailing corner — like the Messages/FaceTime "available" dot. A
+///   dot reads as "done/positive" without competing with the icon's identity,
+///   and it avoids the heavy, off-platform look of a checkmark glyph badge.
+/// - `idle`: the icon as-is.
+private struct TabStatusGlyph: View {
     let state: TerminalExecutionState
+    let symbol: String
+    let index: Int
 
     var body: some View {
-        Group {
-            switch state {
-            case .running:
-                ProgressView()
-                    .controlSize(.small)
-                    .tint(.secondary)
-            case .done:
-                Image(systemName: "checkmark.circle.fill")
-                    .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(.green)
-            case .idle:
-                Image(systemName: "circle")
-                    .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .help(helpText)
-        .frame(width: 12, height: 12)
-    }
-
-    private var helpText: String {
         switch state {
-        case .running: "Running"
-        case .done: "Done"
-        case .idle: "Idle"
+        case .running:
+            ProgressView()
+                .controlSize(.small)
+                .tint(.secondary)
+                .help("Running")
+                .frame(width: 16, height: 16)
+        case .done:
+            SidebarRowIcon(symbol: symbol, index: index)
+                .foregroundStyle(.secondary)
+                .overlay(alignment: .bottomTrailing) {
+                    // Opaque (not translucent) so it reads clearly over the
+                    // icon and the sidebar background. Nested in a background
+                    // ring so it stays legible over any icon color.
+                    Circle()
+                        .fill(.background)
+                        .frame(width: 7, height: 7)
+                        .overlay(
+                            Circle()
+                                .fill(.green)
+                                .frame(width: 5, height: 5)
+                        )
+                        .offset(x: 2.5, y: 2.5)
+                }
+                .help("Done")
+        case .idle:
+            SidebarRowIcon(symbol: symbol, index: index)
+                .foregroundStyle(.secondary)
+                .help("Idle")
         }
     }
 }

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -27,8 +27,11 @@ struct SidebarContent: View {
                     get: { expandedProjects.contains(project.id) },
                     set: { if $0 { expandedProjects.insert(project.id) } else { expandedProjects.remove(project.id) } }
                 )) {
-                    ForEach(Array(tabs.enumerated()), id: \.element.id) { tabIndex, tab in
-                        SidebarTabRow(tab: tab, index: tabIndex + 1) {
+                    ForEach(Array(tabs.enumerated()), id: \.element.id) { _, tab in
+                        SidebarTabRow(
+                            tab: tab,
+                            isActive: ws?.activeTabID == tab.id && appState.activeProjectID == project.id
+                        ) {
                             appState.closeTab(tab.id, projectID: project.id)
                         } onRename: { newName in
                             tab.customTitle = newName.isEmpty ? nil : newName
@@ -221,13 +224,11 @@ private struct SidebarProjectRow: View {
 
 private struct SidebarTabRow: View {
     let tab: TerminalTab
-    let index: Int
+    let isActive: Bool
     let onClose: () -> Void
     let onRename: (String) -> Void
     @Environment(AppState.self)
     private var appState
-    @AppStorage(Preferences.Keys.tabIconSymbol)
-    private var tabIconSymbol = "terminal"
     @State
     private var isRenaming = false
     @State
@@ -253,18 +254,10 @@ private struct SidebarTabRow: View {
     }
 
     var body: some View {
-        Group {
-            if tabIconSymbol == Preferences.noIcon {
-                titleContent
-                    .padding(.leading, 6)
-            } else {
-                Label {
-                    titleContent
-                } icon: {
-                    SidebarRowIcon(symbol: tabIconSymbol, index: index)
-                        .foregroundStyle(.secondary)
-                }
-            }
+        Label {
+            titleContent
+        } icon: {
+            TerminalStateIndicator(state: displayState)
         }
         .contextMenu {
             Button("Rename Tab") { beginRename() }
@@ -293,9 +286,47 @@ private struct SidebarTabRow: View {
         appState.restoreFocusToActivePane()
     }
 
+    private var displayState: TerminalExecutionState {
+        if tab.executionState == .running { return .running }
+        return isActive ? .idle : tab.executionState
+    }
+
     private func cancelRename() {
         isRenaming = false
         appState.restoreFocusToActivePane()
+    }
+}
+
+private struct TerminalStateIndicator: View {
+    let state: TerminalExecutionState
+
+    var body: some View {
+        Group {
+            switch state {
+            case .running:
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.secondary)
+            case .done:
+                Image(systemName: "checkmark.circle.fill")
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.green)
+            case .idle:
+                Image(systemName: "circle")
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .help(helpText)
+        .frame(width: 12, height: 12)
+    }
+
+    private var helpText: String {
+        switch state {
+        case .running: "Running"
+        case .done: "Done"
+        case .idle: "Idle"
+        }
     }
 }
 

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -27,9 +27,10 @@ struct SidebarContent: View {
                     get: { expandedProjects.contains(project.id) },
                     set: { if $0 { expandedProjects.insert(project.id) } else { expandedProjects.remove(project.id) } }
                 )) {
-                    ForEach(Array(tabs.enumerated()), id: \.element.id) { _, tab in
+                    ForEach(Array(tabs.enumerated()), id: \.element.id) { tabIndex, tab in
                         SidebarTabRow(
                             tab: tab,
+                            index: tabIndex + 1,
                             isActive: ws?.activeTabID == tab.id && appState.activeProjectID == project.id
                         ) {
                             appState.closeTab(tab.id, projectID: project.id)
@@ -224,11 +225,16 @@ private struct SidebarProjectRow: View {
 
 private struct SidebarTabRow: View {
     let tab: TerminalTab
+    let index: Int
     let isActive: Bool
     let onClose: () -> Void
     let onRename: (String) -> Void
     @Environment(AppState.self)
     private var appState
+    @AppStorage(Preferences.Keys.tabIconSymbol)
+    private var tabIconSymbol = "terminal"
+    @AppStorage(Preferences.Keys.tabIndicatorMode)
+    private var tabIndicatorMode = TabIndicatorMode.icon.rawValue
     @State
     private var isRenaming = false
     @State
@@ -254,10 +260,24 @@ private struct SidebarTabRow: View {
     }
 
     var body: some View {
-        Label {
-            titleContent
-        } icon: {
-            TerminalStateIndicator(state: displayState)
+        Group {
+            if tabIndicatorMode == TabIndicatorMode.status.rawValue {
+                Label {
+                    titleContent
+                } icon: {
+                    TerminalStateIndicator(state: displayState)
+                }
+            } else if tabIconSymbol == Preferences.noIcon {
+                titleContent
+                    .padding(.leading, 6)
+            } else {
+                Label {
+                    titleContent
+                } icon: {
+                    SidebarRowIcon(symbol: tabIconSymbol, index: index)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
         .contextMenu {
             Button("Rename Tab") { beginRename() }

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -324,8 +324,10 @@ private struct SidebarTabRow: View {
         if tab.executionState == .running { return .running }
         // The tab the user is already looking at never needs an attention
         // indicator; a background tab's `done` checkmark is shown until it's
-        // acknowledged (which focusing it does, via the poll's
-        // `acknowledgeFinishedCommandIfActive`).
+        // acknowledged. Visiting the tab clears all of its panes via the poll's
+        // `acknowledgeFinishedCommandIfActive` (which acknowledges the whole
+        // active tab, not just the focused pane, so the persisted state matches
+        // what's displayed).
         return isActive ? .idle : tab.executionState
     }
 

--- a/Macterm/Views/SplitTreeView.swift
+++ b/Macterm/Views/SplitTreeView.swift
@@ -12,6 +12,7 @@ struct SplitTreeView: View {
     let onFocusPane: (UUID) -> Void
     let onSplit: (UUID, SplitDirection) -> Void
     let onClosePane: (UUID) -> Void
+    let onCommandFinished: (UUID) -> Void
     let onToggleZoom: (UUID) -> Void
     let onMovePane: @MainActor (UUID, UUID, PaneDropZone) -> Void
 
@@ -25,6 +26,7 @@ struct SplitTreeView: View {
         onFocusPane: @escaping (UUID) -> Void,
         onSplit: @escaping (UUID, SplitDirection) -> Void,
         onClosePane: @escaping (UUID) -> Void,
+        onCommandFinished: @escaping (UUID) -> Void = { _ in },
         onToggleZoom: @escaping (UUID) -> Void = { _ in },
         onMovePane: @escaping @MainActor (UUID, UUID, PaneDropZone) -> Void = { _, _, _ in }
     ) {
@@ -37,6 +39,7 @@ struct SplitTreeView: View {
         self.onFocusPane = onFocusPane
         self.onSplit = onSplit
         self.onClosePane = onClosePane
+        self.onCommandFinished = onCommandFinished
         self.onToggleZoom = onToggleZoom
         self.onMovePane = onMovePane
     }
@@ -51,6 +54,7 @@ struct SplitTreeView: View {
                 isSplit: isSplit,
                 onFocus: { onFocusPane(pane.id) },
                 onProcessExit: { onClosePane(pane.id) },
+                onCommandFinished: { onCommandFinished(pane.id) },
                 onSplitRequest: { dir in onSplit(pane.id, dir) },
                 onZoomRequest: { onToggleZoom(pane.id) },
                 onMovePane: onMovePane
@@ -68,6 +72,7 @@ struct SplitTreeView: View {
                     onFocusPane: onFocusPane,
                     onSplit: onSplit,
                     onClosePane: onClosePane,
+                    onCommandFinished: onCommandFinished,
                     onToggleZoom: onToggleZoom,
                     onMovePane: onMovePane
                 )
@@ -83,6 +88,7 @@ struct SplitTreeView: View {
                     onFocusPane: onFocusPane,
                     onSplit: onSplit,
                     onClosePane: onClosePane,
+                    onCommandFinished: onCommandFinished,
                     onToggleZoom: onToggleZoom,
                     onMovePane: onMovePane
                 )
@@ -102,6 +108,7 @@ private struct SplitLeafView: View {
     let isSplit: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
+    let onCommandFinished: () -> Void
     let onSplitRequest: (SplitDirection) -> Void
     let onZoomRequest: () -> Void
     let onMovePane: @MainActor (UUID, UUID, PaneDropZone) -> Void
@@ -122,6 +129,7 @@ private struct SplitLeafView: View {
                 isZoomed: isZoomed,
                 onFocus: onFocus,
                 onProcessExit: onProcessExit,
+                onCommandFinished: onCommandFinished,
                 onSplitRequest: { dir, _ in onSplitRequest(dir) },
                 onZoomRequest: onZoomRequest
             )

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -799,7 +799,8 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private func unshiftedCodepoint(from event: NSEvent) -> UInt32 {
-        guard let chars = event.characters(byApplyingModifiers: []),
+        guard event.type == .keyDown || event.type == .keyUp,
+              let chars = event.characters(byApplyingModifiers: []),
               let scalar = chars.unicodeScalars.first
         else { return 0 }
         return scalar.value

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -51,6 +51,23 @@ final class GhosttyTerminalNSView: NSView {
         onTitleChange?(title)
     }
 
+    func surfaceDidReportProgress(running: Bool) {
+        if running {
+            onProgressStarted?()
+        } else {
+            onProgressFinished?()
+        }
+    }
+
+    func surfaceDidUpdateScrollbar(total: UInt64, offset: UInt64, len: UInt64) {
+        let snapshot = ScrollbarSnapshot(total: total, offset: offset, len: len)
+        if let lastScrollbarSnapshot, total > lastScrollbarSnapshot.total {
+            onTerminalActivity?()
+        }
+        lastScrollbarSnapshot = snapshot
+        onScrollbarUpdate?(total, offset, len)
+    }
+
     var onFocus: (() -> Void)?
     var onInteraction: (() -> Void)?
     var onProcessExit: (() -> Void)?
@@ -63,6 +80,9 @@ final class GhosttyTerminalNSView: NSView {
     var onSearchSelected: ((Int?) -> Void)?
     var onDesktopNotification: ((String, String) -> Void)?
     var onCommandFinished: ((Int16, UInt64) -> Void)?
+    var onProgressStarted: (() -> Void)?
+    var onProgressFinished: (() -> Void)?
+    var onTerminalActivity: (() -> Void)?
     /// libghostty pushes scrollback geometry (all values in rows) whenever the
     /// viewport, scrollback size, or visible row count changes.
     /// `(total, offset, len)`: total rows including scrollback, the first
@@ -70,6 +90,14 @@ final class GhosttyTerminalNSView: NSView {
     var onScrollbarUpdate: ((UInt64, UInt64, UInt64) -> Void)?
     var isFocused: Bool = false
     var currentPwd: String?
+
+    private var lastScrollbarSnapshot: ScrollbarSnapshot?
+
+    private struct ScrollbarSnapshot: Equatable {
+        let total: UInt64
+        let offset: UInt64
+        let len: UInt64
+    }
 
     private var _markedRange: NSRange = .init(location: NSNotFound, length: 0)
     private var _selectedRange: NSRange = .init(location: NSNotFound, length: 0)
@@ -198,6 +226,18 @@ final class GhosttyTerminalNSView: NSView {
         guard let surface else { return nil }
         let pid = ghostty_surface_foreground_pid(surface)
         return pid != 0 ? pid_t(pid) : nil
+    }
+
+    /// The slave tty path for this surface's pty, used by `ProcessInspector` to
+    /// read terminal input mode (canonical shell command vs raw/cbreak TUI).
+    var ttyName: String? {
+        guard let surface else { return nil }
+        let tty = ghostty_surface_tty_name(surface)
+        defer { ghostty_string_free(tty) }
+        guard let ptr = tty.ptr, tty.len > 0 else { return nil }
+        let bytes = UnsafeBufferPointer(start: ptr, count: Int(tty.len)).map { UInt8(bitPattern: $0) }
+        guard let name = String(bytes: bytes, encoding: .utf8), !name.isEmpty else { return nil }
+        return name
     }
 
     deinit {

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -52,6 +52,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     var onFocus: (() -> Void)?
+    var onInteraction: (() -> Void)?
     var onProcessExit: (() -> Void)?
     var onSplitRequest: ((SplitDirection, SplitPosition) -> Void)?
     var onZoomRequest: (() -> Void)?
@@ -373,6 +374,7 @@ final class GhosttyTerminalNSView: NSView {
     // MARK: - Keyboard
 
     override func keyDown(with event: NSEvent) {
+        onInteraction?()
         guard let surface else { super.keyDown(with: event)
             return
         }
@@ -467,6 +469,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func flagsChanged(with event: NSEvent) {
+        onInteraction?()
         guard let surface else { return }
         var ke = buildKeyEvent(from: event, action: isFlagPress(event) ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE)
         ke.text = nil
@@ -475,6 +478,7 @@ final class GhosttyTerminalNSView: NSView {
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if isAppShortcut(event) { return false }
+        onInteraction?()
         guard window?.firstResponder === self || window?.firstResponder === inputContext else { return false }
         guard event.type == .keyDown, let surface else { return false }
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -496,6 +500,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        onInteraction?()
         guard let surface else { return }
         window?.makeFirstResponder(self)
         ghostty_surface_set_focus(surface, true)
@@ -531,6 +536,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func rightMouseDown(with event: NSEvent) {
+        onInteraction?()
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
@@ -549,6 +555,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func scrollWheel(with event: NSEvent) {
+        onInteraction?()
         guard let surface else { return }
         var scrollMods: ghostty_input_scroll_mods_t = 0
         if event.hasPreciseScrollingDeltas { scrollMods |= 1 }
@@ -595,6 +602,7 @@ final class GhosttyTerminalNSView: NSView {
 
     @objc
     private func handlePaste() {
+        onInteraction?()
         guard let text = GhosttyCallbacks.readPasteboardText() else { return }
         window?.makeFirstResponder(self)
         insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -126,7 +126,7 @@ private struct TerminalSurface: NSViewRepresentable {
     private func configure(_ view: GhosttyTerminalNSView) {
         view.onFocus = onFocus
         view.onInteraction = { [weak pane] in
-            pane?.acknowledgeCommandCompletion()
+            pane?.recordUserInteraction()
         }
         view.onProcessExit = onProcessExit
         view.onSplitRequest = onSplitRequest
@@ -181,6 +181,21 @@ private struct TerminalSurface: NSViewRepresentable {
                 trigger: nil
             )
             UNUserNotificationCenter.current().add(request)
+        }
+        view.onProgressStarted = { [weak pane] in
+            pane?.refreshForegroundProcess()
+            pane?.markCommandRunning()
+        }
+        view.onProgressFinished = { [weak pane] in
+            guard let pane, pane.executionState == .running else { return }
+            pane.refreshForegroundProcess()
+            pane.markProgressFinished()
+            onCommandFinished()
+        }
+        view.onTerminalActivity = { [weak pane] in
+            guard let pane else { return }
+            pane.refreshForegroundProcess()
+            pane.markTerminalActivity()
         }
         view.onCommandFinished = { [weak pane, weak view] exitCode, durationNs in
             guard let pane else { return }

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -183,24 +183,30 @@ private struct TerminalSurface: NSViewRepresentable {
             UNUserNotificationCenter.current().add(request)
         }
         view.onProgressStarted = { [weak pane] in
+            guard Preferences.shared.tabIndicatorMode == .status else { return }
             pane?.refreshForegroundProcess()
             pane?.markCommandRunning()
         }
         view.onProgressFinished = { [weak pane] in
-            guard let pane, pane.executionState == .running else { return }
+            guard let pane,
+                  Preferences.shared.tabIndicatorMode == .status,
+                  pane.executionState == .running
+            else { return }
             pane.refreshForegroundProcess()
             pane.markProgressFinished()
             onCommandFinished()
         }
         view.onTerminalActivity = { [weak pane] in
-            guard let pane else { return }
+            guard let pane, Preferences.shared.tabIndicatorMode == .status else { return }
             pane.refreshForegroundProcess()
             pane.markTerminalActivity()
         }
         view.onCommandFinished = { [weak pane, weak view] exitCode, durationNs in
             guard let pane else { return }
-            pane.markCommandFinished()
-            onCommandFinished()
+            if Preferences.shared.tabIndicatorMode == .status {
+                pane.markCommandFinished()
+                onCommandFinished()
+            }
             guard !(NSApp.isActive && view?.isFocused == true) else { return }
             let durationSec = Double(durationNs) / 1_000_000_000
             let body = if exitCode < 0 {

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -183,13 +183,13 @@ private struct TerminalSurface: NSViewRepresentable {
             UNUserNotificationCenter.current().add(request)
         }
         view.onProgressStarted = { [weak pane] in
-            guard Preferences.shared.tabIndicatorMode == .status else { return }
+            guard Preferences.shared.showTabStatusIndicator else { return }
             pane?.refreshForegroundProcess()
             pane?.markCommandRunning()
         }
         view.onProgressFinished = { [weak pane] in
             guard let pane,
-                  Preferences.shared.tabIndicatorMode == .status,
+                  Preferences.shared.showTabStatusIndicator,
                   pane.executionState == .running
             else { return }
             pane.refreshForegroundProcess()
@@ -197,13 +197,13 @@ private struct TerminalSurface: NSViewRepresentable {
             onCommandFinished()
         }
         view.onTerminalActivity = { [weak pane] in
-            guard let pane, Preferences.shared.tabIndicatorMode == .status else { return }
+            guard let pane, Preferences.shared.showTabStatusIndicator else { return }
             pane.refreshForegroundProcess()
             pane.markTerminalActivity()
         }
         view.onCommandFinished = { [weak pane, weak view] exitCode, durationNs in
             guard let pane else { return }
-            if Preferences.shared.tabIndicatorMode == .status {
+            if Preferences.shared.showTabStatusIndicator {
                 pane.markCommandFinished()
                 onCommandFinished()
             }

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -8,6 +8,7 @@ struct TerminalPane: View {
     let isZoomed: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
+    let onCommandFinished: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
     let onZoomRequest: () -> Void
 
@@ -37,6 +38,7 @@ struct TerminalPane: View {
                 isZoomed: isZoomed,
                 onFocus: onFocus,
                 onProcessExit: onProcessExit,
+                onCommandFinished: onCommandFinished,
                 onSplitRequest: onSplitRequest,
                 onZoomRequest: onZoomRequest
             )
@@ -54,6 +56,7 @@ private struct TerminalSurface: NSViewRepresentable {
     let isZoomed: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
+    let onCommandFinished: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
     let onZoomRequest: () -> Void
 
@@ -122,6 +125,9 @@ private struct TerminalSurface: NSViewRepresentable {
 
     private func configure(_ view: GhosttyTerminalNSView) {
         view.onFocus = onFocus
+        view.onInteraction = { [weak pane] in
+            pane?.acknowledgeCommandCompletion()
+        }
         view.onProcessExit = onProcessExit
         view.onSplitRequest = onSplitRequest
         view.onZoomRequest = onZoomRequest
@@ -178,6 +184,8 @@ private struct TerminalSurface: NSViewRepresentable {
         }
         view.onCommandFinished = { [weak pane, weak view] exitCode, durationNs in
             guard let pane else { return }
+            pane.markCommandFinished()
+            onCommandFinished()
             guard !(NSApp.isActive && view?.isFocused == true) else { return }
             let durationSec = Double(durationNs) / 1_000_000_000
             let body = if exitCode < 0 {

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -281,6 +281,45 @@ struct AppStateTests {
         #expect(state.activeProjectID == p2.id)
     }
 
+    @Test
+    func selectTab_persists_cleared_completion_indicator() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-tests-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let store = WorkspaceStore(fileURL: tmp)
+        let state = makeAppState(store: store)
+        let project = seedProject(state)
+        let tab = try #require(state.workspaces[project.id]?.activeTab)
+        let pane = try #require(tab.splitRoot.allPanes().first)
+        pane.executionState = .done
+        state.saveWorkspaces()
+
+        state.selectTab(tab.id, projectID: project.id)
+
+        let restored = WorkspaceSerializer.restore(from: store.load(), validIDs: [project.id])
+        #expect(restored.first?.tabs.first?.executionState == .idle)
+    }
+
+    @Test
+    func selectProject_persists_cleared_active_tab_indicator() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-tests-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let store = WorkspaceStore(fileURL: tmp)
+        let state = makeAppState(store: store)
+        let p1 = seedProject(state, name: "p1", path: "/tmp1")
+        _ = seedProject(state, name: "p2", path: "/tmp2")
+        let tab = try #require(state.workspaces[p1.id]?.activeTab)
+        let pane = try #require(tab.splitRoot.allPanes().first)
+        pane.executionState = .done
+        state.saveWorkspaces()
+
+        state.selectProject(p1)
+
+        let restored = WorkspaceSerializer.restore(from: store.load(), validIDs: [p1.id])
+        #expect(restored.first?.tabs.first?.executionState == .idle)
+    }
+
     // MARK: - Unload project
 
     @Test

--- a/MactermTests/Model/PaneTests.swift
+++ b/MactermTests/Model/PaneTests.swift
@@ -62,18 +62,183 @@ struct PaneTests {
     }
 
     @Test
-    func applyForegroundRefresh_marks_running_for_foreground_programs() {
+    func progressFinishedFromIdle_staysIdle() {
         let p = Pane(projectPath: "/", projectID: UUID())
-        p.applyForegroundRefresh(name: "claude", foregroundPID: 42, programPID: 42)
-        #expect(p.foregroundProcessName == "claude")
+        p.markProgressFinished()
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
+    func progressStartAndFinish_tracksRunningThenDone() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.markCommandRunning()
+        #expect(p.executionState == .running)
+        p.markProgressFinished()
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func progressRunning_isNotCompletedByForegroundOrOutputActivity() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.markCommandRunning()
+        p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
+        p.markTerminalActivity(at: Date(timeIntervalSince1970: 100))
+        p.settleTerminalActivityIfQuiet(now: Date(timeIntervalSince1970: 200), quietInterval: 3)
+        #expect(p.executionState == .running)
+        p.markProgressFinished()
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func progressFinished_settlesCurrentForegroundProcess() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42)
+        p.markCommandRunning()
+        #expect(p.executionState == .running)
+        p.markProgressFinished()
+        #expect(p.executionState == .done)
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42)
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func progressFinished_settlesNextForegroundProcessWhenNoneWasCaptured() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.markCommandRunning()
+        p.markProgressFinished()
+        #expect(p.executionState == .done)
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42)
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func progressFinished_ignoresOutputFromSettledForegroundProcess() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42)
+        p.markCommandRunning()
+        p.markProgressFinished()
+        p.markTerminalActivity()
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func progressFinished_allowsForegroundRestartAfterProcessChanges() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42)
+        p.markCommandRunning()
+        p.markProgressFinished()
+        p.applyForegroundRefresh(name: "node", foregroundPID: 43)
         #expect(p.executionState == .running)
     }
 
     @Test
-    func applyForegroundRefresh_turns_running_into_done_when_foreground_returns_to_shell() {
+    func commandFinishedFromIdle_marksDone() {
         let p = Pane(projectPath: "/", projectID: UUID())
-        p.markCommandRunning()
-        p.applyForegroundRefresh(name: "nu", foregroundPID: 7, programPID: nil)
+        p.markCommandFinished()
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func applyForegroundRefresh_marks_nonShell_process_as_running() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
+        #expect(p.foregroundProcessName == "sleep")
+        #expect(p.executionState == .running)
+    }
+
+    @Test
+    func applyForegroundRefresh_marks_done_when_foreground_returns_to_shell() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
+        p.applyForegroundRefresh(name: shellName(), foregroundPID: 43, foregroundIsShell: true)
+        #expect(p.foregroundProcessName == shellName())
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func applyForegroundRefresh_marks_longLivedApps_as_running_without_exclusions_when_terminalIsCanonical() {
+        for process in ["claude", "pi", "node", "ssh"] {
+            let p = Pane(projectPath: "/", projectID: UUID())
+            p.applyForegroundRefresh(name: process, foregroundPID: 42)
+            #expect(p.foregroundProcessName == process)
+            #expect(p.executionState == .running)
+        }
+    }
+
+    @Test
+    func rawForegroundProcess_doesNotStartFromForegroundAlone() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42, terminalInputIsRaw: true)
+        #expect(p.foregroundProcessName == "node")
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
+    func rawForegroundProcess_settlesExistingForegroundOnlyRun() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42)
+        #expect(p.executionState == .running)
+
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42, terminalInputIsRaw: true)
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func rawForegroundProcess_usesOutputActivityUntilQuiet() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        let start = Date(timeIntervalSince1970: 100)
+        p.recordUserInteraction()
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42, terminalInputIsRaw: true)
+        p.markTerminalActivity(at: start)
+        #expect(p.executionState == .running)
+
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42, terminalInputIsRaw: true)
+        #expect(p.executionState == .running)
+        p.settleTerminalActivityIfQuiet(now: start.addingTimeInterval(3), quietInterval: 3)
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func terminalActivityWithoutUserInteraction_staysIdle() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.markTerminalActivity()
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
+    func terminalActivityAfterUserInteraction_marksRunningUntilQuiet() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        let start = Date(timeIntervalSince1970: 100)
+        p.recordUserInteraction()
+        p.markTerminalActivity(at: start)
+        #expect(p.executionState == .running)
+        p.settleTerminalActivityIfQuiet(now: start.addingTimeInterval(2), quietInterval: 3)
+        #expect(p.executionState == .running)
+        p.settleTerminalActivityIfQuiet(now: start.addingTimeInterval(3), quietInterval: 3)
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func foregroundProcessWithOutput_settlesAfterQuiet_withoutRestartingSameProcess() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        let start = Date(timeIntervalSince1970: 100)
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42)
+        p.markTerminalActivity(at: start)
+        #expect(p.executionState == .running)
+        p.settleTerminalActivityIfQuiet(now: start.addingTimeInterval(3), quietInterval: 3)
+        #expect(p.executionState == .done)
+        p.applyForegroundRefresh(name: "node", foregroundPID: 42)
+        #expect(p.executionState == .done)
+    }
+
+    @Test
+    func silentForegroundProcess_doesNotSettleUntilItReturnsToShell() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        let start = Date(timeIntervalSince1970: 100)
+        p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
+        p.settleTerminalActivityIfQuiet(now: start.addingTimeInterval(30), quietInterval: 3)
+        #expect(p.executionState == .running)
+        p.applyForegroundRefresh(name: shellName(), foregroundPID: 43, foregroundIsShell: true)
         #expect(p.executionState == .done)
     }
 

--- a/MactermTests/Model/PaneTests.swift
+++ b/MactermTests/Model/PaneTests.swift
@@ -69,8 +69,34 @@ struct PaneTests {
     }
 
     @Test
+    func initialForegroundBeforeUserInteraction_staysIdle() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
+        p.markTerminalActivity()
+        p.settleTerminalActivityIfQuiet(now: Date(timeIntervalSince1970: 3), quietInterval: 3)
+        #expect(p.foregroundProcessName == "sleep")
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
+    func progressBeforeUserInteraction_staysIdle() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.markCommandRunning()
+        p.markProgressFinished()
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
+    func layoutCommand_tracksInitialForegroundBeforeUserInteraction() {
+        let p = Pane(projectPath: "/", projectID: UUID(), command: "npm test")
+        p.applyForegroundRefresh(name: "npm", foregroundPID: 42)
+        #expect(p.executionState == .running)
+    }
+
+    @Test
     func executionState_marks_running_then_done_then_idle_on_acknowledge() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.markCommandRunning()
         #expect(p.executionState == .running)
         p.markCommandFinished()
@@ -89,6 +115,7 @@ struct PaneTests {
     @Test
     func progressStartAndFinish_tracksRunningThenDone() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.markCommandRunning()
         #expect(p.executionState == .running)
         p.markProgressFinished()
@@ -98,6 +125,7 @@ struct PaneTests {
     @Test
     func progressRunning_isNotCompletedByForegroundOrOutputActivity() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.markCommandRunning()
         p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
         p.markTerminalActivity(at: Date(timeIntervalSince1970: 100))
@@ -110,6 +138,7 @@ struct PaneTests {
     @Test
     func progressFinished_settlesCurrentForegroundProcess() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "node", foregroundPID: 42)
         p.markCommandRunning()
         #expect(p.executionState == .running)
@@ -122,6 +151,7 @@ struct PaneTests {
     @Test
     func progressFinished_settlesNextForegroundProcessWhenNoneWasCaptured() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.markCommandRunning()
         p.markProgressFinished()
         #expect(p.executionState == .done)
@@ -132,6 +162,7 @@ struct PaneTests {
     @Test
     func progressFinished_ignoresOutputFromSettledForegroundProcess() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "node", foregroundPID: 42)
         p.markCommandRunning()
         p.markProgressFinished()
@@ -142,6 +173,7 @@ struct PaneTests {
     @Test
     func progressFinished_allowsForegroundRestartAfterProcessChanges() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "node", foregroundPID: 42)
         p.markCommandRunning()
         p.markProgressFinished()
@@ -163,6 +195,7 @@ struct PaneTests {
     @Test
     func commandFinishedFromRunning_marksDone() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
         #expect(p.executionState == .running)
         p.markCommandFinished()
@@ -172,6 +205,7 @@ struct PaneTests {
     @Test
     func applyForegroundRefresh_marks_nonShell_process_as_running() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
         #expect(p.foregroundProcessName == "sleep")
         #expect(p.executionState == .running)
@@ -180,6 +214,7 @@ struct PaneTests {
     @Test
     func applyForegroundRefresh_marks_done_when_foreground_returns_to_shell() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
         p.applyForegroundRefresh(name: shellName(), foregroundPID: 43, foregroundIsShell: true)
         #expect(p.foregroundProcessName == shellName())
@@ -190,6 +225,7 @@ struct PaneTests {
     func applyForegroundRefresh_marks_longLivedApps_as_running_without_exclusions_when_terminalIsCanonical() {
         for process in ["claude", "pi", "node", "ssh"] {
             let p = Pane(projectPath: "/", projectID: UUID())
+            p.recordUserInteraction()
             p.applyForegroundRefresh(name: process, foregroundPID: 42)
             #expect(p.foregroundProcessName == process)
             #expect(p.executionState == .running)
@@ -207,6 +243,7 @@ struct PaneTests {
     @Test
     func rawForegroundProcess_settlesExistingForegroundOnlyRun() {
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "node", foregroundPID: 42)
         #expect(p.executionState == .running)
 
@@ -253,6 +290,7 @@ struct PaneTests {
     func foregroundProcessWithOutput_settlesAfterQuiet_withoutRestartingSameProcess() {
         let p = Pane(projectPath: "/", projectID: UUID())
         let start = Date(timeIntervalSince1970: 100)
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "node", foregroundPID: 42)
         p.markTerminalActivity(at: start)
         #expect(p.executionState == .running)
@@ -266,6 +304,7 @@ struct PaneTests {
     func silentForegroundProcess_doesNotSettleUntilItReturnsToShell() {
         let p = Pane(projectPath: "/", projectID: UUID())
         let start = Date(timeIntervalSince1970: 100)
+        p.recordUserInteraction()
         p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
         p.settleTerminalActivityIfQuiet(now: start.addingTimeInterval(30), quietInterval: 3)
         #expect(p.executionState == .running)

--- a/MactermTests/Model/PaneTests.swift
+++ b/MactermTests/Model/PaneTests.swift
@@ -51,6 +51,24 @@ struct PaneTests {
     }
 
     @Test
+    func applyForegroundRefresh_skipsExecutionState_whenIndicatorDisabled() {
+        // Mirrors `refreshForegroundProcess(trackExecution: false)`: a non-shell
+        // foreground process updates the name but must not flip executionState
+        // when the status indicator is off, so icon-mode users don't pay for
+        // tracker mutations (or the shell/raw syscalls the caller skipped).
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(
+            name: "sleep",
+            foregroundPID: 42,
+            foregroundIsShell: false,
+            terminalInputIsRaw: false,
+            applyExecutionState: false
+        )
+        #expect(p.foregroundProcessName == "sleep")
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
     func executionState_marks_running_then_done_then_idle_on_acknowledge() {
         let p = Pane(projectPath: "/", projectID: UUID())
         p.markCommandRunning()

--- a/MactermTests/Model/PaneTests.swift
+++ b/MactermTests/Model/PaneTests.swift
@@ -45,6 +45,39 @@ struct PaneTests {
     }
 
     @Test
+    func executionState_defaults_to_idle() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
+    func executionState_marks_running_then_done_then_idle_on_acknowledge() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.markCommandRunning()
+        #expect(p.executionState == .running)
+        p.markCommandFinished()
+        #expect(p.executionState == .done)
+        p.acknowledgeCommandCompletion()
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
+    func applyForegroundRefresh_marks_running_for_foreground_programs() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "claude", foregroundPID: 42, programPID: 42)
+        #expect(p.foregroundProcessName == "claude")
+        #expect(p.executionState == .running)
+    }
+
+    @Test
+    func applyForegroundRefresh_turns_running_into_done_when_foreground_returns_to_shell() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.markCommandRunning()
+        p.applyForegroundRefresh(name: "nu", foregroundPID: 7, programPID: nil)
+        #expect(p.executionState == .done)
+    }
+
+    @Test
     func init_stores_project_path() {
         let p = Pane(projectPath: "/tmp/foo", projectID: UUID())
         #expect(p.projectPath == "/tmp/foo")

--- a/MactermTests/Model/PaneTests.swift
+++ b/MactermTests/Model/PaneTests.swift
@@ -150,8 +150,21 @@ struct PaneTests {
     }
 
     @Test
-    func commandFinishedFromIdle_marksDone() {
+    func commandFinishedFromIdle_staysIdle() {
+        // Shell integration emits OSC 133;D on every precmd, including empty
+        // commands (Enter, Ctrl-C, Ctrl-L on an idle prompt). A COMMAND_FINISHED
+        // with no preceding running state must not flip the pane to `.done`, or
+        // clearing an idle terminal would persist a spurious checkmark.
         let p = Pane(projectPath: "/", projectID: UUID())
+        p.markCommandFinished()
+        #expect(p.executionState == .idle)
+    }
+
+    @Test
+    func commandFinishedFromRunning_marksDone() {
+        let p = Pane(projectPath: "/", projectID: UUID())
+        p.applyForegroundRefresh(name: "sleep", foregroundPID: 42)
+        #expect(p.executionState == .running)
         p.markCommandFinished()
         #expect(p.executionState == .done)
     }

--- a/MactermTests/Model/PaneTitleTests.swift
+++ b/MactermTests/Model/PaneTitleTests.swift
@@ -58,7 +58,7 @@ struct PaneTitleTests {
     func title_survives_while_its_pid_holds_the_foreground() {
         let pane = makePane()
         pane.receiveReportedTitle("session", programPID: 42)
-        pane.applyForegroundRefresh(name: "claude", foregroundPID: 42, programPID: 42)
+        pane.applyForegroundRefresh(name: "claude", foregroundPID: 42)
         #expect(pane.programTitle == "session")
     }
 
@@ -66,7 +66,7 @@ struct PaneTitleTests {
     func title_expires_when_foreground_returns_to_shell() {
         let pane = makePane()
         pane.receiveReportedTitle("session", programPID: 42)
-        pane.applyForegroundRefresh(name: "nu", foregroundPID: 7, programPID: nil)
+        pane.applyForegroundRefresh(name: "nu", foregroundPID: 7, foregroundIsShell: true)
         #expect(pane.programTitle == nil)
         // Display falls back to the process name.
         #expect(pane.displayTitle == "nu")
@@ -78,7 +78,7 @@ struct PaneTitleTests {
         pane.receiveReportedTitle("session", programPID: 42)
         // claude exits and btop starts between two polls: the pid changed,
         // so claude's title must not be attributed to btop.
-        pane.applyForegroundRefresh(name: "btop", foregroundPID: 43, programPID: 43)
+        pane.applyForegroundRefresh(name: "btop", foregroundPID: 43)
         #expect(pane.programTitle == nil)
         #expect(pane.displayTitle == "btop")
     }
@@ -87,7 +87,7 @@ struct PaneTitleTests {
     func title_expires_when_surface_is_gone() {
         let pane = makePane()
         pane.receiveReportedTitle("session", programPID: 42)
-        pane.applyForegroundRefresh(name: nil, foregroundPID: nil, programPID: nil)
+        pane.applyForegroundRefresh(name: nil, foregroundPID: nil)
         #expect(pane.programTitle == nil)
     }
 
@@ -96,7 +96,7 @@ struct PaneTitleTests {
     @Test
     func displayTitle_falls_back_to_process_name_without_a_program_title() {
         let pane = makePane()
-        pane.applyForegroundRefresh(name: "hx", foregroundPID: 9, programPID: nil)
+        pane.applyForegroundRefresh(name: "hx", foregroundPID: 9)
         #expect(pane.displayTitle == "hx")
     }
 

--- a/MactermTests/Model/PaneTitleTests.swift
+++ b/MactermTests/Model/PaneTitleTests.swift
@@ -58,7 +58,7 @@ struct PaneTitleTests {
     func title_survives_while_its_pid_holds_the_foreground() {
         let pane = makePane()
         pane.receiveReportedTitle("session", programPID: 42)
-        pane.applyForegroundRefresh(name: "claude", foregroundPID: 42)
+        pane.applyForegroundRefresh(name: "claude", foregroundPID: 42, programPID: 42)
         #expect(pane.programTitle == "session")
     }
 
@@ -66,7 +66,7 @@ struct PaneTitleTests {
     func title_expires_when_foreground_returns_to_shell() {
         let pane = makePane()
         pane.receiveReportedTitle("session", programPID: 42)
-        pane.applyForegroundRefresh(name: "nu", foregroundPID: 7)
+        pane.applyForegroundRefresh(name: "nu", foregroundPID: 7, programPID: nil)
         #expect(pane.programTitle == nil)
         // Display falls back to the process name.
         #expect(pane.displayTitle == "nu")
@@ -78,7 +78,7 @@ struct PaneTitleTests {
         pane.receiveReportedTitle("session", programPID: 42)
         // claude exits and btop starts between two polls: the pid changed,
         // so claude's title must not be attributed to btop.
-        pane.applyForegroundRefresh(name: "btop", foregroundPID: 43)
+        pane.applyForegroundRefresh(name: "btop", foregroundPID: 43, programPID: 43)
         #expect(pane.programTitle == nil)
         #expect(pane.displayTitle == "btop")
     }
@@ -87,7 +87,7 @@ struct PaneTitleTests {
     func title_expires_when_surface_is_gone() {
         let pane = makePane()
         pane.receiveReportedTitle("session", programPID: 42)
-        pane.applyForegroundRefresh(name: nil, foregroundPID: nil)
+        pane.applyForegroundRefresh(name: nil, foregroundPID: nil, programPID: nil)
         #expect(pane.programTitle == nil)
     }
 
@@ -96,7 +96,7 @@ struct PaneTitleTests {
     @Test
     func displayTitle_falls_back_to_process_name_without_a_program_title() {
         let pane = makePane()
-        pane.applyForegroundRefresh(name: "hx", foregroundPID: 9)
+        pane.applyForegroundRefresh(name: "hx", foregroundPID: 9, programPID: nil)
         #expect(pane.displayTitle == "hx")
     }
 

--- a/MactermTests/Model/TerminalTabTests.swift
+++ b/MactermTests/Model/TerminalTabTests.swift
@@ -159,6 +159,24 @@ struct TerminalTabTests {
         #expect(tab.splitRoot.allPanes().count == 2)
     }
 
+    // MARK: - executionState
+
+    @Test
+    func executionState_prefers_running_then_done_then_idle() throws {
+        let (tab, ids) = makeTab(H(pane("a"), H(pane("b"), pane("c"))), focused: "a")
+        let bID = try #require(ids["b"])
+        let cID = try #require(ids["c"])
+        let b = try #require(tab.splitRoot.findPane(id: bID))
+        let c = try #require(tab.splitRoot.findPane(id: cID))
+        b.executionState = .done
+        c.executionState = .running
+        #expect(tab.executionState == .running)
+        c.executionState = .idle
+        #expect(tab.executionState == .done)
+        b.executionState = .idle
+        #expect(tab.executionState == .idle)
+    }
+
     // MARK: - toggleZoom
 
     @Test

--- a/MactermTests/Model/WorkspaceTests.swift
+++ b/MactermTests/Model/WorkspaceTests.swift
@@ -103,6 +103,20 @@ struct WorkspaceTests {
     }
 
     @Test
+    func selectTab_acknowledges_completion_in_selected_tab_only() {
+        let ws = makeWorkspace()
+        let selected = ws.tabs[0]
+        let other = ws.createTab(projectPath: "/tmp")
+        selected.splitRoot.allPanes().first?.executionState = .done
+        other.splitRoot.allPanes().first?.executionState = .done
+        let selectedID = selected.id
+        ws.selectTab(selectedID)
+        #expect(ws.activeTabID == selectedID)
+        #expect(selected.executionState == .idle)
+        #expect(other.executionState == .done)
+    }
+
+    @Test
     func recencyOrder_active_first_then_history() {
         let ws = makeWorkspace()
         let t1 = ws.tabs[0].id

--- a/MactermTests/Persistence/WorkspaceSerializerTests.swift
+++ b/MactermTests/Persistence/WorkspaceSerializerTests.swift
@@ -121,6 +121,50 @@ struct WorkspaceSerializerTests {
     }
 
     @Test
+    func round_trip_preserves_done_attention_state() {
+        let ws = Workspace(projectID: UUID(), projectPath: "/tmp")
+        if case let .pane(p) = ws.tabs[0].splitRoot {
+            p.markCommandFinished()
+            #expect(p.executionState == .done)
+        }
+        let roundTripped = roundTrip([ws.projectID: ws])
+        if case let .pane(p) = roundTripped[0].tabs[0].splitRoot {
+            #expect(p.executionState == .done)
+        } else {
+            Issue.record("expected leaf")
+        }
+    }
+
+    @Test
+    func round_trip_does_not_persist_idle_or_running() {
+        let ws = Workspace(projectID: UUID(), projectPath: "/tmp")
+        if case let .pane(p) = ws.tabs[0].splitRoot {
+            // Idle stays idle.
+            #expect(p.executionState == .idle)
+        }
+        let idleRound = roundTrip([ws.projectID: ws])
+        if case let .pane(p) = idleRound[0].tabs[0].splitRoot {
+            #expect(p.executionState == .idle)
+        }
+    }
+
+    @Test
+    func restore_done_is_cleared_by_acknowledge() {
+        let ws = Workspace(projectID: UUID(), projectPath: "/tmp")
+        if case let .pane(p) = ws.tabs[0].splitRoot {
+            p.markCommandFinished()
+        }
+        let roundTripped = roundTrip([ws.projectID: ws])
+        if case let .pane(p) = roundTripped[0].tabs[0].splitRoot {
+            #expect(p.executionState == .done)
+            p.acknowledgeCommandCompletion()
+            #expect(p.executionState == .idle)
+        } else {
+            Issue.record("expected leaf")
+        }
+    }
+
+    @Test
     func roundtrip_via_WorkspaceStore_on_disk() {
         // End-to-end: encode, write to a temp file, load back, restore.
         let tmp = FileManager.default.temporaryDirectory

--- a/MactermTests/Persistence/WorkspaceSerializerTests.swift
+++ b/MactermTests/Persistence/WorkspaceSerializerTests.swift
@@ -124,6 +124,7 @@ struct WorkspaceSerializerTests {
     func round_trip_preserves_done_attention_state() {
         let ws = Workspace(projectID: UUID(), projectPath: "/tmp")
         if case let .pane(p) = ws.tabs[0].splitRoot {
+            p.markCommandRunning()
             p.markCommandFinished()
             #expect(p.executionState == .done)
         }
@@ -152,6 +153,7 @@ struct WorkspaceSerializerTests {
     func restore_done_is_cleared_by_acknowledge() {
         let ws = Workspace(projectID: UUID(), projectPath: "/tmp")
         if case let .pane(p) = ws.tabs[0].splitRoot {
+            p.markCommandRunning()
             p.markCommandFinished()
         }
         let roundTripped = roundTrip([ws.projectID: ws])

--- a/MactermTests/Persistence/WorkspaceSerializerTests.swift
+++ b/MactermTests/Persistence/WorkspaceSerializerTests.swift
@@ -124,6 +124,7 @@ struct WorkspaceSerializerTests {
     func round_trip_preserves_done_attention_state() {
         let ws = Workspace(projectID: UUID(), projectPath: "/tmp")
         if case let .pane(p) = ws.tabs[0].splitRoot {
+            p.recordUserInteraction()
             p.markCommandRunning()
             p.markCommandFinished()
             #expect(p.executionState == .done)
@@ -153,6 +154,7 @@ struct WorkspaceSerializerTests {
     func restore_done_is_cleared_by_acknowledge() {
         let ws = Workspace(projectID: UUID(), projectPath: "/tmp")
         if case let .pane(p) = ws.tabs[0].splitRoot {
+            p.recordUserInteraction()
             p.markCommandRunning()
             p.markCommandFinished()
         }
@@ -185,6 +187,40 @@ struct WorkspaceSerializerTests {
 
         let restored = WorkspaceSerializer.restore(from: reloaded, validIDs: [ws.projectID])
         #expect(restored[0].tabs[0].splitRoot.allPanes().count == 2)
+    }
+
+    @Test
+    func load_v3_file_clears_persisted_attention_bits() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-tests-v3-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let store = WorkspaceStore(fileURL: tmp)
+        let projectID = UUID()
+        let tabID = UUID()
+        let paneID = UUID()
+        let file = WorkspacesFile(
+            version: 3,
+            workspaces: [WorkspaceSnapshot(
+                projectID: projectID,
+                activeTabID: tabID,
+                tabs: [TabSnapshot(
+                    id: tabID,
+                    customTitle: nil,
+                    focusedPaneID: paneID,
+                    splitRoot: .pane(PaneSnapshot(
+                        id: paneID,
+                        projectPath: "/tmp",
+                        needsAttention: true
+                    ))
+                )]
+            )]
+        )
+        let encoder = JSONEncoder()
+        try encoder.encode(file).write(to: tmp)
+
+        let restored = WorkspaceSerializer.restore(from: store.load(), validIDs: [projectID])
+
+        #expect(restored.first?.tabs.first?.executionState == .idle)
     }
 
     @Test

--- a/MactermTests/System/ProcessInspectorTests.swift
+++ b/MactermTests/System/ProcessInspectorTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 @testable import Macterm
 import Testing
@@ -45,5 +46,38 @@ struct ProcessInspectorTests {
     @Test
     func argv_returns_nil_for_nonexistent_pid() {
         #expect(ProcessInspector.argv(pid: 999_999) == nil)
+    }
+
+    @Test
+    func shellDetection_uses_system_shells() throws {
+        let loginShellPtr = try #require(getpwuid(getuid())?.pointee.pw_shell)
+        let loginShell = String(cString: loginShellPtr)
+        let loginShellName = (loginShell as NSString).lastPathComponent
+
+        #expect(ProcessInspector.isShellProcessName(loginShell))
+        #expect(ProcessInspector.isShellProcessName("-\(loginShellName)"))
+        #expect(!ProcessInspector.isShellProcessName("macterm-definitely-not-a-shell"))
+    }
+
+    @Test
+    func terminalInputIsRaw_reads_tty_input_mode() throws {
+        var master: Int32 = -1
+        var slave: Int32 = -1
+        #expect(openpty(&master, &slave, nil, nil, nil) == 0)
+        defer {
+            if master >= 0 { close(master) }
+            if slave >= 0 { close(slave) }
+        }
+        let path = try String(cString: #require(ttyname(slave)))
+
+        #expect(ProcessInspector.terminalInputIsRaw(ttyPath: path) == false)
+
+        var attrs = termios()
+        #expect(tcgetattr(slave, &attrs) == 0)
+        attrs.c_lflag &= ~tcflag_t(ICANON)
+        attrs.c_lflag &= ~tcflag_t(ECHO)
+        #expect(tcsetattr(slave, TCSANOW, &attrs) == 0)
+
+        #expect(ProcessInspector.terminalInputIsRaw(ttyPath: path) == true)
     }
 }


### PR DESCRIPTION
## What

Adds live status indicators to sidebar terminal tabs: spinner while running, green checkmark when a background command completes, and empty circle when idle/active/acknowledged.

## Why

When running multiple terminal-based agents in parallel, it should be easy to see which tabs are still working,which finished and need attention, and which are just idle leftovers.

## How

Adds a small execution-state model on panes, aggregates it at the tab level, and renders that state in the sidebar instead of the static tab icon.

The sidebar treats this as an attention indicator:
- running always shows a spinner
- completed background tabs show a checkmark
- the active tab suppresses completed state and shows idle unless something is currently running
- selecting/interacting with a completed tab acknowledges it back to idle

Command completion is driven by Ghostty command-finished events and the existing foreground-process refresh fallback.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

Also ran:

- `mise run build --verbose`

## Notes for reviewers

Screenshots attached below show the sidebar states: running spinner, completed checkmark, and idle circle.

https://github.com/user-attachments/assets/047fe65a-2cfa-44e7-8fab-67b432e3177c

