### PR TITLE
Inherit the source pane's live cwd when splitting

### DIFF
--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -103,7 +103,12 @@ final class TerminalTab: Identifiable {
     @discardableResult
     func split(paneID: UUID, direction: SplitDirection) -> UUID? {
         let pane = splitRoot.findPane(id: paneID)
-        let livePwd = pane?.nsView?.currentPwd
+        // Inherit the source pane's cwd. Prefer the shell's OSC 7-reported pwd
+        // (most accurate when shell integration is active), then fall back to
+        // the foreground process's actual cwd read from the kernel (works
+        // without shell integration / when a program holds the foreground),
+        // and only then to the pane's original project path.
+        let livePwd = pane.flatMap { p in p.nsView?.currentPwd ?? ProcessInspector.foregroundWorkingDirectory(forPane: p) }
         let sourcePath = livePwd ?? pane?.projectPath ?? NSHomeDirectory()
         let sourceProjectID = pane?.projectID ?? UUID()
         let (newRoot, newID) = splitRoot.splitting(

--- a/Macterm/System/ProcessInspector.swift
+++ b/Macterm/System/ProcessInspector.swift
@@ -111,6 +111,38 @@ enum ProcessInspector {
         return !canonical || !echo
     }
 
+    /// The current working directory of the pane's foreground process, read
+    /// straight from the kernel (`proc_pidinfo(PROC_PIDVNODEPATHINFO)`), or nil.
+    ///
+    /// This is the OS-truth fallback for inheriting cwd on split: unlike
+    /// `GhosttyTerminalNSView.currentPwd` (populated only when the shell emits
+    /// OSC 7 via shell integration), it works even when the shell reports no
+    /// cwd — a prompt without shell integration, nushell, or a non-shell
+    /// program (`hx`, `nvim`) holding the foreground. We read the *foreground*
+    /// pid's cwd, which is what the user sees as "where they are"; for a shell
+    /// at a prompt that's the shell's cwd, and for a running program it's that
+    /// program's cwd (typically launched from, and matching, the shell's).
+    @MainActor
+    static func foregroundWorkingDirectory(forPane pane: Pane) -> String? {
+        guard let pid = pane.nsView?.foregroundPID else { return nil }
+        return workingDirectory(pid: pid)
+    }
+
+    /// The current working directory of `pid` via `PROC_PIDVNODEPATHINFO`, or
+    /// nil. Only same-uid processes are readable (the pane's foreground is).
+    static func workingDirectory(pid: pid_t) -> String? {
+        var info = proc_vnodepathinfo()
+        let size = Int32(MemoryLayout<proc_vnodepathinfo>.size)
+        let ret = proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &info, size)
+        guard ret == size else { return nil }
+        let path = withUnsafeBytes(of: &info.pvi_cdir.vip_path) { raw -> String? in
+            let bytes = raw.bindMemory(to: CChar.self)
+            return bytes.baseAddress.map { String(cString: $0) }
+        }
+        guard let path, !path.isEmpty else { return nil }
+        return path
+    }
+
     /// The kernel short accounting name (`p_comm` / `pbsi_comm`) of `pid` — a
     /// basename truncated to `MAXCOMLEN`, no path or arguments — or nil. Same
     /// field tmux uses for window names.

--- a/MactermTests/System/ProcessInspectorTests.swift
+++ b/MactermTests/System/ProcessInspectorTests.swift
@@ -13,10 +13,11 @@ struct ProcessInspectorTests {
     /// Launch a process directly (no shell, so argv is deterministic from the
     /// start), run `body` against its pid, then terminate it. Polls briefly for
     /// the pid to become readable.
-    private func withProcess(_ launchPath: String, _ args: [String], _ body: (pid_t) -> Void) {
+    private func withProcess(_ launchPath: String, _ args: [String], cwd: String? = nil, _ body: (pid_t) -> Void) {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: launchPath)
         proc.arguments = args
+        if let cwd { proc.currentDirectoryURL = URL(fileURLWithPath: cwd) }
         do {
             try proc.run()
         } catch {
@@ -46,6 +47,25 @@ struct ProcessInspectorTests {
     @Test
     func argv_returns_nil_for_nonexistent_pid() {
         #expect(ProcessInspector.argv(pid: 999_999) == nil)
+    }
+
+    @Test
+    func workingDirectory_reads_the_process_cwd() throws {
+        // The kernel reports the fully symlink-resolved cwd (e.g. /var/folders
+        // → /private/var/folders on macOS), so compare against realpath of the
+        // launch dir rather than the raw path.
+        let launchDir = FileManager.default.temporaryDirectory.path
+        let resolved = try #require(launchDir.withCString { realpath($0, nil) })
+        defer { free(resolved) }
+        let expected = String(cString: resolved)
+        withProcess("/bin/sleep", ["91"], cwd: launchDir) { pid in
+            #expect(ProcessInspector.workingDirectory(pid: pid) == expected)
+        }
+    }
+
+    @Test
+    func workingDirectory_returns_nil_for_nonexistent_pid() {
+        #expect(ProcessInspector.workingDirectory(pid: 999_999) == nil)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Splitting a pane didn't inherit the source pane's current working directory — the new pane often opened in the original project root instead of where the user actually was.

The split path only inherited cwd from `GhosttyTerminalNSView.currentPwd`, which is populated **only** when the shell emits **OSC 7** via shell integration. With nushell, a custom prompt that doesn't emit OSC 7, or a non-shell program (e.g. `hx`, `nvim`) holding the foreground, `currentPwd` is nil and the split silently fell back to the pane's original `projectPath`.

## Fix

Add a kernel-truth fallback. When no OSC 7 pwd is known, read the foreground process's **actual** cwd straight from the kernel via `proc_pidinfo(PROC_PIDVNODEPATHINFO)`. New resolution order on split:

```
currentPwd (OSC 7)  →  foreground pid's cwd (kernel)  →  projectPath  →  $HOME
```

This works regardless of shell integration, and reads the foreground pid's cwd (the shell's cwd at an idle prompt; the program's cwd when one is running — which is normally the same dir it was launched from).

## Changes

- `ProcessInspector`: new `foregroundWorkingDirectory(forPane:)` + `workingDirectory(pid:)`.
- `TerminalTab.split`: use the OSC 7 → kernel-cwd → projectPath fallback chain.
- Tests: `workingDirectory(pid:)` against a real subprocess with a known cwd, plus a nonexistent-pid case.

## Testing

Release build, format, lint, and full test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)