### PR TITLE
fix: correct off-by-one in search match counter

### DIFF
--- a/Macterm/Model/TerminalSearchState.swift
+++ b/Macterm/Model/TerminalSearchState.swift
@@ -11,7 +11,7 @@ final class TerminalSearchState {
     var displayText: String {
         guard let total else { return "" }
         guard let selected else { return "\(total) matches" }
-        return "\(selected) of \(total)"
+        return "\(selected + 1) of \(total)"
     }
 
     @ObservationIgnored

--- a/MactermTests/Model/TerminalSearchStateTests.swift
+++ b/MactermTests/Model/TerminalSearchStateTests.swift
@@ -1,0 +1,30 @@
+@testable import Macterm
+import Testing
+
+@MainActor
+struct TerminalSearchStateTests {
+    @Test
+    func displayText_is_one_indexed() {
+        let state = TerminalSearchState()
+        state.total = 5
+        state.selected = 0
+        #expect(state.displayText == "1 of 5")
+
+        state.selected = 4
+        #expect(state.displayText == "5 of 5")
+    }
+
+    @Test
+    func displayText_falls_back_to_match_count_without_selection() {
+        let state = TerminalSearchState()
+        state.total = 5
+        state.selected = nil
+        #expect(state.displayText == "5 matches")
+    }
+
+    @Test
+    func displayText_is_empty_without_total() {
+        let state = TerminalSearchState()
+        #expect(state.displayText.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Terminal search's match counter rendered ghostty's zero-based `selected` index directly, so the first match showed "0 of 5" and the counter topped out at "4 of 5" instead of "5 of 5".
- `TerminalSearchState.displayText` now adds 1 when formatting the selected index.

## Test plan
- [x] Added `TerminalSearchStateTests` covering `displayText` at first/last match and the no-selection/no-total fallbacks.
- [x] `mise run test --verbose`