### PR TITLE
fix: consistent slider width for each settings screen

### DIFF
--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -189,6 +189,8 @@ private struct GhosttyCLIBanner: View {
 // MARK: - Appearance
 
 private struct AppearanceSettings: View {
+    private let sliderLabelWidth: CGFloat = 126
+
     @AppStorage(Preferences.Keys.projectIconSymbol)
     private var projectIconSymbol = "folder"
     @AppStorage(Preferences.Keys.tabIconSymbol)
@@ -213,6 +215,7 @@ private struct AppearanceSettings: View {
             Section("Window") {
                 HStack {
                     Text("Background opacity")
+                        .frame(width: sliderLabelWidth, alignment: .leading)
                     Slider(value: $backgroundOpacity, in: 0.0 ... 1.0)
                     Text("\(Int((backgroundOpacity * 100).rounded()))%")
                         .monospacedDigit()
@@ -238,8 +241,9 @@ private struct AppearanceSettings: View {
 
                 HStack {
                     Text("Background blur")
+                        .frame(width: sliderLabelWidth, alignment: .leading)
                     Slider(value: $backgroundBlurRadius, in: 0 ... 100)
-                    Text("\(Int(backgroundBlurRadius.rounded()))")
+                    Text("\(Int(backgroundBlurRadius.rounded()))%")
                         .monospacedDigit()
                         .frame(width: 42, alignment: .trailing)
                 }
@@ -359,6 +363,8 @@ private struct AppearanceSettings: View {
 // MARK: - Quick Terminal
 
 private struct QuickTerminalSettings: View {
+    private let sliderLabelWidth: CGFloat = 44
+
     @AppStorage(Preferences.Keys.quickTerminalEnabled)
     private var enabled = true
     @State
@@ -373,6 +379,7 @@ private struct QuickTerminalSettings: View {
 
                 HStack {
                     Text("Width")
+                        .frame(width: sliderLabelWidth, alignment: .leading)
                     Slider(value: $qtWidth, in: 0.2 ... 1.0, step: 0.05)
                     Text("\(Int(qtWidth * 100))%")
                         .monospacedDigit()
@@ -385,6 +392,7 @@ private struct QuickTerminalSettings: View {
 
                 HStack {
                     Text("Height")
+                        .frame(width: sliderLabelWidth, alignment: .leading)
                     Slider(value: $qtHeight, in: 0.2 ... 1.0, step: 0.05)
                     Text("\(Int(qtHeight * 100))%")
                         .monospacedDigit()


### PR DESCRIPTION
<!--
PRs merge via squash — make the title a good squash subject (focus on the "why").
Delete any section that doesn't apply. Keep it tight.
-->

## What

Make the sliders of settings screen consistent

## Why

Currently the sliders are jagged (see screenshot below)
<img width="490" height="193" alt="Screenshot 2026-06-30 at 3 39 04 PM" src="https://github.com/user-attachments/assets/a02f5556-3cde-46a4-9db9-66aa1cb463eb" />

<img width="490" height="193" alt="Screenshot 2026-06-30 at 3 39 24 PM" src="https://github.com/user-attachments/assets/6207c84b-0673-4c99-8e26-42012dee2bfa" />

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [ ] (no need) Added or updated tests for new model / persistence / palette / hotkey logic

<img width="490" height="193" alt="Screenshot 2026-06-30 at 4 09 47 PM" src="https://github.com/user-attachments/assets/24d4577b-c226-408c-8992-ab884ec03c1f" />
<img width="490" height="193" alt="Screenshot 2026-06-30 at 4 09 53 PM" src="https://github.com/user-attachments/assets/3ca4c7d1-3ec8-4967-97e6-8e42eb02f0a2" />