### PR TITLE
Add "Move to Project" to the tab context menu

### DIFF
--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -336,6 +336,29 @@ final class AppState {
         workspaces[projectID]?.selectTab(tabID)
     }
 
+    /// Move a tab — with its live panes and running shells intact — from one
+    /// project's workspace into another's. The `TerminalTab` object is reused
+    /// as-is, so its surfaces stay valid (both workspaces live in the same
+    /// window). The destination becomes the active project with the moved tab
+    /// selected, so the user lands where they meant to be. No-op for a
+    /// same-project move or an unknown source/tab.
+    func moveTab(_ tabID: UUID, from sourceProjectID: UUID, to destProjectID: UUID, destPath: String) {
+        guard sourceProjectID != destProjectID,
+              let source = workspaces[sourceProjectID],
+              let tab = source.tabs.first(where: { $0.id == tabID })
+        else { return }
+        logger.debug(
+            "moveTab: \(tabID, privacy: .public) from=\(sourceProjectID, privacy: .public) to=\(destProjectID, privacy: .public)"
+        )
+        ensureWorkspace(projectID: destProjectID, path: destPath)
+        guard let dest = workspaces[destProjectID] else { return }
+        source.closeTab(tabID)
+        dest.adoptTab(tab)
+        activeProjectID = destProjectID
+        recordProjectVisit(destProjectID)
+        saveWorkspaces()
+    }
+
     func selectNextTab(projectID: UUID) {
         workspaces[projectID]?.selectNextTab()
     }

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -215,6 +215,16 @@ final class Workspace: Identifiable {
         return tab
     }
 
+    /// Append an existing tab — moved in from another workspace — and make it
+    /// active. Unlike `createTab` the `TerminalTab` (and its live panes/surfaces)
+    /// is reused as-is; the caller is responsible for having removed it from its
+    /// previous workspace first.
+    func adoptTab(_ tab: TerminalTab) {
+        tabs.append(tab)
+        if let current = activeTabID { tabHistory.push(current) }
+        activeTabID = tab.id
+    }
+
     func closeTab(_ tabID: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
         tabs.remove(at: index)

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -28,12 +28,20 @@ struct SidebarContent: View {
                     set: { if $0 { expandedProjects.insert(project.id) } else { expandedProjects.remove(project.id) } }
                 )) {
                     ForEach(Array(tabs.enumerated()), id: \.element.id) { tabIndex, tab in
-                        SidebarTabRow(tab: tab, index: tabIndex + 1) {
-                            appState.closeTab(tab.id, projectID: project.id)
-                        } onRename: { newName in
-                            tab.customTitle = newName.isEmpty ? nil : newName
-                            appState.saveWorkspaces()
-                        }
+                        SidebarTabRow(
+                            tab: tab,
+                            index: tabIndex + 1,
+                            moveTargets: projectStore.projects.filter { $0.id != project.id },
+                            onClose: { appState.closeTab(tab.id, projectID: project.id) },
+                            onRename: { newName in
+                                tab.customTitle = newName.isEmpty ? nil : newName
+                                appState.saveWorkspaces()
+                            },
+                            onMoveToProject: { destination in
+                                appState.moveTab(tab.id, from: project.id, to: destination.id, destPath: destination.path)
+                                expandedProjects.insert(destination.id)
+                            }
+                        )
                         .tag(SidebarItem.tab(projectID: project.id, tabID: tab.id))
                     }
                     .onMove { source, destination in
@@ -222,8 +230,10 @@ private struct SidebarProjectRow: View {
 private struct SidebarTabRow: View {
     let tab: TerminalTab
     let index: Int
+    let moveTargets: [Project]
     let onClose: () -> Void
     let onRename: (String) -> Void
+    let onMoveToProject: (Project) -> Void
     @Environment(AppState.self)
     private var appState
     @AppStorage(Preferences.Keys.tabIconSymbol)
@@ -268,6 +278,13 @@ private struct SidebarTabRow: View {
         }
         .contextMenu {
             Button("Rename Tab") { beginRename() }
+            if !moveTargets.isEmpty {
+                Menu("Move to Project") {
+                    ForEach(moveTargets) { project in
+                        Button(project.name) { onMoveToProject(project) }
+                    }
+                }
+            }
             Divider()
             Button("Close Tab", action: onClose)
         }

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -113,6 +113,80 @@ struct AppStateTests {
         #expect(originalTab.splitRoot.allPanes().count == 1)
     }
 
+    // MARK: - Move tab between projects
+
+    @Test
+    func moveTab_relocates_tab_and_activates_destination() throws {
+        let state = makeAppState()
+        let p1 = seedProject(state, name: "p1", path: "/tmp1")
+        let p2 = seedProject(state, name: "p2", path: "/tmp2")
+        let ws1 = try #require(state.workspaces[p1.id])
+        // Give p1 a second tab so moving one away doesn't empty it.
+        let moving = ws1.createTab(projectPath: "/tmp1")
+        let staying = try #require(ws1.tabs.first?.id)
+
+        state.moveTab(moving.id, from: p1.id, to: p2.id, destPath: p2.path)
+
+        // Source lost the tab; destination gained it (object reused, surfaces intact).
+        #expect(ws1.tabs.map(\.id) == [staying])
+        let ws2 = try #require(state.workspaces[p2.id])
+        #expect(ws2.tabs.contains { $0.id == moving.id })
+        // Destination is now active with the moved tab selected.
+        #expect(state.activeProjectID == p2.id)
+        #expect(ws2.activeTabID == moving.id)
+    }
+
+    @Test
+    func moveTab_leaves_source_workspace_empty_when_moving_its_only_tab() throws {
+        let state = makeAppState()
+        let p1 = seedProject(state, name: "p1", path: "/tmp1")
+        let p2 = seedProject(state, name: "p2", path: "/tmp2")
+        let ws1 = try #require(state.workspaces[p1.id])
+        let only = try #require(ws1.tabs.first?.id)
+
+        state.moveTab(only, from: p1.id, to: p2.id, destPath: p2.path)
+
+        #expect(ws1.tabs.isEmpty)
+        #expect(ws1.activeTabID == nil)
+        #expect(state.workspaces[p2.id]?.tabs.contains { $0.id == only } == true)
+    }
+
+    @Test
+    func moveTab_creates_destination_workspace_when_absent() throws {
+        let state = makeAppState()
+        let p1 = seedProject(state, name: "p1", path: "/tmp1")
+        let ws1 = try #require(state.workspaces[p1.id])
+        let tab = ws1.createTab(projectPath: "/tmp1")
+        // A project that's never been opened — no workspace yet.
+        let p2 = Project(name: "p2", path: "/tmp2", sortOrder: 1)
+        #expect(state.workspaces[p2.id] == nil)
+
+        state.moveTab(tab.id, from: p1.id, to: p2.id, destPath: p2.path)
+
+        let ws2 = try #require(state.workspaces[p2.id])
+        #expect(ws2.tabs.contains { $0.id == tab.id })
+    }
+
+    @Test
+    func moveTab_same_project_is_noop() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        let before = ws.tabs.map(\.id)
+        state.moveTab(try #require(before.first), from: p.id, to: p.id, destPath: p.path)
+        #expect(ws.tabs.map(\.id) == before)
+    }
+
+    @Test
+    func moveTab_unknown_tab_is_noop() throws {
+        let state = makeAppState()
+        let p1 = seedProject(state, name: "p1", path: "/tmp1")
+        let p2 = seedProject(state, name: "p2", path: "/tmp2")
+        let ws2Before = try #require(state.workspaces[p2.id]).tabs.count
+        state.moveTab(UUID(), from: p1.id, to: p2.id, destPath: p2.path)
+        #expect(state.workspaces[p2.id]?.tabs.count == ws2Before)
+    }
+
     // MARK: - Focus navigation
 
     @Test

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -173,7 +173,7 @@ struct AppStateTests {
         let p = seedProject(state)
         let ws = try #require(state.workspaces[p.id])
         let before = ws.tabs.map(\.id)
-        state.moveTab(try #require(before.first), from: p.id, to: p.id, destPath: p.path)
+        try state.moveTab(#require(before.first), from: p.id, to: p.id, destPath: p.path)
         #expect(ws.tabs.map(\.id) == before)
     }
 

--- a/MactermTests/Model/WorkspaceTests.swift
+++ b/MactermTests/Model/WorkspaceTests.swift
@@ -26,6 +26,29 @@ struct WorkspaceTests {
     }
 
     @Test
+    func adoptTab_appends_existing_tab_and_selects_it() {
+        let ws = makeWorkspace()
+        let original = ws.tabs[0].id
+        let incoming = TerminalTab(projectPath: "/elsewhere", projectID: UUID())
+        ws.adoptTab(incoming)
+        #expect(ws.tabs.count == 2)
+        #expect(ws.tabs.last?.id == incoming.id)
+        #expect(ws.activeTabID == incoming.id)
+        _ = original
+    }
+
+    @Test
+    func adoptTab_pushes_previous_active_onto_history() {
+        let ws = makeWorkspace()
+        let original = ws.tabs[0].id
+        let incoming = TerminalTab(projectPath: "/elsewhere", projectID: UUID())
+        ws.adoptTab(incoming)
+        // Closing the adopted (active) tab should fall back to the prior active.
+        ws.closeTab(incoming.id)
+        #expect(ws.activeTabID == original)
+    }
+
+    @Test
     func closeTab_active_selects_most_recent_from_history() {
         let ws = makeWorkspace()
         let t1 = ws.tabs[0].id


### PR DESCRIPTION
## What

Adds a **Move to Project** submenu to the sidebar tab context menu, listing every other project. Choosing one relocates the tab — with its live panes and running shells — into that project's workspace and switches to it.

## Why

Closes #91.

The common case: you hit Cmd+T in a project and start working, only to realize you're in the wrong project. Rather than recreating the work elsewhere, you can now move the tab to where it belongs.

## How

- `Workspace.adoptTab(_:)` appends an existing `TerminalTab` and makes it active (recording focus history), the mirror of `createTab` but reusing the tab object instead of building a fresh one.
- `AppState.moveTab(_:from:to:destPath:)` removes the tab from the source workspace (via `closeTab`, which preserves the surfaces — it doesn't destroy them) and adopts it into the destination, creating the destination workspace if the project hasn't been opened yet. The destination becomes the active project with the moved tab selected, so the user lands where they meant to be. Because both workspaces live in the same window, the tab's panes/`CAMetalLayer` surfaces stay valid across the move — no shells are restarted.
- The sidebar tab row gains a `Move to Project` submenu, shown only when other projects exist.

A pane's `projectID`/`projectPath` are immutable (`let`) and stay pointing at the original project after a move; this is only used for split-inherited cwd and logging while live, and self-heals on the next launch (restore rebuilds panes under the new workspace's project ID).

**Design note:** the issue framed this as drag-and-drop. SwiftUI's `List` doesn't support dragging rows across `DisclosureGroup` sections, and bolting on `.draggable`/`.dropDestination` would fight the existing `.onMove` reorder — exactly the kind of native-component workaround the repo's UI principles say to avoid. A context-menu submenu is fully native, discoverable, and reliable, and covers the same need.

## Verified

- [x] Added tests for `moveTab` (relocation + activation, emptying the source, lazy destination creation, same-project and unknown-tab no-ops) and `adoptTab`.
- [ ] `mise run format`, `mise run lint`, and `mise run test` — not run; this session's environment is Linux with no Xcode/Swift toolchain or GhosttyKit, so the macOS build/test suite can't run here. Please run locally before merge.
- [ ] Built and ran in the app — same toolchain limitation.

## Notes for reviewers

Moving the only tab out of a project leaves that project's workspace empty, which renders the existing `EmptyProjectView` — an already-supported state (same as closing the last tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMLxkXtMVDEj6wTKkMm83T)_