### PR TITLE
Isolate UserDefaults under test so runs can't corrupt the developer's app state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ One `XxxTests.swift` per production type, mirroring the source path. `@testable 
 
 - Shared helpers in `MactermTests/Support/`: `TreeBuilder` DSL (`H(pane("a"), V(pane("b"), pane("c")))` → tree + name map) and `TreeRenderer` (inverse, for readable assertions).
 - Tests needing `AppState`/`WorkspaceStore` inject a tempdir file — never touch `~/Library/Application Support/`.
+- Tests run hosted inside the debug app, so `UserDefaults.standard` there is the developer's real debug-app domain. `Preferences.defaults` detects a test run (XCTest env vars) and resolves to a wiped `.tests` side suite instead, and everything that persists defaults (`Preferences.shared`, project recency, hotkey overrides) goes through it — so writes, including indirect ones like `AppState.activeProjectID`'s write-through, never leak out of the run (`PreferencesTests` guards this). Never use `UserDefaults.standard` directly in app code.
 - UI (SwiftUI views, AppKit surfaces, libghostty bindings) is not unit-tested; coverage targets model + persistence + palette/hotkey logic and pure helpers.
 - `BundledResourcesTests` is an artifact check: it asserts `Macterm/Resources/` ships what libghostty needs (#39/#40 guard) and `#require`-skips on a fresh checkout before setup has run.
 

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -142,7 +142,7 @@ final class AppState {
         ) { [weak self] _ in
             MainActor.assumeIsolated { self?.rebalanceAllWorkspacesIfEnabled() }
         }
-        let restored = (UserDefaults.standard.stringArray(forKey: recencyKey) ?? [])
+        let restored = (Preferences.defaults.stringArray(forKey: recencyKey) ?? [])
             .compactMap { UUID(uuidString: $0) }
         projectRecency = RecencyStack<UUID>(limit: 50, items: restored)
 
@@ -266,7 +266,7 @@ final class AppState {
 
     private func recordProjectVisit(_ projectID: UUID) {
         projectRecency.push(projectID)
-        UserDefaults.standard.set(projectRecency.items.map(\.uuidString), forKey: recencyKey)
+        Preferences.defaults.set(projectRecency.items.map(\.uuidString), forKey: recencyKey)
     }
 
     /// Recently-visited projects, filtered to only those still present in the store.

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -289,7 +289,7 @@ enum HotkeyRegistry {
     }
 
     static func selectedShortcutString(for action: HotkeyAction) -> String {
-        UserDefaults.standard.string(forKey: action.defaultsKey) ?? action.defaultShortcut
+        Preferences.defaults.string(forKey: action.defaultsKey) ?? action.defaultShortcut
     }
 
     static func selectedShortcut(for action: HotkeyAction) -> HotkeyShortcut? {
@@ -297,7 +297,7 @@ enum HotkeyRegistry {
     }
 
     static func setShortcutString(_ shortcut: String, for action: HotkeyAction) {
-        UserDefaults.standard.set(shortcut, forKey: action.defaultsKey)
+        Preferences.defaults.set(shortcut, forKey: action.defaultsKey)
     }
 
     static func isValidShortcutString(_ shortcut: String) -> Bool {

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -43,7 +43,16 @@ enum WindowGlassStyle: String, CaseIterable, Identifiable {
 /// files Macterm generates around it.
 @MainActor @Observable
 final class Preferences {
-    static let shared = Preferences()
+    static let shared = Preferences(defaults: defaults)
+
+    /// The UserDefaults domain all Macterm state persists to — `.standard` in
+    /// the app, a wiped side suite under test (see `resolveDefaults()`). Use
+    /// this instead of `UserDefaults.standard` anywhere the app reads or
+    /// writes defaults directly (project recency, hotkey overrides), so those
+    /// writes get the same test isolation as `Preferences` properties.
+    /// `nonisolated(unsafe)` because the SDK doesn't mark `UserDefaults`
+    /// Sendable even though it's documented thread-safe.
+    nonisolated(unsafe) static let defaults: UserDefaults = resolveDefaults()
 
     // MARK: - Layout / appearance
 
@@ -241,9 +250,34 @@ final class Preferences {
 
     // MARK: - Init
 
+    /// The unit-test suite runs hosted inside the debug app, so
+    /// `UserDefaults.standard` there is the developer's real
+    /// `com.thdxg.macterm.debug` domain — a test mutating a preference (even
+    /// indirectly, e.g. `AppState.activeProjectID`'s write-through) would
+    /// corrupt the app they use day to day. Under a test run, back the app's
+    /// defaults with a wiped side suite instead so writes never leave the run.
+    nonisolated private static func resolveDefaults() -> UserDefaults {
+        guard isTestRun else { return .standard }
+        let suiteName = appBundleID + ".tests"
+        guard let suite = UserDefaults(suiteName: suiteName) else { return .standard }
+        // Wipe residue from previous runs so every test run starts clean.
+        suite.removePersistentDomain(forName: suiteName)
+        return suite
+    }
+
+    /// True when this process is an XCTest / Swift Testing host. Detected via
+    /// the runner's environment (`XCTestConfigurationFilePath`,
+    /// `XCTestSessionIdentifier`, … — the exact key varies by Xcode version)
+    /// rather than a loaded-class check: the test bundle injects only after app
+    /// launch, but the environment is set from process start, so this is
+    /// correct however early `shared` is first touched.
+    nonisolated private static var isTestRun: Bool {
+        ProcessInfo.processInfo.environment.keys.contains { $0.hasPrefix("XCTest") }
+    }
+
     private let defaults: UserDefaults
 
-    private init(defaults: UserDefaults = .standard) {
+    private init(defaults: UserDefaults) {
         self.defaults = defaults
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
         eagerlyStartProjectTabs = (defaults.object(forKey: Keys.eagerlyStartProjectTabs) as? Bool) ?? true

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -34,7 +34,7 @@ final class QuickTerminalService: NSObject {
         // which bypasses Preferences entirely. Reading defaults here keeps the
         // service in sync with whatever the toggle's current persisted value
         // actually is.
-        UserDefaults.standard.object(forKey: Preferences.Keys.quickTerminalEnabled) as? Bool ?? true
+        Preferences.defaults.object(forKey: Preferences.Keys.quickTerminalEnabled) as? Bool ?? true
     }
 
     override private init() {

--- a/MactermTests/App/PreferencesTests.swift
+++ b/MactermTests/App/PreferencesTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+/// Regression guard: the test suite runs hosted inside the debug app, so
+/// `UserDefaults.standard` here is the developer's real
+/// `com.thdxg.macterm.debug` domain. `Preferences.shared` must be backed by
+/// an ephemeral side suite under test — if it ever falls back to `.standard`,
+/// every test that touches a preference (even indirectly) would overwrite the
+/// developer's live app state.
+@MainActor
+struct PreferencesTests {
+    @Test
+    func shared_writes_do_not_reach_the_standard_defaults_domain() {
+        let sentinel = UUID()
+        let prior = Preferences.shared.activeProjectID
+        defer { Preferences.shared.activeProjectID = prior }
+
+        Preferences.shared.activeProjectID = sentinel
+
+        let standardValue = UserDefaults.standard.string(forKey: Preferences.Keys.activeProjectID)
+        #expect(standardValue != sentinel.uuidString)
+    }
+
+    /// The original leak: `AppState.selectProject` persists the active project
+    /// ID through `Preferences.shared` and pushes it onto the project-recency
+    /// list, so seeding a throwaway project in a test used to leave the
+    /// developer's app pointing at a dangling UUID ("No project selected" on
+    /// next launch) and flush their real recency stack with test UUIDs.
+    @Test
+    func selectProject_does_not_persist_to_the_standard_defaults_domain() {
+        let prior = Preferences.shared.activeProjectID
+        defer { Preferences.shared.activeProjectID = prior }
+
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-prefs-tests-\(UUID().uuidString).json")
+        let state = AppState(workspaceStore: WorkspaceStore(fileURL: tmp))
+        let project = Project(name: "throwaway", path: "/tmp", sortOrder: 0)
+        state.selectProject(project)
+
+        #expect(Preferences.shared.activeProjectID == project.id)
+        let standardValue = UserDefaults.standard.string(forKey: Preferences.Keys.activeProjectID)
+        #expect(standardValue != project.id.uuidString)
+        let standardRecency = UserDefaults.standard.stringArray(forKey: "macterm.projectRecency") ?? []
+        #expect(!standardRecency.contains(project.id.uuidString))
+    }
+}


### PR DESCRIPTION
## What

Back all UserDefaults persistence with a test-isolated domain: `Preferences.defaults` resolves to `.standard` in the app and to a wiped `com.thdxg.macterm.debug.tests` side suite under a test run. Adds `PreferencesTests` as a regression guard.

## Why

The unit-test suite runs hosted inside the debug app (`TEST_HOST`), so `UserDefaults.standard` in the test process **is** the developer's real `com.thdxg.macterm.debug` domain. Tests wrote through to it in two ways:

- `AppStateTests.seedProject()` → `selectProject` → `AppState.activeProjectID`'s didSet persisted a random test UUID as the active project — after every `mise run test` the debug app launched on "No project selected".
- The same path pushed throwaway UUIDs into `macterm.projectRecency` (capped at 50), flushing the developer's real recency stack each run. One run produces dozens of junk entries.

`Hotkeys` also read shortcut overrides from `.standard`, so a developer's custom keybinds could bleed into test behavior.

## How

- `Preferences.defaults` (new static) picks the domain once: a test run is detected via the XCTest runner's environment (any `XCTest*` key) rather than a loaded-class check — the env is set from process start, so detection is correct even if the singleton is touched before the test bundle injects into the hosted app. The side suite is wiped via `removePersistentDomain` at first touch so every run starts clean.
- Every direct `.standard` user now goes through it: `Preferences.shared`'s backing store, `AppState`'s project recency, `HotkeyRegistry`'s overrides, and `QuickTerminal`'s enabled-flag read (which deliberately reads the same key `Preferences` writes, so it must stay in the same domain). In the app all of these still resolve to the literal `.standard` object — zero behavior change at runtime, including for Settings' `@AppStorage` bindings.
- `nonisolated(unsafe)` on the static because the SDK doesn't mark `UserDefaults` Sendable, though it's documented thread-safe (`HotkeyRegistry` is a non-isolated enum).
- The new tests are self-verifying: if env-var detection ever breaks, the sentinel write lands in the standard domain and the tests fail loudly (and restore the prior value on the way out).

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

Also verified end-to-end after a full test run: the `.tests` suite plist holds the test residue (random `activeProjectID`, junk recency UUIDs) while the real debug domain's `macterm.activeProjectID` kept its stable value across two runs.

## Notes for reviewers

The save/restore dance around `Preferences.shared.activeProjectID` in `AppStateTests.layout_file_wins_over_restored_snapshot` is intentionally left — it's still useful intra-run hygiene between tests sharing the singleton, and is now harmless either way. AGENTS.md's tests section documents the mechanism and adds a "never use `UserDefaults.standard` directly" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)