### PR TITLE
Silence Swift 6 non-Sendable warnings on AppState's poll-event observers

### DIFF
--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -191,7 +191,7 @@ final class AppState {
         projectRecency = RecencyStack<UUID>(limit: 50, items: restored)
 
         let center = NotificationCenter.default
-        let onEvent: (Notification) -> Void = { [weak self] _ in
+        let onEvent: @Sendable (Notification) -> Void = { [weak self] _ in
             MainActor.assumeIsolated { self?.notePollEvent() }
         }
         pollEventObservers = [


### PR DESCRIPTION
## Why

The five `NotificationCenter.addObserver(forName:object:queue:using:)` registrations in `AppState.init` (`.terminalPollEvent`, app become/resign active, window occlusion, `NSWorkspace.didWakeNotification`) all pass the shared `onEvent` function value. Its declared type was a plain `(Notification) -> Void`, so converting it to the `@Sendable (Notification) -> Void` parameter produced a "may introduce data races" warning at each site under Swift 6.

## What

Annotate the one shared closure as `@Sendable`. Its body already hops onto the main actor via `MainActor.assumeIsolated` — the same pattern as the observers in `MactermApp.swift` — so the annotation is all that was missing. Delivery stays on `queue: .main`; no behavior change.

## Verification

- `mise run lint` and `mise run test` pass.
- Forced a recompile of `AppState.swift` under `xcodebuild`: zero `non-Sendable` / `may introduce data races` warnings in the log, `BUILD SUCCEEDED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)