### PR TITLE
Tidy Settings appearance copy and fold glass controls into one picker

### DIFF
--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -194,7 +194,7 @@ private struct AppearanceSettings: View {
         Form {
             Section("Window") {
                 HStack {
-                    Text("Background Opacity")
+                    Text("Background opacity")
                     Slider(value: $backgroundOpacity, in: 0.0 ... 1.0)
                     Text("\(Int((backgroundOpacity * 100).rounded()))%")
                         .monospacedDigit()
@@ -205,28 +205,21 @@ private struct AppearanceSettings: View {
                 }
 
                 // Liquid glass (NSGlassEffectView) exists only on macOS 26+;
-                // hide the controls entirely on older systems where they'd be
-                // inert rather than show dead toggles.
+                // hide the control entirely on older systems where it'd be
+                // inert rather than show a dead picker. "None" off / a style on
+                // are folded into one picker over the two underlying prefs.
                 if WindowAppearance.glassSupported {
-                    Toggle("Liquid Glass", isOn: $liquidGlass)
-                        .onChange(of: liquidGlass) { _, v in
-                            Preferences.shared.windowGlassEnabled = v
-                        }
-                        .disabled(backgroundOpacity >= 0.999)
-
-                    Picker("Glass Style", selection: $liquidGlassStyle) {
+                    Picker("Liquid glass", selection: glassSelection) {
+                        Text("None").tag(WindowGlassStyle?.none)
                         ForEach(WindowGlassStyle.allCases) { style in
-                            Text(style.displayName).tag(style)
+                            Text(style.displayName).tag(WindowGlassStyle?.some(style))
                         }
                     }
-                    .onChange(of: liquidGlassStyle) { _, v in
-                        Preferences.shared.windowGlassStyle = v
-                    }
-                    .disabled(backgroundOpacity >= 0.999 || !liquidGlass)
+                    .disabled(backgroundOpacity >= 0.999)
                 }
 
                 HStack {
-                    Text("Background Blur")
+                    Text("Background blur")
                     Slider(value: $backgroundBlurRadius, in: 0 ... 100)
                     Text("\(Int(backgroundBlurRadius.rounded()))")
                         .monospacedDigit()
@@ -250,23 +243,23 @@ private struct AppearanceSettings: View {
                 }
                 .onChange(of: projectIconSymbol) { _, v in Preferences.shared.projectIconSymbol = v }
 
-                Toggle("Show tab status indicator", isOn: $showTabStatusIndicator)
-                    .onChange(of: showTabStatusIndicator) { _, v in
-                        Preferences.shared.showTabStatusIndicator = v
-                    }
-                Text(
-                    "Replaces a tab’s icon with a spinner while a command is running, " +
-                        "and adds a small checkmark badge when it finishes and awaits attention."
-                )
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-
                 Picker("Tab icon", selection: $tabIconSymbol) {
                     ForEach(Preferences.tabIconChoices, id: \.self) { name in
                         iconPickerLabel(name).tag(name)
                     }
                 }
                 .onChange(of: tabIconSymbol) { _, v in Preferences.shared.tabIconSymbol = v }
+
+                Toggle("Show tab status indicator", isOn: $showTabStatusIndicator)
+                    .onChange(of: showTabStatusIndicator) { _, v in
+                        Preferences.shared.showTabStatusIndicator = v
+                    }
+                Text(
+                    "Replaces a tab’s icon with a spinner while a command is running, " +
+                        "and adds a small status dot when it finishes and awaits attention."
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
 
                 Toggle("Show New Project button", isOn: $showNewProjectButton)
                     .onChange(of: showNewProjectButton) { _, v in Preferences.shared.showNewProjectButton = v }
@@ -290,6 +283,26 @@ private struct AppearanceSettings: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    /// One picker over the two glass prefs: `nil` ("None") means disabled, a
+    /// concrete style means enabled with that material. The remembered style is
+    /// preserved across a None round-trip — picking None only flips the enabled
+    /// flag, so re-selecting glass restores the last material.
+    private var glassSelection: Binding<WindowGlassStyle?> {
+        Binding(
+            get: { liquidGlass ? liquidGlassStyle : nil },
+            set: { selection in
+                if let selection {
+                    liquidGlassStyle = selection
+                    Preferences.shared.windowGlassStyle = selection
+                    liquidGlass = true
+                } else {
+                    liquidGlass = false
+                }
+                Preferences.shared.windowGlassEnabled = liquidGlass
+            }
+        )
     }
 
     private var blurFootnote: String {


### PR DESCRIPTION
## What

Small refinements to the **Appearance** settings, mostly follow-ups to the sidebar status-indicator feature (#90):

- Merge the **Liquid glass** toggle and **Glass style** picker into a single picker with a **None** option.
- Sentence-case the Window section labels (they're settings, not actions).
- Move **Show tab status indicator** below the Tab icon picker.
- Fix the status-indicator description copy.

## Why

The Window section had a separate on/off toggle *and* a style dropdown for liquid glass — two controls for what is really one choice. Folding them into one picker (None / Regular / Clear) is less clutter and reads as a single decision.

The rest is polish: the Window labels were Title Case like menu actions when they're plain settings; the status-indicator toggle read more naturally after the icon picker it relates to; and its description called the completion glyph a "checkmark badge" when the code actually renders a small green dot (the `TabStatusGlyph` comment explicitly avoids a checkmark) — so "status dot" is the accurate term.

## How

The merged picker keeps the **two underlying prefs** (`windowGlassEnabled` + `windowGlassStyle`) exactly as they were — so `WindowAppearance` and workspace persistence need no changes and there's no migration. A computed `Binding<WindowGlassStyle?>` maps the picker onto them:

- **None** (`nil`) → `windowGlassEnabled = false`
- **Regular / Clear** → `windowGlassEnabled = true` + that style

The last-used style is remembered across a None round-trip (selecting None only flips the enabled flag), so re-selecting glass restores the previous material. The blur slider's `.disabled` and the `blurFootnote` both still read the local `liquidGlass` state, which the binding's setter keeps in sync. The control stays hidden on macOS < 26 (`WindowAppearance.glassSupported`), unchanged.

"Liquid Glass" is left capitalized in the footnote prose (Apple's branded material name), even though the control label is now sentence-cased.

## Verified

- [x] `mise run format` and `mise run lint` pass (no test logic changed — pure UI copy + a settings binding, so no new tests)
- [x] Debug build compiles and the app launches clean (macOS 26, so the new picker is live)

## Notes for reviewers

- No production logic or persistence touched beyond the Settings view — the glass prefs and their consumers in `WindowAppearance` are untouched.
- I did **not** drive the Settings window through UI automation (it's unreliable on macOS); I traced the `glassSelection` binding against all three consumers (the picker, the blur slider's `disabled`, and `blurFootnote`) by hand. Happy to record a quick screen capture of the picker if you'd like one.