### PR TITLE
Paste clipboard images into TUIs instead of dropping them

### DIFF
--- a/Macterm/Ghostty/GhosttyCallbacks.swift
+++ b/Macterm/Ghostty/GhosttyCallbacks.swift
@@ -131,9 +131,12 @@ final class GhosttyCallbacks: @unchecked Sendable {
     /// Returns pasted text from the pasteboard: file paths (Finder drag/copy)
     /// fall back to plain string. Called by both the context-menu paste path
     /// and the libghostty Cmd+V clipboard path.
-    static func readPasteboardText() -> String? {
-        let pb = NSPasteboard.general
-
+    ///
+    /// When the pasteboard holds a raw image (e.g. a screenshot) and no text,
+    /// the image is written to a temporary PNG file and its path is returned —
+    /// matching base Ghostty's behavior. This is what lets TUIs such as Claude
+    /// Code receive pasted images: they read the file at the pasted path.
+    static func readPasteboardText(from pb: NSPasteboard = .general) -> String? {
         // Finder copies files as NSURL data, not strings.
         if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL] {
             let paths = urls
@@ -146,7 +149,60 @@ final class GhosttyCallbacks: @unchecked Sendable {
             }
         }
 
-        return pb.string(forType: .string).flatMap { !$0.isEmpty ? $0 : nil }
+        // Prefer real text when present.
+        if let s = pb.string(forType: .string), !s.isEmpty {
+            return s
+        }
+
+        // Raw image on the clipboard (screenshot, "Copy Image", etc.): persist
+        // it to a temp PNG and paste the escaped path.
+        if let path = Self.imagePasteboardPath(pb) {
+            return Self.shellEscape(path)
+        }
+
+        return nil
+    }
+
+    /// Cheap, side-effect-free check for whether there is anything pasteable
+    /// (text, file URLs, or an image). Used to enable/disable the Paste menu
+    /// item without writing a temp file.
+    static func hasPasteboardContent(in pb: NSPasteboard = .general) -> Bool {
+        let types: [NSPasteboard.PasteboardType] = [.string, .fileURL, .URL, .png, .tiff]
+        return pb.availableType(from: types) != nil
+    }
+
+    /// If the pasteboard contains image data, write a normalized PNG to the
+    /// temporary directory and return its absolute path. Returns nil when no
+    /// image is available or the write fails.
+    static func imagePasteboardPath(_ pb: NSPasteboard) -> String? {
+        // Pull raw bytes for the best available image type, normalizing to PNG.
+        let pngData: Data? = if let data = pb.data(forType: .png) {
+            data
+        } else if let data = pb.data(forType: .tiff),
+                  let rep = NSBitmapImageRep(data: data)
+        {
+            rep.representation(using: .png, properties: [:])
+        } else if let image = NSImage(pasteboard: pb),
+                  let tiff = image.tiffRepresentation,
+                  let rep = NSBitmapImageRep(data: tiff)
+        {
+            rep.representation(using: .png, properties: [:])
+        } else {
+            nil
+        }
+
+        guard let data = pngData else { return nil }
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-paste", isDirectory: true)
+        let url = dir.appendingPathComponent("image-\(UUID().uuidString).png")
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try data.write(to: url)
+            return url.path
+        } catch {
+            return nil
+        }
     }
 
     func confirmReadClipboard(ud: UnsafeMutableRawPointer?, content: UnsafePointer<CChar>?, state: UnsafeMutableRawPointer?) {

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -646,7 +646,7 @@ final class GhosttyTerminalNSView: NSView {
         let menu = NSMenu(title: "Terminal")
         let paste = NSMenuItem(title: "Paste", action: #selector(handlePaste), keyEquivalent: "")
         paste.target = self
-        paste.isEnabled = GhosttyCallbacks.readPasteboardText() != nil
+        paste.isEnabled = GhosttyCallbacks.hasPasteboardContent()
         menu.addItem(paste)
         menu.addItem(.separator())
         addSplitItem(menu, "Split Right", .horizontal, .second)

--- a/MactermTests/Ghostty/GhosttyCallbacksTests.swift
+++ b/MactermTests/Ghostty/GhosttyCallbacksTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+@testable import Macterm
+import Testing
+
+/// Covers the pasteboard resolver that backs Cmd+V / context-menu paste —
+/// specifically the image branch that lets a raw clipboard image (a screenshot,
+/// "Copy Image") paste into a TUI as a temp-file path. Each test drives a
+/// private, uniquely named `NSPasteboard` so it never touches the real
+/// system clipboard or races with other tests.
+@MainActor
+struct GhosttyCallbacksTests {
+    /// A fresh, isolated pasteboard for one test. Released on deinit.
+    private func makePasteboard() -> NSPasteboard {
+        let pb = NSPasteboard(name: NSPasteboard.Name("macterm.test.\(UUID().uuidString)"))
+        pb.clearContents()
+        return pb
+    }
+
+    /// A real 4×4 PNG, encoded the way the system would put one on the clipboard.
+    private func samplePNG() -> Data {
+        let image = NSImage(size: NSSize(width: 4, height: 4))
+        image.lockFocus()
+        NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: 4, height: 4).fill()
+        image.unlockFocus()
+        let tiff = image.tiffRepresentation!
+        return NSBitmapImageRep(data: tiff)!.representation(using: .png, properties: [:])!
+    }
+
+    /// A real 4×4 TIFF, for exercising the `.tiff`→PNG normalization path.
+    private func sampleTIFF() -> Data {
+        let image = NSImage(size: NSSize(width: 4, height: 4))
+        image.lockFocus()
+        NSColor.blue.setFill()
+        NSRect(x: 0, y: 0, width: 4, height: 4).fill()
+        image.unlockFocus()
+        return image.tiffRepresentation!
+    }
+
+    @Test
+    func plainText_returnsTheString() {
+        let pb = makePasteboard()
+        pb.declareTypes([.string], owner: nil)
+        pb.setString("hello world", forType: .string)
+
+        #expect(GhosttyCallbacks.readPasteboardText(from: pb) == "hello world")
+    }
+
+    @Test
+    func emptyPasteboard_returnsNil() {
+        let pb = makePasteboard()
+        #expect(GhosttyCallbacks.readPasteboardText(from: pb) == nil)
+        #expect(GhosttyCallbacks.hasPasteboardContent(in: pb) == false)
+    }
+
+    @Test
+    func image_pastesPathToARealPNGFile() throws {
+        let pb = makePasteboard()
+        pb.declareTypes([.png], owner: nil)
+        pb.setData(samplePNG(), forType: .png)
+
+        let resolved = try #require(GhosttyCallbacks.readPasteboardText(from: pb))
+        // The pasted text is a shell-escaped path; unescape spaces to hit disk.
+        let path = resolved.replacingOccurrences(of: "\\", with: "")
+
+        #expect(path.hasSuffix(".png"))
+        #expect(path.contains("macterm-paste"))
+        #expect(FileManager.default.fileExists(atPath: path))
+        // The written file must be a decodable image, not just any bytes.
+        #expect(NSImage(contentsOfFile: path) != nil)
+
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    @Test
+    func tiffOnly_isNormalizedToAPNGFile() throws {
+        let pb = makePasteboard()
+        // Put a genuine TIFF (no .png type) on the board.
+        pb.declareTypes([.tiff], owner: nil)
+        pb.setData(sampleTIFF(), forType: .tiff)
+
+        let resolved = try #require(GhosttyCallbacks.readPasteboardText(from: pb))
+        let path = resolved.replacingOccurrences(of: "\\", with: "")
+
+        #expect(path.hasSuffix(".png"))
+        #expect(NSImage(contentsOfFile: path) != nil)
+
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    @Test
+    func text_takesPrecedenceOverImage() {
+        let pb = makePasteboard()
+        pb.declareTypes([.string, .png], owner: nil)
+        pb.setString("real text", forType: .string)
+        pb.setData(samplePNG(), forType: .png)
+
+        // Text wins, so normal copy/paste is never rerouted through a temp file.
+        #expect(GhosttyCallbacks.readPasteboardText(from: pb) == "real text")
+    }
+
+    @Test
+    func hasPasteboardContent_isSideEffectFreeForImages() {
+        let pb = makePasteboard()
+        pb.declareTypes([.png], owner: nil)
+        pb.setData(samplePNG(), forType: .png)
+
+        // Reports content present without writing a temp PNG (unlike the resolver).
+        #expect(GhosttyCallbacks.hasPasteboardContent(in: pb) == true)
+        #expect(GhosttyCallbacks.imagePasteboardPath(pb) != nil)
+    }
+}


### PR DESCRIPTION
## What

Pasting a raw image from the clipboard (a screenshot, "Copy Image", etc.) into the terminal now writes the image to a temp PNG and pastes its file path, instead of inserting nothing.

## Why

Pasting an image into a TUI that reads images from a pasted path — e.g. Claude Code — does nothing in Macterm, even though it works in base Ghostty, Terminal.app, and others. Macterm overrides libghostty's clipboard-read callback with a text-only resolver (`readPasteboardText`), so an image-only pasteboard returns an empty string and the paste is dropped on the floor.

## How

`readPasteboardText()` gains an image fallback: when the pasteboard has no text/file-URL but does carry `.png`/`.tiff` (or an `NSImage`), the image is normalized to PNG, written to a temp dir, and its shell-escaped path is returned — matching base Ghostty's behavior and what path-reading TUIs consume. Text and Finder file-URLs still take precedence, so normal pastes are unchanged.

A side-effect-free `hasPasteboardContent()` (a cheap `availableType(from:)` check) now drives the context-menu Paste item's enablement, so opening the menu no longer writes a temp PNG just to test whether anything is pasteable.

The resolvers take an injectable `NSPasteboard` (defaulting to `.general`) so the behavior is covered by unit tests that drive a real, isolated pasteboard with a real PNG.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic
