### PR TITLE
Fix activity detection for in-place terminal output

### DIFF
--- a/Macterm/Ghostty/GhosttyCallbacks.swift
+++ b/Macterm/Ghostty/GhosttyCallbacks.swift
@@ -68,6 +68,12 @@ final class GhosttyCallbacks: @unchecked Sendable {
             let s = action.action.scrollbar
             DispatchQueue.main.async { view.surfaceDidUpdateScrollbar(total: s.total, offset: s.offset, len: s.len) }
             return true
+        case GHOSTTY_ACTION_RENDER:
+            guard let view = surfaceView(from: target) else { return false }
+            DispatchQueue.main.async { view.surfaceDidRender() }
+            // Do not consume the action: keep libghostty's existing render path
+            // unchanged, and use this only as an activity signal.
+            return false
         case GHOSTTY_ACTION_RELOAD_CONFIG:
             // libghostty fires this (with soft = true) when a surface's
             // conditional state changes — notably on set_color_scheme, which

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -64,31 +64,31 @@ private struct ForegroundProcessKey: Equatable {
     }
 }
 
+private enum TerminalExecutionSource: Equatable {
+    case foreground
+    case activity(Date)
+    case progress
+}
+
 private struct TerminalExecutionTracker {
     init(hasUserInteraction: Bool = false) {
         self.hasUserInteraction = hasUserInteraction
     }
 
-    /// The foreground process seen on the last poll (nil = shell / none).
-    /// Transitions are driven by *changes* to this, not by re-deriving state
-    /// on every poll — so a settled idle process never flip-flops back to
-    /// running just because it's still foreground.
+    /// The foreground process seen on the last poll (nil = idle shell / none).
+    /// Transitions are driven by *changes* to this, not by re-deriving state on
+    /// every poll — so a settled process doesn't flip-flop back to running just
+    /// because it is still foreground.
     private var lastForeground: ForegroundProcessKey?
-    /// Timestamp of the most recent terminal output. nil while running is owed
-    /// to a foreground command or explicit progress (which don't quiet-settle).
-    /// Its presence/absence is the only record of whether running is
-    /// "output-sourced" (settles when quiet) or not — no separate source enum.
-    private var lastActivityAt: Date?
-    /// True while an OSC 9;4 progress report owns the pane; output and
-    /// foreground changes are ignored while it's active.
-    private var progressActive = false
+    /// Why the pane is currently considered running. Foreground and explicit
+    /// progress run until a completion/foreground transition; activity is a
+    /// render/output heartbeat and quiet-settles.
+    private var runningSource: TerminalExecutionSource?
     /// After progress clears, the foreground process that owned it is
-    /// "quiesced": its own output and re-polls are ignored until the
-    /// foreground moves away, so a settled program that reported progress
-    /// doesn't flip back to running on its own render output.
-    /// `pendingProgressQuiesce` covers the race where progress started and
-    /// cleared before any foreground poll — the first process to appear is
-    /// quiesced instead of marked running.
+    /// "quiesced": its own output and re-polls are ignored until the foreground
+    /// moves away, so a settled program that reported progress doesn't flip back
+    /// to running on its own render output. `pendingProgressQuiesce` covers the
+    /// race where progress started and cleared before any foreground poll.
     private var progressQuiesced: ForegroundProcessKey?
     private var pendingProgressQuiesce = false
     /// Output is ignored until the user has interacted with the pane, so a
@@ -101,8 +101,7 @@ private struct TerminalExecutionTracker {
 
     mutating func markProgressStarted(currentState: TerminalExecutionState) -> TerminalExecutionState {
         guard hasUserInteraction else { return currentState }
-        progressActive = true
-        lastActivityAt = nil
+        runningSource = .progress
         return .running
     }
 
@@ -114,22 +113,20 @@ private struct TerminalExecutionTracker {
         // precmd noise and must not flip the pane to `.done` (which would
         // persist as a spurious checkmark after restart).
         guard currentState == .running else { return currentState }
-        progressActive = false
+        runningSource = nil
         progressQuiesced = nil
         pendingProgressQuiesce = false
-        lastActivityAt = nil
         return .done
     }
 
     mutating func markProgressFinished(currentState: TerminalExecutionState) -> TerminalExecutionState {
-        guard hasUserInteraction || progressActive else { return currentState }
-        progressActive = false
+        guard hasUserInteraction || runningSource == .progress else { return currentState }
         if let lastForeground {
             progressQuiesced = lastForeground
         } else {
             pendingProgressQuiesce = true
         }
-        lastActivityAt = nil
+        runningSource = nil
         return currentState == .running ? .done : currentState
     }
 
@@ -137,14 +134,14 @@ private struct TerminalExecutionTracker {
         at date: Date,
         currentState: TerminalExecutionState
     ) -> TerminalExecutionState {
-        guard !progressActive else { return currentState }
+        guard runningSource != .progress else { return currentState }
         if let progressQuiesced, progressQuiesced == lastForeground { return currentState }
-        // Output only counts after user interaction (or a declarative `run:`,
-        // which seeds `hasUserInteraction`). Fresh/restored shells can emit
-        // startup banners or shell-integration redraws before the user does
+        // Output/render only counts after user interaction (or a declarative
+        // `run:`, which seeds `hasUserInteraction`). Fresh/restored shells can
+        // emit startup banners or shell-integration redraws before the user does
         // anything; those must not become persisted completion indicators.
         guard hasUserInteraction else { return currentState }
-        lastActivityAt = date
+        runningSource = .activity(date)
         return .running
     }
 
@@ -154,11 +151,10 @@ private struct TerminalExecutionTracker {
         currentState: TerminalExecutionState
     ) -> TerminalExecutionState {
         guard currentState == .running,
-              !progressActive,
-              let lastActivityAt,
+              case let .activity(lastActivityAt) = runningSource,
               now.timeIntervalSince(lastActivityAt) >= quietInterval
         else { return currentState }
-        self.lastActivityAt = nil
+        runningSource = nil
         return .done
     }
 
@@ -192,41 +188,39 @@ private struct TerminalExecutionTracker {
         let changed = newKey != lastForeground
         lastForeground = newKey
 
-        // Foreground returned to the shell: a running command exited.
+        // Foreground returned to the shell: a foreground-running command exited.
         if newKey == nil {
             guard changed, currentState == .running else { return currentState }
-            lastActivityAt = nil
+            runningSource = nil
             return .done
         }
 
-        // Non-shell foreground. Explicit progress owns the state while active.
-        if progressActive { return currentState }
+        // Explicit progress owns the state while active.
+        if runningSource == .progress { return currentState }
 
-        // A newly-created/restored plain shell can briefly look like a
-        // non-shell foreground while its startup files and shell integration
-        // settle. Do not turn that launch noise into a persisted checkmark.
-        // Once the user has interacted, foreground transitions are real user
-        // work. Declarative layout `run:` panes seed `hasUserInteraction` so
-        // their startup command is still tracked.
+        // A newly-created/restored plain shell can briefly look like a non-shell
+        // foreground while its startup files and shell integration settle. Do
+        // not turn that launch noise into a persisted checkmark. Once the user
+        // has interacted, foreground transitions are real user work.
         guard hasUserInteraction else { return currentState }
 
         if terminalInputIsRaw {
-            // A raw/cbreak-mode program (full-screen editors, multiplexers,
-            // interactive CLIs) shouldn't hold a foreground-only spinner just
-            // because it's the foreground process. If we were running only
-            // because of a prior canonical command (no recent output), settle
-            // now; output-sourced running is left to quiet-settle on its own.
-            if currentState == .running, lastActivityAt == nil {
+            // Raw/cbreak-mode programs (editors, multiplexers, interactive CLIs)
+            // should not be held running by foreground alone. If a canonical
+            // command switched the tty raw, finish that foreground-only run;
+            // activity-sourced runs still quiet-settle normally.
+            if currentState == .running, runningSource == .foreground {
+                runningSource = nil
                 return .done
             }
             return currentState
         }
 
-        // Canonical non-shell command (a build, `sleep`, …) → running until
-        // it returns to the shell. Only act on a change so a settled idle
-        // process doesn't flip back to running on every poll.
+        // Canonical non-shell command (a build, `sleep`, shell script, …) →
+        // running until it returns to the shell. Only act on a change so a
+        // settled idle process doesn't flip back to running on every poll.
         guard changed else { return currentState }
-        lastActivityAt = nil
+        runningSource = .foreground
         return .running
     }
 }

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -459,6 +459,7 @@ final class Pane: Identifiable {
         view.onProgressStarted = nil
         view.onProgressFinished = nil
         view.onTerminalActivity = nil
+        view.onTerminalRender = nil
         view.onScrollbarUpdate = nil
         view.destroySurface()
         let scroll = _scrollView

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -70,7 +70,7 @@ private enum TerminalExecutionSource: Equatable {
     case progress
 }
 
-private struct TerminalExecutionTracker {
+struct TerminalExecutionTracker {
     init(hasUserInteraction: Bool = false) {
         self.hasUserInteraction = hasUserInteraction
     }
@@ -134,6 +134,14 @@ private struct TerminalExecutionTracker {
         at date: Date,
         currentState: TerminalExecutionState
     ) -> TerminalExecutionState {
+        // A render/output heartbeat can keep an already-running command active,
+        // but it must never (re)start one. From `.done` — a finished command
+        // whose checkmark is showing — output (e.g. a background job) must not
+        // flip the pane back to running; only a new foreground process or an
+        // explicit progress marker can. Pinned by TerminalExecutionTrackerTests
+        // so a refactor of the onTerminalRender closure can't silently
+        // reintroduce the "prompt redraw keeps spinning" bug.
+        guard currentState != .done else { return currentState }
         guard runningSource != .progress else { return currentState }
         if let progressQuiesced, progressQuiesced == lastForeground { return currentState }
         // Output/render only counts after user interaction (or a declarative

--- a/Macterm/System/ProcessInspector.swift
+++ b/Macterm/System/ProcessInspector.swift
@@ -77,7 +77,7 @@ enum ProcessInspector {
     @MainActor
     static func foregroundProcessIsShell(forPane pane: Pane) -> Bool {
         guard let pid = pane.nsView?.foregroundPID else { return false }
-        return isShellProcess(pid: pid)
+        return isIdleShellProcess(pid: pid)
     }
 
     static func isShellProcess(pid: pid_t) -> Bool {
@@ -85,6 +85,40 @@ enum ProcessInspector {
         if let firstArg = argv(pid: pid)?.first, isShellProcessName(firstArg) { return true }
         if let name = comm(pid: pid), isShellProcessName(name) { return true }
         return false
+    }
+
+    /// Whether `pid` is a shell sitting at an interactive prompt. A shell that
+    /// is executing a script (including a shebang script like
+    /// `/tmp/spinner-test.sh`) or a `-c` command is foreground work, not idle.
+    static func isIdleShellProcess(pid: pid_t) -> Bool {
+        if let args = argv(pid: pid), let first = args.first, isShell(first) {
+            return isIdleShellInvocation(args)
+        }
+        return isShellProcess(pid: pid)
+    }
+
+    static func isIdleShellInvocation(_ argv: [String]) -> Bool {
+        guard let first = argv.first, isShell(first) else { return false }
+        return !shellInvocationRunsCommand(argv)
+    }
+
+    private static func shellInvocationRunsCommand(_ argv: [String]) -> Bool {
+        guard argv.count > 1 else { return false }
+        var index = 1
+        while index < argv.count {
+            let arg = argv[index]
+            if arg == "--" { return index + 1 < argv.count }
+            if !arg.hasPrefix("-") || arg == "-" { return true }
+            if arg == "-c" || (arg.hasPrefix("-") && !arg.hasPrefix("--") && arg.dropFirst().contains("c")) {
+                return true
+            }
+            index += shellOptionConsumesNextArgument(arg) ? 2 : 1
+        }
+        return false
+    }
+
+    private static func shellOptionConsumesNextArgument(_ option: String) -> Bool {
+        option == "--rcfile" || option == "--init-file"
     }
 
     /// Whether the pane's tty is in raw/cbreak-style input mode. Full-screen and

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -59,6 +59,10 @@ final class GhosttyTerminalNSView: NSView {
         }
     }
 
+    func surfaceDidRender() {
+        onTerminalRender?()
+    }
+
     func surfaceDidUpdateScrollbar(total: UInt64, offset: UInt64, len: UInt64) {
         let snapshot = ScrollbarSnapshot(total: total, offset: offset, len: len)
         if let lastScrollbarSnapshot, total > lastScrollbarSnapshot.total {
@@ -83,6 +87,7 @@ final class GhosttyTerminalNSView: NSView {
     var onProgressStarted: (() -> Void)?
     var onProgressFinished: (() -> Void)?
     var onTerminalActivity: (() -> Void)?
+    var onTerminalRender: (() -> Void)?
     /// libghostty pushes scrollback geometry (all values in rows) whenever the
     /// viewport, scrollback size, or visible row count changes.
     /// `(total, offset, len)`: total rows including scrollback, the first

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -201,6 +201,18 @@ private struct TerminalSurface: NSViewRepresentable {
             pane.refreshForegroundProcess()
             pane.markTerminalActivity()
         }
+        view.onTerminalRender = { [weak pane] in
+            guard let pane, Preferences.shared.showTabStatusIndicator else { return }
+            // Renders also happen for prompt redraws and input echo. Use them to
+            // keep an already-detected command active (including in-place
+            // spinners), but don't let a render alone start the status spinner.
+            if pane.executionState != .running {
+                pane.refreshForegroundProcess()
+            }
+            if pane.executionState == .running {
+                pane.markTerminalActivity()
+            }
+        }
         view.onCommandFinished = { [weak pane, weak view] exitCode, durationNs in
             guard let pane else { return }
             if Preferences.shared.showTabStatusIndicator {

--- a/MactermTests/Model/TerminalExecutionTrackerTests.swift
+++ b/MactermTests/Model/TerminalExecutionTrackerTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+/// Direct unit tests for `TerminalExecutionTracker`, the state machine behind a
+/// pane's tab status spinner.
+///
+/// These pin the core invariant surfaced in the activity-detection fix: a
+/// render/output heartbeat can keep an already-running command active (so
+/// in-place spinners that repaint with carriage returns stay alive), but it can
+/// never start or resurrect the spinner on its own. The "keep-alive only" rule
+/// is enforced at the call site (`onTerminalRender` only calls the heartbeat
+/// while already `.running`), and these tests lock the matching guarantee into
+/// the tracker itself — otherwise a future refactor could silently reintroduce
+/// the "prompt redraw keeps spinning" bug with nothing to catch it.
+struct TerminalExecutionTrackerTests {
+    @Test
+    func markTerminalActivity_fromIdleWithoutInteraction_staysIdle() {
+        // No prior user interaction: a fresh/restored shell's startup output
+        // must not register as activity.
+        var tracker = TerminalExecutionTracker()
+        let state = tracker.markTerminalActivity(at: Date(timeIntervalSince1970: 1), currentState: .idle)
+        #expect(state == .idle)
+    }
+
+    @Test
+    func markTerminalActivity_fromIdleWithInteraction_startsRun() {
+        // Output activity (scrollback) after interaction is a genuine signal
+        // that something is running, so — unlike a render heartbeat — it *may*
+        // start the spinner from idle. Pinned here so the "render can't start"
+        // guard isn't over-corrected into "no activity can ever start".
+        var tracker = TerminalExecutionTracker()
+        tracker.recordUserInteraction()
+        let state = tracker.markTerminalActivity(at: Date(timeIntervalSince1970: 1), currentState: .idle)
+        #expect(state == .running)
+    }
+
+    @Test
+    func markTerminalActivity_fromDone_doesNotReturnToRunning() {
+        // A finished command (`.done`, checkmark showing) must not be flipped
+        // back to running by a render/output heartbeat — e.g. a background job
+        // printing while the foreground command is already settled.
+        var tracker = TerminalExecutionTracker()
+        tracker.recordUserInteraction()
+        var state = tracker.markTerminalActivity(at: Date(timeIntervalSince1970: 100), currentState: .idle)
+        state = tracker.settleIfQuiet(now: Date(timeIntervalSince1970: 103), quietInterval: 3, currentState: state)
+        #expect(state == .done)
+
+        state = tracker.markTerminalActivity(at: Date(timeIntervalSince1970: 110), currentState: state)
+        #expect(state == .done)
+    }
+
+    @Test
+    func markTerminalActivity_fromRunning_keepsAliveAndRefreshesTimestamp() {
+        // While running, each heartbeat refreshes the activity timestamp so the
+        // quiet-settle window restarts. This is "a render can keep a spinner
+        // alive" — the fix for in-place spinners that repaint the same line.
+        var tracker = TerminalExecutionTracker()
+        tracker.recordUserInteraction()
+        let start = Date(timeIntervalSince1970: 100)
+        var state = tracker.markTerminalActivity(at: start, currentState: .idle)
+        #expect(state == .running)
+
+        // A heartbeat at start+2 restarts the window; settling at start+3 (only
+        // 1s after the last heartbeat) must still be running.
+        state = tracker.markTerminalActivity(at: start.addingTimeInterval(2), currentState: state)
+        #expect(state == .running)
+        state = tracker.settleIfQuiet(now: start.addingTimeInterval(3), quietInterval: 3, currentState: state)
+        #expect(state == .running)
+
+        // After the full quiet interval elapses past the last heartbeat, it settles.
+        state = tracker.settleIfQuiet(now: start.addingTimeInterval(5), quietInterval: 3, currentState: state)
+        #expect(state == .done)
+    }
+
+    @Test
+    func activitySourcedRun_settlesAfterQuietInterval() {
+        // An activity-sourced run is not held forever: once output goes quiet
+        // for the interval it decays to `.done` (foreground- and progress-sourced
+        // runs are not subject to this timer).
+        var tracker = TerminalExecutionTracker()
+        tracker.recordUserInteraction()
+        let start = Date(timeIntervalSince1970: 100)
+        var state = tracker.markTerminalActivity(at: start, currentState: .idle)
+        #expect(state == .running)
+
+        // Just under the quiet interval: still running.
+        state = tracker.settleIfQuiet(now: start.addingTimeInterval(2), quietInterval: 3, currentState: state)
+        #expect(state == .running)
+        // At the quiet interval: settles to done.
+        state = tracker.settleIfQuiet(now: start.addingTimeInterval(3), quietInterval: 3, currentState: state)
+        #expect(state == .done)
+    }
+}

--- a/MactermTests/System/ProcessInspectorTests.swift
+++ b/MactermTests/System/ProcessInspectorTests.swift
@@ -80,6 +80,16 @@ struct ProcessInspectorTests {
     }
 
     @Test
+    func shellScriptInvocation_isNotIdleShell() {
+        #expect(ProcessInspector.isIdleShellInvocation(["/bin/bash"]))
+        #expect(ProcessInspector.isIdleShellInvocation(["/bin/bash", "-l"]))
+        // This is only an argv shape; the script path is not opened.
+        #expect(!ProcessInspector.isIdleShellInvocation(["/bin/bash", "/path/to/script.sh"]))
+        #expect(!ProcessInspector.isIdleShellInvocation(["/bin/bash", "-c", "sleep 10"]))
+        #expect(!ProcessInspector.isIdleShellInvocation(["/bin/bash", "-lc", "sleep 10"]))
+    }
+
+    @Test
     func terminalInputIsRaw_reads_tty_input_mode() throws {
         var master: Int32 = -1
         var slave: Int32 = -1


### PR DESCRIPTION
## What

Fix tab status spinner/activity detection for tools that repaint the same terminal line instead of producing scrollback.

## Why

I noticed this while running the pi coding-agent harness: its spinner could run without keeping Macterm’s tab spinner active. The same pattern likely affects other tools with in-place progress output, such as Claude Code, Codex, and similar CLIs.

The previous activity signal depended on scrollback/scrollbar changes, so output using carriage returns could repaint the terminal without being detected as ongoing activity.

## How

Use libghostty render actions as an activity heartbeat for commands that are already considered running. Render events are not allowed to start the spinner by themselves, because renders also happen for prompt redraws and input echo.

Also treat shell interpreters running scripts or `-c` commands as foreground work rather than idle shells, so shebang scripts are classified correctly.

Finally, simplify execution tracking around explicit running sources: foreground, activity, and progress.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

## Notes for reviewers

Manual repro script used for verification:

```bash
#!/bin/bash
spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
end_time=$(($(date +%s) + 10))

while [ "$(date +%s)" -lt "$end_time" ]; do
  for s in "${spinner[@]}"; do
    echo -ne "\r$s Testing."
    sleep 0.15
    if [ "$(date +%s)" -ge "$end_time" ]; then
      break
    fi
  done
done

echo -ne "\rDone!          \n"
```
