### PR TITLE
fix: render CJK IME preedit text

### DIFF
--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -913,9 +913,9 @@ extension GhosttyTerminalNSView: @preconcurrency NSTextInputClient {
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
         guard let surface else { return }
         let text = (string as? String) ?? (string as? NSAttributedString)?.string ?? ""
-        _markedRange = text.isEmpty ? NSRange(location: NSNotFound, length: 0) : NSRange(location: 0, length: text.count)
+        _markedRange = text.isEmpty ? NSRange(location: NSNotFound, length: 0) : NSRange(location: 0, length: text.utf16.count)
         _selectedRange = selectedRange
-        text.withCString { ghostty_surface_preedit(surface, $0, UInt(text.count)) }
+        text.withCString { ghostty_surface_preedit(surface, $0, UInt(text.utf8.count)) }
     }
 
     func unmarkText() {


### PR DESCRIPTION
<!--
PRs merge via squash — make the title a good squash subject (focus on the "why").
Delete any section that doesn't apply. Keep it tight.
-->

## What

<!-- What this PR changes, in a sentence or two. -->

Fix CJK IME preedit text rendering while composing.

Macterm now passes the UTF-8 byte length of marked text to `ghostty_surface_preedit`, instead of Swift's character count. It also reports the marked range length with `String.UTF16View`, matching `NSRange`/AppKit expectations.

## Why

<!-- The motivation. Link the issue this closes, if any. -->

CJK IME preedit text can be invisible while composing. I reproduced this with Japanese IME input: the committed text appeared after conversion, but the in-progress kana/kanji composition did not render at the cursor.

`ghostty_surface_preedit` takes a UTF-8 pointer and byte length. For CJK/non-ASCII text, `String.count` is shorter than the UTF-8 byte count (`"あ"` is 1 Swift character but 3 UTF-8 bytes), so libghostty could receive a truncated UTF-8 sequence and fail to decode/render the preedit text.

Closes #118

## How

<!-- The approach, and anything non-obvious a reviewer needs to follow it.
     Call out tradeoffs, framework limitations worked around, or design choices. -->

`GhosttyTerminalNSView.setMarkedText` now computes the preedit length from `text.utf8.count` before calling `ghostty_surface_preedit`.

The marked range length is computed with `text.utf16.count`, so AppKit-facing range values stay in UTF-16 code units.

No new tests are added; the change is a narrow AppKit/libghostty bridge fix that uses Swift's standard UTF-8 and UTF-16 views directly at the call site.

## Verified

<!-- How you confirmed this works. Tick what applies. -->

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [ ] (no model / persistence / palette / hotkey logic changed) Added or updated tests for new model / persistence / palette / hotkey logic

## Notes for reviewers

<!-- Optional: anything to flag — branch history detours, follow-ups deferred,
     screenshots / recordings for UI changes. -->

Verified Japanese IME preedit text is visible while composing in the built app.

Recordings:

- Before: Japanese IME preedit text is invisible while composing.
  
  https://github.com/user-attachments/assets/c49b10c3-1d98-4b59-a9df-ef59399cf1bd
- After: Japanese IME preedit text is visible at the cursor before commit/conversion.
  
  https://github.com/user-attachments/assets/5a06d8f0-f723-4326-8dcc-15e2e5db3884

Also ran:

- `mise run format --verbose`
- `mise run test --verbose`
- `mise run build --verbose`