### PR TITLE
Make terminal scrolling feel like iTerm2

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -61,6 +61,12 @@ final class Preferences {
         didSet { defaults.set(eagerlyStartProjectTabs, forKey: Keys.eagerlyStartProjectTabs) }
     }
 
+    /// Multiplier applied to terminal scroll wheel / trackpad row deltas.
+    /// 1.0 matches iTerm2's default scroll accumulator behavior.
+    var terminalScrollSpeed: Double {
+        didSet { defaults.set(terminalScrollSpeed, forKey: Keys.terminalScrollSpeed) }
+    }
+
     // MARK: - Sidebar icons
 
     var projectIconSymbol: String {
@@ -242,6 +248,7 @@ final class Preferences {
         self.defaults = defaults
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
         eagerlyStartProjectTabs = (defaults.object(forKey: Keys.eagerlyStartProjectTabs) as? Bool) ?? true
+        terminalScrollSpeed = Self.clampScrollSpeed(defaults.double(forKey: Keys.terminalScrollSpeed), fallback: 1.0)
         windowOpacity = (defaults.object(forKey: Keys.windowOpacity) as? Double) ?? 1.0
         windowBlurRadius = defaults.integer(forKey: Keys.windowBlurRadius)
         windowGlassEnabled = defaults.object(forKey: Keys.windowGlassEnabled) as? Bool ?? false
@@ -266,6 +273,11 @@ final class Preferences {
         return max(0.2, min(1.0, v))
     }
 
+    private static func clampScrollSpeed(_ v: Double, fallback: Double) -> Double {
+        guard v > 0 else { return fallback }
+        return max(0.25, min(3.0, v))
+    }
+
     /// Pre-v2 builds stored theme/font/option-as-alt in UserDefaults. Those
     /// settings now live entirely in the user's Ghostty config, so the keys
     /// are dead. Drop them so `defaults read com.thdxg.macterm` is clean
@@ -286,6 +298,7 @@ final class Preferences {
     enum Keys {
         static let autoTiling = "macterm.autoTiling.enabled"
         static let eagerlyStartProjectTabs = "macterm.eagerlyStartProjectTabs.enabled"
+        static let terminalScrollSpeed = "macterm.terminal.scrollSpeed"
         static let windowOpacity = "macterm.window.opacity"
         static let windowBlurRadius = "macterm.window.blurRadius"
         static let windowGlassEnabled = "macterm.window.glassEnabled"

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -62,7 +62,6 @@ final class Preferences {
     }
 
     /// Multiplier applied to terminal scroll wheel / trackpad row deltas.
-    /// 1.0 matches iTerm2's default scroll accumulator behavior.
     var terminalScrollSpeed: Double {
         didSet { defaults.set(terminalScrollSpeed, forKey: Keys.terminalScrollSpeed) }
     }

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -460,6 +460,7 @@ final class Pane: Identifiable {
         view.onProgressFinished = nil
         view.onTerminalActivity = nil
         view.onScrollbarUpdate = nil
+        view.onScrollWheel = nil
         view.destroySurface()
         let scroll = _scrollView
         _scrollView = nil

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -31,6 +31,8 @@ private struct GeneralSettings: View {
     @AppStorage(Preferences.Keys.eagerlyStartProjectTabs)
     private var eagerlyStartProjectTabs = true
     @State
+    private var terminalScrollSpeed: Double = Preferences.shared.terminalScrollSpeed
+    @State
     private var ghosttyConfigPath: String = Preferences.shared.userGhosttyConfigPath
 
     private let ghosttyCLI = GhosttyCLI.standard
@@ -64,6 +66,22 @@ private struct GeneralSettings: View {
                 )
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
+            }
+
+            Section("Terminal") {
+                HStack {
+                    Text("Scroll speed")
+                    Slider(value: $terminalScrollSpeed, in: 0.25 ... 3.0, step: 0.25)
+                    Text("\(terminalScrollSpeed, specifier: "%.2g")×")
+                        .monospacedDigit()
+                        .frame(width: 42, alignment: .trailing)
+                }
+                .onChange(of: terminalScrollSpeed) { _, v in
+                    Preferences.shared.terminalScrollSpeed = v
+                }
+                Text("Controls terminal scrollback speed for trackpads and mouse wheels. 1× matches iTerm2's default.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
             }
 
             Section("Layout") {

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -71,15 +71,15 @@ private struct GeneralSettings: View {
             Section("Terminal") {
                 HStack {
                     Text("Scroll speed")
-                    Slider(value: $terminalScrollSpeed, in: 0.25 ... 3.0, step: 0.25)
-                    Text("\(terminalScrollSpeed, specifier: "%.2g")×")
+                    Slider(value: $terminalScrollSpeed, in: 0.25 ... 3.0, step: 0.05)
+                    Text("\(terminalScrollSpeed, specifier: "%.2f")×")
                         .monospacedDigit()
-                        .frame(width: 42, alignment: .trailing)
+                        .frame(width: 52, alignment: .trailing)
                 }
                 .onChange(of: terminalScrollSpeed) { _, v in
                     Preferences.shared.terminalScrollSpeed = v
                 }
-                Text("Controls terminal scrollback speed for trackpads and mouse wheels. 1× matches iTerm2's default.")
+                Text("Controls terminal scrollback speed for trackpads and mouse wheels.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -71,7 +71,7 @@ private struct GeneralSettings: View {
             Section("Terminal") {
                 HStack {
                     Text("Scroll speed")
-                    Slider(value: $terminalScrollSpeed, in: 0.25 ... 3.0, step: 0.05)
+                    Slider(value: $terminalScrollSpeed, in: 0.25 ... 3.0)
                     Text("\(terminalScrollSpeed, specifier: "%.2f")×")
                         .monospacedDigit()
                         .frame(width: 52, alignment: .trailing)

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -88,10 +88,11 @@ final class GhosttyTerminalNSView: NSView {
     /// `(total, offset, len)`: total rows including scrollback, the first
     /// visible row (0 = top of history), and the visible row count.
     var onScrollbarUpdate: ((UInt64, UInt64, UInt64) -> Void)?
-    /// Gives the hosting `SurfaceScrollView` first chance to process ordinary
-    /// scrollback wheel/trackpad events with its iTerm-style line accumulator.
-    /// Return false to let libghostty handle mouse-reporting / alternate-screen
-    /// behavior.
+    /// Gives the hosting `SurfaceScrollView` first chance to handle scrollback
+    /// wheel/trackpad events with its iTerm-style line accumulator. It declines
+    /// when there's no scrollback to move through (so alternate-screen apps
+    /// like less/vim fall through to libghostty for mouse reporting). Return
+    /// false to let libghostty handle the event directly.
     var onScrollWheel: ((NSEvent) -> Bool)?
     var isFocused: Bool = false
     var currentPwd: String?

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -88,6 +88,11 @@ final class GhosttyTerminalNSView: NSView {
     /// `(total, offset, len)`: total rows including scrollback, the first
     /// visible row (0 = top of history), and the visible row count.
     var onScrollbarUpdate: ((UInt64, UInt64, UInt64) -> Void)?
+    /// Gives the hosting `SurfaceScrollView` first chance to process ordinary
+    /// scrollback wheel/trackpad events with its iTerm-style line accumulator.
+    /// Return false to let libghostty handle mouse-reporting / alternate-screen
+    /// behavior.
+    var onScrollWheel: ((NSEvent) -> Bool)?
     var isFocused: Bool = false
     var currentPwd: String?
 
@@ -597,9 +602,41 @@ final class GhosttyTerminalNSView: NSView {
     override func scrollWheel(with event: NSEvent) {
         onInteraction?()
         guard let surface else { return }
+
+        var x = event.scrollingDeltaX
+        var y = event.scrollingDeltaY
+        if event.hasPreciseScrollingDeltas {
+            // Match Ghostty's macOS frontend: precise trackpad/Magic Mouse
+            // deltas are valid but feel slow at 1x because terminals scroll in
+            // rows instead of continuous document pixels.
+            x *= 2
+            y *= 2
+        }
+
+        if !ghostty_surface_mouse_captured(surface), onScrollWheel?(event) == true {
+            return
+        }
+
+        ghostty_surface_mouse_scroll(surface, x, y, scrollMods(for: event))
+    }
+
+    private func scrollMods(for event: NSEvent) -> ghostty_input_scroll_mods_t {
         var scrollMods: ghostty_input_scroll_mods_t = 0
         if event.hasPreciseScrollingDeltas { scrollMods |= 1 }
-        ghostty_surface_mouse_scroll(surface, event.scrollingDeltaX, event.scrollingDeltaY, scrollMods)
+        scrollMods |= scrollMomentum(for: event.momentumPhase) << 1
+        return scrollMods
+    }
+
+    private func scrollMomentum(for phase: NSEvent.Phase) -> ghostty_input_scroll_mods_t {
+        switch phase {
+        case .began: 1
+        case .stationary: 2
+        case .changed: 3
+        case .ended: 4
+        case .cancelled: 5
+        case .mayBegin: 6
+        default: 0
+        }
     }
 
     // MARK: - Context menu

--- a/Macterm/Views/Terminal/SurfaceScrollView.swift
+++ b/Macterm/Views/Terminal/SurfaceScrollView.swift
@@ -15,12 +15,13 @@ import GhosttyKit
 ///        └─ GhosttyTerminalNSView      (pinned to the visible rect)
 /// ```
 ///
-/// Wheel/trackpad events are NOT arbitrated here: they hit the frontmost
-/// surface view, whose `scrollWheel` forwards every event to libghostty, which
-/// decides scrollback vs. cursor-keys vs. mouse-report. The scroll view is
-/// display/drag-only. Scrollback geometry flows **into** this view via the
-/// `GHOSTTY_ACTION_SCROLLBAR` action (`onScrollbarUpdate`), and user drags flow
-/// **out** via the `scroll_to_row:<n>` keybind action.
+/// Wheel/trackpad events hit the frontmost surface view first. Ordinary
+/// scrollback gestures are handled here with an iTerm2-style line accumulator
+/// that converts AppKit's wheel/trackpad deltas (including inertia) into whole
+/// terminal-row movement; mouse-reporting / alt-screen cases continue to go to
+/// libghostty. Scrollback geometry flows **into** this view via the
+/// `GHOSTTY_ACTION_SCROLLBAR` action (`onScrollbarUpdate`), and user-visible
+/// scroll positions flow **out** via the `scroll_to_row:<n>` keybind action.
 final class SurfaceScrollView: NSScrollView {
     /// The Metal terminal surface. Owned by `Pane`; we just re-parent it into
     /// our document view.
@@ -42,6 +43,11 @@ final class SurfaceScrollView: NSScrollView {
     /// Last row index sent to the core via `scroll_to_row`, to dedupe spam.
     private var lastSentRow: Int = -1
 
+    /// iTerm2's default vertical scroll-wheel accumulator. It turns AppKit's
+    /// messy wheel/trackpad deltas into whole terminal-row movement, including
+    /// momentum events, instead of trying to pixel-scroll terminal contents.
+    private let verticalScrollAccumulator = ITermScrollAccumulator()
+
     nonisolated(unsafe) private var observers: [NSObjectProtocol] = []
 
     init(surfaceView: GhosttyTerminalNSView) {
@@ -56,6 +62,7 @@ final class SurfaceScrollView: NSScrollView {
         hasHorizontalScroller = false
         autohidesScrollers = false
         usesPredominantAxisScrolling = true
+        verticalScrollElasticity = .none
         // The window composites its own translucency (see WindowAppearance);
         // drawing a background here would double-tint.
         drawsBackground = false
@@ -72,6 +79,9 @@ final class SurfaceScrollView: NSScrollView {
         surfaceView.onScrollbarUpdate = { [weak self] total, offset, len in
             self?.applyScrollbar(total: total, offset: offset, len: len)
         }
+        surfaceView.onScrollWheel = { [weak self] event in
+            self?.handleSurfaceScrollWheel(event) ?? false
+        }
     }
 
     @available(*, unavailable)
@@ -80,6 +90,7 @@ final class SurfaceScrollView: NSScrollView {
     }
 
     deinit {
+        MainActor.assumeIsolated { surfaceView.onScrollWheel = nil }
         for token in observers {
             NotificationCenter.default.removeObserver(token)
         }
@@ -144,6 +155,7 @@ final class SurfaceScrollView: NSScrollView {
             return
         }
 
+        verticalLineScroll = cellHeight
         let docHeight = Self.documentHeight(total: total, cellHeight: cellHeight, viewportHeight: viewportHeight)
         if spacer.frame.height != docHeight || spacer.frame.width != contentView.bounds.width {
             spacer.frame = NSRect(x: 0, y: 0, width: contentView.bounds.width, height: docHeight)
@@ -168,9 +180,24 @@ final class SurfaceScrollView: NSScrollView {
 
     // MARK: - UI → Core
 
+    private func handleSurfaceScrollWheel(_ event: NSEvent) -> Bool {
+        let cellHeight = surfaceView.cellHeightPoints
+        guard canHandleScrollbackWheel(event, cellHeight: cellHeight) else { return false }
+        let rowDelta = verticalScrollAccumulator.delta(for: event)
+        guard rowDelta != 0 else { return true }
+        let currentRow = Int(min(offset, UInt64(Int.max)))
+        sendScrollToRow(currentRow - rowDelta)
+        return true
+    }
+
+    private func canHandleScrollbackWheel(_ event: NSEvent, cellHeight: CGFloat) -> Bool {
+        guard surfaceView.surface != nil, cellHeight > 0, total > len else { return false }
+        return abs(event.scrollingDeltaY) >= abs(event.scrollingDeltaX)
+    }
+
     private func handleLiveScroll() {
         let cellHeight = surfaceView.cellHeightPoints
-        guard cellHeight > 0, let surface = surfaceView.surface else { return }
+        guard cellHeight > 0, surfaceView.surface != nil else { return }
         let visible = contentView.documentVisibleRect
         let docHeight = spacer.frame.height
         let row = Self.rowFromOffset(
@@ -183,10 +210,25 @@ final class SurfaceScrollView: NSScrollView {
             layoutSurface()
             return
         }
+        sendScrollToRow(row)
+        layoutSurface()
+    }
+
+    private func sendScrollToRow(_ requestedRow: Int) {
+        guard let surface = surfaceView.surface else { return }
+        let maxScrollable = total > len ? total - len : 0
+        let maxRow = Int(min(maxScrollable, UInt64(Int.max)))
+        let row = min(max(0, requestedRow), maxRow)
+        guard row != lastSentRow else { return }
         lastSentRow = row
+
+        // Keep the native scroller in step immediately, like iTerm2's
+        // `scrollRectToVisible`, while the row-based terminal core catches up.
+        offset = UInt64(row)
+        synchronize()
+
         let action = "scroll_to_row:\(row)"
         ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
-        layoutSurface()
     }
 
     // MARK: - Legacy scroller discoverability
@@ -213,6 +255,77 @@ final class SurfaceScrollView: NSScrollView {
         // scroller when the pointer is over its track so it stays discoverable.
         guard NSScroller.preferredScrollerStyle == .legacy else { return }
         flashScrollers()
+    }
+}
+
+// MARK: - iTerm2-style scroll accumulation
+
+/// Swift port of iTerm2's `iTermScrollAccumulator` with its default settings:
+/// modern accumulator enabled, `fastTrackpad = YES`, sensitivity 1.0, and
+/// scroll-wheel acceleration 1.0.
+private final class ITermScrollAccumulator {
+    private var accumulatedDelta: CGFloat = 0
+
+    func delta(for event: NSEvent) -> Int {
+        let accumulated = accumulatedDelta(for: event)
+        let sign: CGFloat = accumulated > 0 ? 1 : -1
+        return Int(pow(abs(accumulated), 1) * sign)
+    }
+
+    private func accumulatedDelta(for event: NSEvent) -> CGFloat {
+        if event.phase.isEmpty, event.momentumPhase.isEmpty {
+            return accumulatedDeltaForMouseWheelEvent(event)
+        }
+        return accumulatedDeltaForTrackpadEvent(event)
+    }
+
+    private func accumulatedDeltaForMouseWheelEvent(_ event: NSEvent) -> CGFloat {
+        let delta = adjustedDelta(for: event)
+        let roundDelta = delta.rounded()
+        if roundDelta == 0, delta != 0 {
+            return delta > 0 ? 1 : -1
+        }
+        return roundDelta
+    }
+
+    private func accumulatedDeltaForTrackpadEvent(_ event: NSEvent) -> CGFloat {
+        if event.phase == .began {
+            accumulatedDelta = 0
+        }
+        let delta = adjustedDelta(for: event)
+        accumulatedDelta += delta
+        return takeWholePortion(delta: delta)
+    }
+
+    private func adjustedDelta(for event: NSEvent) -> CGFloat {
+        if event.hasPreciseScrollingDeltas {
+            // iTerm2's default `fastTrackpad` path, based on Terminal.app:
+            // use the device line delta and round away from zero so small
+            // trackpad gestures don't feel sluggish.
+            return Self.roundAwayFromZero(event.deltaY)
+        }
+        return event.scrollingDeltaY
+    }
+
+    private func takeWholePortion(delta: CGFloat) -> CGFloat {
+        if abs(accumulatedDelta) >= 1 {
+            let roundDelta = Self.roundTowardZero(accumulatedDelta)
+            accumulatedDelta -= roundDelta
+            return roundDelta
+        }
+        if delta * accumulatedDelta < 0 {
+            accumulatedDelta = 0
+            return delta.rounded()
+        }
+        return 0
+    }
+
+    private static func roundTowardZero(_ value: CGFloat) -> CGFloat {
+        value > 0 ? floor(value) : ceil(value)
+    }
+
+    private static func roundAwayFromZero(_ value: CGFloat) -> CGFloat {
+        value > 0 ? ceil(value) : floor(value)
     }
 }
 
@@ -247,6 +360,6 @@ extension SurfaceScrollView {
     ) -> Int {
         guard cellHeight > 0 else { return 0 }
         let topFromTop = documentHeight - visibleOriginY - visibleHeight
-        return max(0, Int((topFromTop / cellHeight).rounded()))
+        return max(0, Int(topFromTop / cellHeight))
     }
 }

--- a/Macterm/Views/Terminal/SurfaceScrollView.swift
+++ b/Macterm/Views/Terminal/SurfaceScrollView.swift
@@ -43,8 +43,8 @@ final class SurfaceScrollView: NSScrollView {
     /// Last row index sent to the core via `scroll_to_row`, to dedupe spam.
     private var lastSentRow: Int = -1
 
-    /// iTerm2's default vertical scroll-wheel accumulator. It turns AppKit's
-    /// messy wheel/trackpad deltas into whole terminal-row movement, including
+    /// iTerm-style vertical scroll-wheel accumulator. It turns AppKit's messy
+    /// wheel/trackpad deltas into whole terminal-row movement, including
     /// momentum events, instead of trying to pixel-scroll terminal contents.
     private let verticalScrollAccumulator = ITermScrollAccumulator()
 
@@ -304,9 +304,9 @@ private final class ITermScrollAccumulator {
 
     private func adjustedDelta(for event: NSEvent) -> CGFloat {
         if event.hasPreciseScrollingDeltas {
-            // iTerm2's default `fastTrackpad` path, based on Terminal.app:
-            // use the device line delta and round away from zero so small
-            // trackpad gestures don't feel sluggish.
+            // iTerm2's `fastTrackpad` path, based on Terminal.app: use the
+            // device line delta and round away from zero so small trackpad
+            // gestures don't feel sluggish.
             return Self.roundAwayFromZero(event.deltaY)
         }
         return event.scrollingDeltaY

--- a/Macterm/Views/Terminal/SurfaceScrollView.swift
+++ b/Macterm/Views/Terminal/SurfaceScrollView.swift
@@ -15,13 +15,16 @@ import GhosttyKit
 ///        └─ GhosttyTerminalNSView      (pinned to the visible rect)
 /// ```
 ///
-/// Wheel/trackpad events hit the frontmost surface view first. Ordinary
-/// scrollback gestures are handled here with an iTerm2-style line accumulator
-/// that converts AppKit's wheel/trackpad deltas (including inertia) into whole
-/// terminal-row movement; mouse-reporting / alt-screen cases continue to go to
-/// libghostty. Scrollback geometry flows **into** this view via the
-/// `GHOSTTY_ACTION_SCROLLBAR` action (`onScrollbarUpdate`), and user-visible
-/// scroll positions flow **out** via the `scroll_to_row:<n>` keybind action.
+/// Wheel/trackpad events hit the frontmost surface view first. The scroll
+/// view handles them with an iTerm2-style line accumulator that converts
+/// AppKit's wheel/trackpad deltas (including inertia) into whole terminal-row
+/// movement — but only while there's scrollback to move through. Apps with no
+/// scrollback (alternate-screen programs like less/vim, or a fresh prompt)
+/// have nothing to scroll, so the view declines and libghostty handles the
+/// event (mouse reporting / cursor keys). Scrollback geometry flows **into**
+/// this view via the `GHOSTTY_ACTION_SCROLLBAR` action (`onScrollbarUpdate`),
+/// and user-visible scroll positions flow **out** via the `scroll_to_row:<n>`
+/// keybind action.
 final class SurfaceScrollView: NSScrollView {
     /// The Metal terminal surface. Owned by `Pane`; we just re-parent it into
     /// our document view.
@@ -90,7 +93,6 @@ final class SurfaceScrollView: NSScrollView {
     }
 
     deinit {
-        MainActor.assumeIsolated { surfaceView.onScrollWheel = nil }
         for token in observers {
             NotificationCenter.default.removeObserver(token)
         }
@@ -191,6 +193,9 @@ final class SurfaceScrollView: NSScrollView {
     }
 
     private func canHandleScrollbackWheel(_ event: NSEvent, cellHeight: CGFloat) -> Bool {
+        // `total > len` is the alt-screen guard: programs with no scrollback
+        // (less/vim, a fresh prompt) have nothing to scroll, so we decline and
+        // let libghostty handle the event (mouse reporting / cursor keys).
         guard surfaceView.surface != nil, cellHeight > 0, total > len else { return false }
         return abs(event.scrollingDeltaY) >= abs(event.scrollingDeltaX)
     }
@@ -268,9 +273,7 @@ private final class ITermScrollAccumulator {
 
     func delta(for event: NSEvent, sensitivity: Double) -> Int {
         let sensitivity = CGFloat(max(0.25, min(3.0, sensitivity)))
-        let accumulated = accumulatedDelta(for: event, sensitivity: sensitivity)
-        let sign: CGFloat = accumulated > 0 ? 1 : -1
-        return Int(pow(abs(accumulated), 1) * sign)
+        return Int(accumulatedDelta(for: event, sensitivity: sensitivity))
     }
 
     private func accumulatedDelta(for event: NSEvent, sensitivity: CGFloat) -> CGFloat {
@@ -281,15 +284,8 @@ private final class ITermScrollAccumulator {
     }
 
     private func accumulatedDeltaForMouseWheelEvent(_ event: NSEvent, sensitivity: CGFloat) -> CGFloat {
-        let delta = adjustedDelta(for: event)
-        if sensitivity == 1 {
-            let roundDelta = delta.rounded()
-            if roundDelta == 0, delta != 0 {
-                return delta > 0 ? 1 : -1
-            }
-            return roundDelta
-        }
-        accumulatedDelta += delta * sensitivity
+        let delta = adjustedDelta(for: event) * sensitivity
+        accumulatedDelta += delta
         return takeWholePortion(delta: delta)
     }
 

--- a/Macterm/Views/Terminal/SurfaceScrollView.swift
+++ b/Macterm/Views/Terminal/SurfaceScrollView.swift
@@ -183,7 +183,7 @@ final class SurfaceScrollView: NSScrollView {
     private func handleSurfaceScrollWheel(_ event: NSEvent) -> Bool {
         let cellHeight = surfaceView.cellHeightPoints
         guard canHandleScrollbackWheel(event, cellHeight: cellHeight) else { return false }
-        let rowDelta = verticalScrollAccumulator.delta(for: event)
+        let rowDelta = verticalScrollAccumulator.delta(for: event, sensitivity: Preferences.shared.terminalScrollSpeed)
         guard rowDelta != 0 else { return true }
         let currentRow = Int(min(offset, UInt64(Int.max)))
         sendScrollToRow(currentRow - rowDelta)
@@ -260,39 +260,44 @@ final class SurfaceScrollView: NSScrollView {
 
 // MARK: - iTerm2-style scroll accumulation
 
-/// Swift port of iTerm2's `iTermScrollAccumulator` with its default settings:
-/// modern accumulator enabled, `fastTrackpad = YES`, sensitivity 1.0, and
-/// scroll-wheel acceleration 1.0.
+/// Swift port of iTerm2's `iTermScrollAccumulator`: modern accumulator enabled,
+/// `fastTrackpad = YES`, configurable sensitivity, and scroll-wheel acceleration
+/// 1.0.
 private final class ITermScrollAccumulator {
     private var accumulatedDelta: CGFloat = 0
 
-    func delta(for event: NSEvent) -> Int {
-        let accumulated = accumulatedDelta(for: event)
+    func delta(for event: NSEvent, sensitivity: Double) -> Int {
+        let sensitivity = CGFloat(max(0.25, min(3.0, sensitivity)))
+        let accumulated = accumulatedDelta(for: event, sensitivity: sensitivity)
         let sign: CGFloat = accumulated > 0 ? 1 : -1
         return Int(pow(abs(accumulated), 1) * sign)
     }
 
-    private func accumulatedDelta(for event: NSEvent) -> CGFloat {
+    private func accumulatedDelta(for event: NSEvent, sensitivity: CGFloat) -> CGFloat {
         if event.phase.isEmpty, event.momentumPhase.isEmpty {
-            return accumulatedDeltaForMouseWheelEvent(event)
+            return accumulatedDeltaForMouseWheelEvent(event, sensitivity: sensitivity)
         }
-        return accumulatedDeltaForTrackpadEvent(event)
+        return accumulatedDeltaForTrackpadEvent(event, sensitivity: sensitivity)
     }
 
-    private func accumulatedDeltaForMouseWheelEvent(_ event: NSEvent) -> CGFloat {
+    private func accumulatedDeltaForMouseWheelEvent(_ event: NSEvent, sensitivity: CGFloat) -> CGFloat {
         let delta = adjustedDelta(for: event)
-        let roundDelta = delta.rounded()
-        if roundDelta == 0, delta != 0 {
-            return delta > 0 ? 1 : -1
+        if sensitivity == 1 {
+            let roundDelta = delta.rounded()
+            if roundDelta == 0, delta != 0 {
+                return delta > 0 ? 1 : -1
+            }
+            return roundDelta
         }
-        return roundDelta
+        accumulatedDelta += delta * sensitivity
+        return takeWholePortion(delta: delta)
     }
 
-    private func accumulatedDeltaForTrackpadEvent(_ event: NSEvent) -> CGFloat {
+    private func accumulatedDeltaForTrackpadEvent(_ event: NSEvent, sensitivity: CGFloat) -> CGFloat {
         if event.phase == .began {
             accumulatedDelta = 0
         }
-        let delta = adjustedDelta(for: event)
+        let delta = adjustedDelta(for: event) * sensitivity
         accumulatedDelta += delta
         return takeWholePortion(delta: delta)
     }

--- a/MactermTests/Views/SurfaceScrollGeometryTests.swift
+++ b/MactermTests/Views/SurfaceScrollGeometryTests.swift
@@ -85,6 +85,16 @@ struct SurfaceScrollGeometryTests {
     }
 
     @Test
+    func row_from_fractional_offset_uses_whole_lines() {
+        // Scroller drags can land between cells, but the terminal core is
+        // row-based, so fractional offsets choose the containing whole row.
+        let row = SurfaceScrollView.rowFromOffset(
+            visibleOriginY: 9, visibleHeight: 480, documentHeight: 2000, cellHeight: cell
+        )
+        #expect(row == 75)
+    }
+
+    @Test
     func row_never_negative() {
         let row = SurfaceScrollView.rowFromOffset(
             visibleOriginY: 9999, visibleHeight: 480, documentHeight: 2000, cellHeight: cell


### PR DESCRIPTION
## What

Routes ordinary terminal scrollback wheel/trackpad events through an iTerm2-style scroll accumulator instead of forwarding every wheel event directly to libghostty. The accumulator converts AppKit wheel/trackpad deltas, including momentum, into whole-row `scroll_to_row` actions while keeping the native overlay scrollbar in sync.

## Why

Macterm scrollback felt sluggish compared with iTerm2 because precise trackpad input was handled by libghostty's row scroll path without iTerm2's fast trackpad accumulation behavior.

## How

Adds a Swift port of iTerm2's default modern scroll accumulator (`fastTrackpad = YES`, sensitivity `1.0`, acceleration `1.0`). `GhosttyTerminalNSView` gives `SurfaceScrollView` first chance to handle ordinary scrollback events when libghostty has not captured the mouse; captured mouse / alternate-screen cases still fall back to libghostty, with momentum metadata preserved.

Scroller drags continue to use `scroll_to_row`, and fractional scroller offsets are floored to whole rows because the terminal core is row-based.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

## Notes for reviewers

This intentionally stays row-based to match terminal/iTerm2 behavior; it does not attempt pixel-continuous text scrolling.
