### PR TITLE
Skip quiet-settle for occluded panes so parked renderers can't fake completion

### DIFF
--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -88,6 +88,21 @@ final class AppState {
     @ObservationIgnored
     private var processNameTimer: Timer?
 
+    /// Whether a pane's surface is occluded — its renderer parked by
+    /// `ghostty_surface_set_occlusion`, so render/scrollbar heartbeats are
+    /// suppressed and silence says nothing about completion. Injectable for
+    /// tests. "No window" counts as occluded, which also covers panes
+    /// incubated off-screen (the incubator window is never visible).
+    @ObservationIgnored
+    var paneIsOccluded: (Pane) -> Bool = { pane in
+        !(pane.nsView?.window?.occlusionState.contains(.visible) ?? false)
+    }
+
+    /// Panes that were occluded on the previous poll tick, so the visible
+    /// transition can restart their quiet window before settling resumes.
+    @ObservationIgnored
+    private var previouslyOccludedPanes: Set<UUID> = []
+
     init(workspaceStore: WorkspaceStore = WorkspaceStore()) {
         self.workspaceStore = workspaceStore
         autoTileObserver = NotificationCenter.default.addObserver(
@@ -118,12 +133,14 @@ final class AppState {
         // this feature.
         let trackExecution = Preferences.shared.showTabStatusIndicator
         var didAcknowledgeCompletion = false
+        var seenPanes: Set<UUID> = []
         for (projectID, ws) in workspaces {
             for tab in ws.tabs {
                 for pane in tab.splitRoot.allPanes() {
+                    seenPanes.insert(pane.id)
                     pane.refreshForegroundProcess(trackExecution: trackExecution)
                     if trackExecution {
-                        pane.settleTerminalActivityIfQuiet()
+                        settleIfVisible(pane)
                     }
                     didAcknowledgeCompletion = acknowledgeFinishedCommandIfActive(
                         paneID: pane.id,
@@ -133,7 +150,24 @@ final class AppState {
                 }
             }
         }
+        previouslyOccludedPanes.formIntersection(seenPanes)
         if didAcknowledgeCompletion { saveWorkspaces() }
+    }
+
+    /// Quiet-settle only while the surface actually renders: an occluded pane
+    /// emits no activity heartbeats (its renderer is parked), so settling it
+    /// would misread suppressed output as completion. On the occluded→visible
+    /// edge the quiet window restarts, giving a still-running program time to
+    /// deliver heartbeats again before the settle can fire.
+    private func settleIfVisible(_ pane: Pane) {
+        if paneIsOccluded(pane) {
+            previouslyOccludedPanes.insert(pane.id)
+            return
+        }
+        if previouslyOccludedPanes.remove(pane.id) != nil {
+            pane.refreshTerminalActivityWindow()
+        }
+        pane.settleTerminalActivityIfQuiet()
     }
 
     private func recordProjectVisit(_ projectID: UUID) {

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -159,7 +159,11 @@ final class AppState {
     /// would misread suppressed output as completion. On the occluded→visible
     /// edge the quiet window restarts, giving a still-running program time to
     /// deliver heartbeats again before the settle can fire.
-    private func settleIfVisible(_ pane: Pane) {
+    ///
+    /// Not private so tests can drive the guard directly (`paneIsOccluded` is
+    /// injectable) without a live surface or mutating the `Preferences`
+    /// singleton the poll reads.
+    func settleIfVisible(_ pane: Pane) {
         if paneIsOccluded(pane) {
             previouslyOccludedPanes.insert(pane.id)
             return

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -166,6 +166,16 @@ struct TerminalExecutionTracker {
         return .done
     }
 
+    /// Restart the quiet window of an activity-sourced run. Used on the
+    /// occluded→visible edge: a parked renderer emits no heartbeats, so the
+    /// elapsed silence says nothing about completion — and a false `.done`
+    /// would stick, because activity can never revive `.done` (see
+    /// `markTerminalActivity`).
+    mutating func refreshActivityWindow(now: Date) {
+        guard case .activity = runningSource else { return }
+        runningSource = .activity(now)
+    }
+
     mutating func refreshForeground(
         name: String?,
         pid: pid_t?,
@@ -352,6 +362,10 @@ final class Pane: Identifiable {
             quietInterval: quietInterval,
             currentState: executionState
         )
+    }
+
+    func refreshTerminalActivityWindow(now: Date = Date()) {
+        executionTracker.refreshActivityWindow(now: now)
     }
 
     @discardableResult

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -652,4 +652,76 @@ struct AppStateTests {
         let ws = Workspace(projectID: pid, tabs: [tab], activeTabID: tab.id)
         #expect(AppState.panesToWarm(in: ws).isEmpty)
     }
+
+    // MARK: - Occlusion-aware quiet-settle
+
+    /// Seed a project whose single pane is running from terminal activity
+    /// that went quiet long ago (well past the 3s settle threshold).
+    private func seedQuietRunningPane(
+        _ state: AppState
+    ) throws -> Pane {
+        let p = seedProject(state)
+        let pane = try #require(state.workspaces[p.id]?.activeTab?.splitRoot.allPanes().first)
+        pane.recordUserInteraction()
+        pane.markTerminalActivity(at: Date().addingTimeInterval(-10))
+        #expect(pane.executionState == .running)
+        return pane
+    }
+
+    private func withStatusIndicator(_ body: () throws -> Void) rethrows {
+        let prior = Preferences.shared.showTabStatusIndicator
+        Preferences.shared.showTabStatusIndicator = true
+        defer { Preferences.shared.showTabStatusIndicator = prior }
+        try body()
+    }
+
+    @Test
+    func occluded_pane_does_not_quiet_settle() throws {
+        try withStatusIndicator {
+            let state = makeAppState()
+            let pane = try seedQuietRunningPane(state)
+            state.paneIsOccluded = { _ in true }
+
+            state.refreshAllForegroundProcesses()
+            // 10s of silence, but the renderer was parked — silence proves
+            // nothing, the pane must stay running.
+            #expect(pane.executionState == .running)
+        }
+    }
+
+    @Test
+    func visible_pane_still_quiet_settles() throws {
+        try withStatusIndicator {
+            let state = makeAppState()
+            let pane = try seedQuietRunningPane(state)
+            state.paneIsOccluded = { _ in false }
+
+            state.refreshAllForegroundProcesses()
+            #expect(pane.executionState == .done)
+        }
+    }
+
+    @Test
+    func deoccluded_pane_gets_fresh_quiet_window_before_settling() throws {
+        try withStatusIndicator {
+            let state = makeAppState()
+            let pane = try seedQuietRunningPane(state)
+
+            // Tick 1: occluded — no settle.
+            state.paneIsOccluded = { _ in true }
+            state.refreshAllForegroundProcesses()
+            #expect(pane.executionState == .running)
+
+            // Tick 2: now visible. The stale 10s-old activity timestamp must
+            // not settle it instantly — `.done` would stick, since activity
+            // can never revive a done pane. The window restarts instead.
+            state.paneIsOccluded = { _ in false }
+            state.refreshAllForegroundProcesses()
+            #expect(pane.executionState == .running)
+
+            // With heartbeats back and genuine quiet elapsing, it settles.
+            pane.settleTerminalActivityIfQuiet(now: Date().addingTimeInterval(4))
+            #expect(pane.executionState == .done)
+        }
+    }
 }

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -655,73 +655,65 @@ struct AppStateTests {
 
     // MARK: - Occlusion-aware quiet-settle
 
-    /// Seed a project whose single pane is running from terminal activity
-    /// that went quiet long ago (well past the 3s settle threshold).
-    private func seedQuietRunningPane(
-        _ state: AppState
-    ) throws -> Pane {
-        let p = seedProject(state)
-        let pane = try #require(state.workspaces[p.id]?.activeTab?.splitRoot.allPanes().first)
+    // These drive `AppState.settleIfVisible` directly with an injected
+    // occlusion closure, rather than the full `refreshAllForegroundProcesses`
+    // tick. The tick also re-reads each pane's real foreground process (nil in
+    // a unit test with no live surface, which clears the run source) and is
+    // gated on the `Preferences.shared.showTabStatusIndicator` singleton —
+    // mutating that global races the parallel test runner. Testing the guard
+    // in isolation is both deterministic and a truer unit of what PR adds.
+
+    /// A pane whose activity went quiet long ago (past the 3s settle window),
+    /// so a visible settle resolves it to `.done` and an occluded one holds.
+    private func quietRunningPane() -> Pane {
+        let pane = Pane(projectPath: "/tmp", projectID: UUID())
         pane.recordUserInteraction()
         pane.markTerminalActivity(at: Date().addingTimeInterval(-10))
         #expect(pane.executionState == .running)
         return pane
     }
 
-    private func withStatusIndicator(_ body: () throws -> Void) rethrows {
-        let prior = Preferences.shared.showTabStatusIndicator
-        Preferences.shared.showTabStatusIndicator = true
-        defer { Preferences.shared.showTabStatusIndicator = prior }
-        try body()
+    @Test
+    func occluded_pane_does_not_quiet_settle() {
+        let state = makeAppState()
+        let pane = quietRunningPane()
+        state.paneIsOccluded = { _ in true }
+
+        state.settleIfVisible(pane)
+        // 10s of silence, but the renderer was parked — silence proves
+        // nothing, so the pane must stay running.
+        #expect(pane.executionState == .running)
     }
 
     @Test
-    func occluded_pane_does_not_quiet_settle() throws {
-        try withStatusIndicator {
-            let state = makeAppState()
-            let pane = try seedQuietRunningPane(state)
-            state.paneIsOccluded = { _ in true }
+    func visible_pane_still_quiet_settles() {
+        let state = makeAppState()
+        let pane = quietRunningPane()
+        state.paneIsOccluded = { _ in false }
 
-            state.refreshAllForegroundProcesses()
-            // 10s of silence, but the renderer was parked — silence proves
-            // nothing, the pane must stay running.
-            #expect(pane.executionState == .running)
-        }
+        state.settleIfVisible(pane)
+        #expect(pane.executionState == .done)
     }
 
     @Test
-    func visible_pane_still_quiet_settles() throws {
-        try withStatusIndicator {
-            let state = makeAppState()
-            let pane = try seedQuietRunningPane(state)
-            state.paneIsOccluded = { _ in false }
+    func deoccluded_pane_gets_fresh_quiet_window_before_settling() {
+        let state = makeAppState()
+        let pane = quietRunningPane()
 
-            state.refreshAllForegroundProcesses()
-            #expect(pane.executionState == .done)
-        }
-    }
+        // Occluded: no settle, and the pane is marked as having been occluded.
+        state.paneIsOccluded = { _ in true }
+        state.settleIfVisible(pane)
+        #expect(pane.executionState == .running)
 
-    @Test
-    func deoccluded_pane_gets_fresh_quiet_window_before_settling() throws {
-        try withStatusIndicator {
-            let state = makeAppState()
-            let pane = try seedQuietRunningPane(state)
+        // Now visible. The stale 10s-old activity timestamp must not settle it
+        // instantly — a false `.done` would stick, since activity can never
+        // revive a done pane. The window restarts instead.
+        state.paneIsOccluded = { _ in false }
+        state.settleIfVisible(pane)
+        #expect(pane.executionState == .running)
 
-            // Tick 1: occluded — no settle.
-            state.paneIsOccluded = { _ in true }
-            state.refreshAllForegroundProcesses()
-            #expect(pane.executionState == .running)
-
-            // Tick 2: now visible. The stale 10s-old activity timestamp must
-            // not settle it instantly — `.done` would stick, since activity
-            // can never revive a done pane. The window restarts instead.
-            state.paneIsOccluded = { _ in false }
-            state.refreshAllForegroundProcesses()
-            #expect(pane.executionState == .running)
-
-            // With heartbeats back and genuine quiet elapsing, it settles.
-            pane.settleTerminalActivityIfQuiet(now: Date().addingTimeInterval(4))
-            #expect(pane.executionState == .done)
-        }
+        // With genuine quiet now elapsing from the reset window, it settles.
+        pane.settleTerminalActivityIfQuiet(now: Date().addingTimeInterval(4))
+        #expect(pane.executionState == .done)
     }
 }


### PR DESCRIPTION
## What

Quiet-settle (the status indicator's "running → done after 3s of silence" transition) now only runs for panes whose window is actually visible, with a fresh quiet window granted on the occluded→visible edge.

## Why

#115 parks the renderer of occluded surfaces, which suppresses the render/scrollbar heartbeats that keep an activity-sourced `.running` state alive. The settle logic read that suppressed silence as completion: run `btop` in a tab, switch away for 3 seconds, and the sidebar shows a done checkmark for a program that's still running. Worse, the checkmark sticks — `markTerminalActivity` deliberately never revives a `.done` pane (pinned by TerminalExecutionTrackerTests), so the false state survives until user interaction.

Follow-up identified during the #110/#111/#115 review cycle.

## How

- `AppState.refreshAllForegroundProcesses` consults an injectable `paneIsOccluded` closure (default: `pane.nsView?.window?.occlusionState`; no window counts as occluded, which covers incubator-hosted panes) and skips settle while occluded.
- On the occluded→visible transition, `TerminalExecutionTracker.refreshActivityWindow` restarts the quiet window — without this, the first visible tick would settle instantly off the stale timestamp and the false `.done` would stick.
- OSC-driven signals (133 command-finished, 9;4 progress) are termio-side and unaffected; they still finish hidden panes correctly.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Added tests: occluded pane doesn't settle; visible pane still settles; de-occluded pane gets a fresh quiet window instead of instantly settling

🤖 Generated with [Claude Code](https://claude.com/claude-code)