### PR TITLE
Tick libghostty on wakeup instead of a 120Hz timer

### DIFF
--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -62,9 +62,16 @@ final class GhosttyApp {
         app = createdApp
         config = cfg
 
-        let timer = Timer(timeInterval: 1.0 / 120.0, repeats: true) { [weak self] _ in
+        // Ticking is event-driven: libghostty's `wakeup_cb` fires whenever the
+        // core needs `ghostty_app_tick` (GhosttyCallbacks.wakeup schedules it
+        // on the main queue) — the same model as upstream Ghostty.app. A slow
+        // 1s timer remains as a safety net so a missed wakeup degrades to one
+        // extra tick per second instead of a wedged UI; it replaces a 120Hz
+        // timer that burned 120 wakeups/sec even while the app was hidden.
+        let timer = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated { self?.tick() }
         }
+        timer.tolerance = 0.5
         RunLoop.main.add(timer, forMode: .common)
         tickTimer = timer
 


### PR DESCRIPTION
## What

Replaces the unconditional 120Hz `ghostty_app_tick` timer with event-driven ticking via libghostty's `wakeup_cb` (already wired — `GhosttyCallbacks.wakeup` schedules `tick()` on the main queue), keeping a 1s safety-net timer so a missed wakeup degrades to a late tick rather than a wedged UI.

## Why

Profiling the post-#115/#123 idle residue showed the 120Hz timer is the largest remaining constant wakeup source — 120/sec even while hidden. Upstream libghostty's own contract is demand-driven: *"Tick the event loop. This should be called whenever the 'wakeup' callback is invoked for the runtime"* (src/apprt/embedded.zig). The fixed timer was never the intended mechanism; this makes Macterm follow the documented contract, the same way Ghostty.app does.

## Verified

Measured head-to-head, debug builds, idle:

| | main (120Hz timer) | this PR |
|---|---|---|
| idle CPU | ~1.1% | **~0.2%** |
| 120Hz timer in `sample` | present (`GhosttyApp.swift:66`, `ghostty_app_tick` firing) | **gone** — zero tick frames |

- [x] `mise run format`, `mise run lint`, `mise run test` all pass
- [x] Measured: the 120Hz wakeups are eliminated and idle CPU drops ~5×
- [x] Verified against upstream libghostty docs that `wakeup_cb` is the intended on-demand tick driver, and confirmed the `wakeup_cb → wakeup() → tick()` path is intact and unconditional

**Not yet observed live:** a keypress→echo confirmation in the running app (my verification build launched with no project selected, so there was no surface to type into). The CPU win is measured and the wakeup contract is upstream-documented, but the empirical input loop is best confirmed by running this branch alongside #126 as a daily driver — a wedged terminal would be immediately obvious. Recommend merging together after that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)