### PR TITLE
Persist zmx sessions across quit and reattach on relaunch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,9 +135,9 @@ One `XxxTests.swift` per production type, mirroring the source path. `@testable 
 ### Persistence
 
 - Workspaces → `~/Library/Application Support/Macterm/workspaces_v3.json`; projects → `projects.json`; wrapper configs (`macterm-defaults.conf`, `macterm-overrides.conf`) in the same directory. The directory name comes from `appDisplayName` (`CFBundleDisplayName`), so debug builds use `Macterm Debug/` — fully separate data per build, mirroring the bundle-ID split.
-- `Pane` IDs are not preserved across restarts — restore creates fresh UUIDs.
+- `Pane` IDs are not preserved across restarts — restore creates fresh UUIDs. Session identity is separate: `Pane.sessionID`/`sessionName` persist in the snapshot (the name VERBATIM, never re-derived — its slug reflects the project at creation), so a restored pane reattaches its still-running zmx session.
 - Declarative layouts are an _authorable_ file at `.macterm/layout.yaml` in the project root, applied/saved on demand via `applyLayout`/`saveLayout`. An unparseable file surfaces `LayoutFileError` and is never applied. JSON schema at `assets/layout.schema.json` — keep it in sync when layout types change.
-  - A committed layout file is the source of truth: on relaunch, `restoreSelection` skips the workspace snapshot for any project that has one; a project's first open auto-applies it (with no live panes the reconcile is pure-spawn, never destructive).
+  - On relaunch the workspace snapshot always wins — it carries live session identity, and force-applying a committed layout would destroy reattachable shells. A committed layout file only seeds a genuine first open (no snapshot; pure-spawn, never destructive) via `autoApplyLayoutOnFirstOpen`.
   - `save` records a pane's `run:` as its **live** foreground command (`ghostty_surface_foreground_pid` → `ProcessInspector` argv via `KERN_PROCARGS2`) — an idle prompt saves no `run`. `shell:` is recorded only when the pane sits in a _non-default_ shell. `run` and `shell` are mutually exclusive on a leaf.
   - `apply` (`LayoutReconciler`) matches live panes to declared ones by that same live `(run, cwd)`; a pane that quit its declared command is respawned. A plain-shell leaf matches an idle pane positionally, but a declared `shell:` only reuses an idle pane running that shell (basename compare). The live-command/live-shell lookups are injected closures (default `ProcessInspector`), so the logic is unit-testable.
   - The file's top-level `name:` is the project it was saved for — a mismatch on apply stages a confirmation warning. Tab `name:` is the tab's title, matched to live tabs during reconcile.
@@ -167,7 +167,7 @@ Macterm-side settings flow through `Preferences` (UserDefaults); ghostty-shaped 
 
 ## Known Limitations
 
-- **No process persistence** — closing the app kills all shells (recommend tmux/zellij).
+- **Quick-terminal sessions are ephemeral** — they die on quit (workspace panes persist via zmx and reattach on relaunch; sessions don't survive reboot — the zmx daemon dies with the OS).
 - **Single window only** — multi-window would require a tmux-like daemon; out of scope.
 - **Not code-signed with a Developer ID** — first launch needs `xattr -cr /Applications/Macterm.app` (or Homebrew install); Sparkle updates verify EdDSA after that.
 - **Pane IDs not stable across restarts** — fresh views are created on restore.

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -380,14 +380,14 @@ final class AppState {
         hasRestoredSelection = true
         let snapshots = workspaceStore.load()
         let valid = Set(projects.map(\.id))
-        // A committed layout file is the source of truth: skip restoring the
-        // session snapshot for any project that has one, leaving its workspace
-        // nil so it rebuilds from `.macterm/layout.yaml` on open (below / on
-        // first select). Projects with no layout file restore their snapshot.
-        let pathByID = Dictionary(projects.map { ($0.id, $0.path) }, uniquingKeysWith: { a, _ in a })
-        for ws in WorkspaceSerializer.restore(from: snapshots, validIDs: valid)
-            where !LayoutFile.exists(atProjectRoot: pathByID[ws.projectID] ?? "")
-        {
+        // Restore every project's snapshot — including layout-file projects.
+        // The snapshot carries each pane's persisted zmx session identity, so
+        // panes REATTACH their still-running shells; force-applying the
+        // committed `.macterm/layout.yaml` here would silently destroy them
+        // on every launch. The layout now only seeds a genuine first open
+        // (no snapshot) — `autoApplyLayoutOnFirstOpen` guards on
+        // `workspaces[id] == nil`, so a restored snapshot disables it.
+        for ws in WorkspaceSerializer.restore(from: snapshots, validIDs: valid) {
             workspaces[ws.projectID] = ws
         }
         if let id = Preferences.shared.activeProjectID,
@@ -395,14 +395,21 @@ final class AppState {
         {
             activeProjectID = id
             recordProjectVisit(id)
-            // Build the active project from its layout file if it has one (its
-            // snapshot was skipped above); otherwise the restored snapshot stands
-            // and `ensureWorkspace` only creates a default when neither exists.
             autoApplyLayoutOnFirstOpen(project)
             ensureWorkspace(projectID: id, path: project.path)
             acknowledgeActiveTab(projectID: id)
             warmFocusedProject()
         }
+        // Sweep crash/force-quit orphans: kill zero-client macterm-* sessions
+        // no restored pane claims. Attach-aware and fail-closed (a failed
+        // probe reaps nothing); foreign prefixes (supa-*, user sessions) are
+        // spared. Quick-terminal sessions are never persisted, so leftovers
+        // from a crash die here too.
+        let known = Set(workspaces.values
+            .flatMap(\.tabs)
+            .flatMap { $0.splitRoot.allPanes() }
+            .map(\.sessionName))
+        Task { [zmx] in await zmx.reapOrphans(knownSessionNames: known) }
     }
 
     func saveWorkspaces() {
@@ -434,8 +441,22 @@ final class AppState {
               let projectID = activeProjectID,
               let ws = workspaces[projectID]
         else { return }
-        for pane in Self.panesToWarm(in: ws) {
-            SurfaceIncubator.shared.warm(pane)
+        // Stagger the spawns: each warm is a login shell (PAM, rc files) and —
+        // when restoring — a `zmx attach` reattaching a daemon. Firing them all
+        // in one tick multiplies launch pressure with tab count (cmux hit a
+        // relaunch memory/PAM storm doing exactly this). 125ms apart keeps
+        // relaunch smooth; `warm` is idempotent, so a pane the user views
+        // before its slot just spawns early via SwiftUI and the delayed warm
+        // no-ops.
+        for (index, pane) in Self.panesToWarm(in: ws).enumerated() {
+            if index == 0 {
+                SurfaceIncubator.shared.warm(pane)
+                continue
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.125 * Double(index)) { [weak pane] in
+                guard let pane else { return }
+                SurfaceIncubator.shared.warm(pane)
+            }
         }
     }
 
@@ -519,11 +540,9 @@ final class AppState {
         logger.debug("unloadProject: \(projectID, privacy: .public)")
         let snapshot = WorkspaceSerializer.snapshot([projectID: ws])
         for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {
-            // The snapshot round-trip below rebuilds panes with FRESH session
-            // ids (session identity isn't persisted yet), so the old sessions
-            // would orphan — kill them. Once snapshots carry the session name,
-            // unload becomes a true detach and this kill goes away.
-            pane.killPersistentSession(using: zmx)
+            // Detach, don't kill: the snapshot round-trip preserves each
+            // pane's session identity, so reopening the project reattaches
+            // the still-running shells.
             pane.destroySurface()
         }
         if let restored = WorkspaceSerializer.restore(from: snapshot, validIDs: [projectID]).first {

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -306,20 +306,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_: Notification) {
         onTerminate?()
-        // Interim (until snapshots carry session identity and quit becomes a
-        // detach): quitting kills every pane's zmx session, blocking briefly so
-        // the kills land before the process exits — a detached Task would never
-        // be scheduled during teardown. Sessions can't be reattached next
-        // launch yet, so leaving them running would only orphan daemons.
-        var names = (appState?.workspaces.values ?? [:].values)
-            .flatMap(\.tabs)
-            .flatMap { $0.splitRoot.allPanes() }
-            .map(\.sessionName)
-        names += QuickTerminalService.shared.splitState.tab.splitRoot.allPanes().map(\.sessionName)
+        // Quit is a DETACH by default: workspace panes' sessions survive and
+        // reattach on relaunch (the snapshot saved by onTerminate carries each
+        // pane's session identity). Quick-terminal sessions are ephemeral —
+        // never persisted — so they're always killed; leaving them would only
+        // feed the next launch's reaper. The terminate-on-quit setting opts
+        // into killing everything. Kills block briefly so they land before
+        // the process exits (a detached Task is never scheduled during
+        // teardown), bounded by ZmxClient's timeouts.
+        var names = QuickTerminalService.shared.splitState.tab.splitRoot.allPanes().map(\.sessionName)
+        if Preferences.shared.terminateSessionsOnQuit {
+            names += (appState?.workspaces.values ?? [:].values)
+                .flatMap(\.tabs)
+                .flatMap { $0.splitRoot.allPanes() }
+                .map(\.sessionName)
+        }
         (appState?.zmx ?? .live).killSessionsBlocking(names)
     }
 
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+        // Silent quit when persistence is active: workspace sessions detach
+        // and reattach next launch, so there's nothing to confirm for them.
+        // The full prompt returns when the user opted into terminate-on-quit,
+        // or when zmx is unavailable (sessions genuinely die with the app).
+        // Quick-terminal sessions are ephemeral and die on every quit, so a
+        // busy quick-terminal pane still confirms even on a silent quit —
+        // the confirmation follows the destruction.
+        let persistenceActive = (appState?.zmx ?? .live).isBundled()
+            && !Preferences.shared.terminateSessionsOnQuit
+        if persistenceActive {
+            let qtRows = collectQuickTerminalRows()
+            if qtRows.isEmpty || QuitConfirmation.runModal(rows: qtRows) {
+                AppTerminationState.isTerminating = true
+                return .terminateNow
+            }
+            return .terminateCancel
+        }
+
         let rows = collectRunningProcessRows()
         if rows.isEmpty {
             AppTerminationState.isTerminating = true
@@ -358,6 +381,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        rows += collectQuickTerminalRows()
+        return rows
+    }
+
+    /// Quick-terminal panes with a running foreground process. Split out
+    /// because a silent (persistence-active) quit still confirms these: the
+    /// quick terminal's sessions are ephemeral and die on every quit.
+    private func collectQuickTerminalRows() -> [RunningProcessRow] {
+        var rows: [RunningProcessRow] = []
         let qtTab = QuickTerminalService.shared.splitState.tab
         for pane in qtTab.splitRoot.allPanes() where pane.nsView?.needsConfirmQuit() == true {
             pane.refreshForegroundProcess(trackExecution: false)
@@ -366,7 +398,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 processName: pane.processTitle
             ))
         }
-
         return rows
     }
 

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -96,6 +96,15 @@ final class Preferences {
         didSet { defaults.set(showNewProjectButton, forKey: Keys.showNewProjectButton) }
     }
 
+    /// When true, quitting Macterm kills every pane's zmx session so nothing
+    /// keeps running in the background. Default off — session persistence
+    /// (shells survive quit and reattach on relaunch) is the point, so quit
+    /// detaches rather than terminates. Macterm-side only; never touches the
+    /// ghostty config pipeline.
+    var terminateSessionsOnQuit: Bool {
+        didSet { defaults.set(terminateSessionsOnQuit, forKey: Keys.terminateSessionsOnQuit) }
+    }
+
     // MARK: - Toolbar
 
     var tabSwitcherVisibility: TabSwitcherVisibility {
@@ -296,6 +305,7 @@ final class Preferences {
         tabIconSymbol = defaults.string(forKey: Keys.tabIconSymbol) ?? "terminal"
         showTabStatusIndicator = defaults.object(forKey: Keys.showTabStatusIndicator) as? Bool ?? false
         showNewProjectButton = defaults.object(forKey: Keys.showNewProjectButton) as? Bool ?? true
+        terminateSessionsOnQuit = defaults.object(forKey: Keys.terminateSessionsOnQuit) as? Bool ?? false
         tabSwitcherVisibility = (defaults.string(forKey: Keys.tabSwitcherVisibility))
             .flatMap(TabSwitcherVisibility.init(rawValue:)) ?? .whenMultiple
         Self.runOneTimeMigrations(defaults: defaults)
@@ -345,6 +355,7 @@ final class Preferences {
         static let tabIconSymbol = "macterm.sidebar.tabIcon"
         static let showTabStatusIndicator = "macterm.sidebar.showTabStatusIndicator"
         static let showNewProjectButton = "macterm.sidebar.showNewProjectButton"
+        static let terminateSessionsOnQuit = "macterm.session.terminateOnQuit"
         static let tabSwitcherVisibility = "macterm.toolbar.tabSwitcherVisibility"
         static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"
     }

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -443,8 +443,13 @@ final class Pane: Identifiable {
     /// foreground pid when that process is a non-shell program, nil otherwise.
     func receiveReportedTitle(_ title: String, programPID: pid_t?) {
         // A title arrival is a command boundary — wake the adaptive poll so
-        // the other panes' names catch up too.
-        NotificationCenter.default.post(name: .terminalPollEvent, object: nil)
+        // the other panes' names catch up too. Deferred: this path also runs
+        // from the `onTitleChange` replay inside `TerminalSurface.configure`,
+        // i.e. mid view-update — posting (and polling) synchronously there
+        // re-invalidates SwiftUI from within its own render transaction.
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .terminalPollEvent, object: nil)
+        }
         refreshForegroundProcess()
         guard let programPID else { return }
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -573,6 +573,7 @@ final class Pane: Identifiable {
         projectID: UUID,
         sessionID: UUID = UUID(),
         sessionSlug: String? = nil,
+        sessionName persistedSessionName: String? = nil,
         command: String? = nil,
         shell: String? = nil,
         env: [String: String]? = nil
@@ -580,9 +581,20 @@ final class Pane: Identifiable {
         self.projectPath = projectPath
         self.projectID = projectID
         self.sessionID = sessionID
-        let slug = sessionSlug ?? (projectPath as NSString).lastPathComponent
-        self.sessionSlug = slug
-        sessionName = ZmxSessionName.make(projectName: slug, paneSessionID: sessionID)
+        if let persistedSessionName {
+            // Restore path: the snapshot's name is authoritative and used
+            // VERBATIM — the slug inside it reflects the project at creation,
+            // and re-deriving after a project rename would target a session
+            // that doesn't exist. The slug is recovered only so a split off
+            // this pane groups with it.
+            sessionName = persistedSessionName
+            self.sessionSlug = ZmxSessionName.slug(fromName: persistedSessionName)
+                ?? (projectPath as NSString).lastPathComponent
+        } else {
+            let slug = sessionSlug ?? (projectPath as NSString).lastPathComponent
+            self.sessionSlug = slug
+            sessionName = ZmxSessionName.make(projectName: slug, paneSessionID: sessionID)
+        }
         self.command = command
         self.shell = shell
         self.env = env

--- a/Macterm/Persistence/WorkspacePersistence.swift
+++ b/Macterm/Persistence/WorkspacePersistence.swift
@@ -70,9 +70,40 @@ struct PaneSnapshot: Codable {
     /// outlive the shell process, and `.idle` is the default. Optional so older
     /// snapshots (without the field) decode as nil / idle.
     var needsAttention: Bool?
+    /// Stable zmx session id (`Pane.sessionID`). On restore the rebuilt pane
+    /// reuses it, so its shell reattaches to the still-running daemon instead
+    /// of spawning fresh. Optional: older snapshots decode nil → fresh id.
+    var sessionID: UUID?
+    /// The pane's zmx session name, persisted VERBATIM — never re-derived. The
+    /// name embeds the project slug at creation time, so re-deriving it after
+    /// a project rename would target a session that doesn't exist.
+    var sessionName: String?
+    /// The pane's live working directory at snapshot time, so a session that
+    /// did NOT survive (reboot, external kill) respawns where the user was.
+    /// A surviving session reattaches with its own live cwd regardless.
+    var workingDirectory: String?
     // No `title`: the tab name is derived live from the pane's foreground
     // process, so there's nothing per-pane to persist. (An older snapshot's
     // `title` key is harmlessly ignored on decode.)
+
+    /// Memberwise init with defaults for the optional fields, so call sites
+    /// and tests that build old-shape snapshots keep compiling. (SwiftLint
+    /// forbids `= nil` on the stored declarations.)
+    init(
+        id: UUID,
+        projectPath: String,
+        needsAttention: Bool? = nil,
+        sessionID: UUID? = nil,
+        sessionName: String? = nil,
+        workingDirectory: String? = nil
+    ) {
+        self.id = id
+        self.projectPath = projectPath
+        self.needsAttention = needsAttention
+        self.sessionID = sessionID
+        self.sessionName = sessionName
+        self.workingDirectory = workingDirectory
+    }
 }
 
 struct SplitBranchSnapshot: Codable {
@@ -204,14 +235,20 @@ enum WorkspaceSerializer {
         case let .pane(p):
             // Prefer the shell's live cwd over the pane's original project
             // path so reopening the app lands each pane back in the directory
-            // the user had navigated to. Falls back to projectPath when the
-            // surface hasn't reported a pwd yet.
-            let path = p.nsView?.currentPwd ?? p.projectPath
+            // the user had navigated to: OSC 7 (`currentPwd`) first, then the
+            // foreground process's kernel cwd (works without shell
+            // integration), finally projectPath.
+            let path = p.nsView?.currentPwd
+                ?? ProcessInspector.foregroundWorkingDirectory(forPane: p)
+                ?? p.projectPath
             let needsAttention = p.executionState == .done
             return .pane(PaneSnapshot(
                 id: p.id,
                 projectPath: path,
-                needsAttention: needsAttention
+                needsAttention: needsAttention,
+                sessionID: p.sessionID,
+                sessionName: p.sessionName,
+                workingDirectory: path
             ))
         case let .split(b):
             return .split(SplitBranchSnapshot(
@@ -226,7 +263,18 @@ enum WorkspaceSerializer {
     private static func restoreNode(_ snap: SplitNodeSnapshot, projectID: UUID) -> SplitNode {
         switch snap {
         case let .pane(p):
-            let pane = Pane(projectPath: p.projectPath, projectID: projectID)
+            // Reuse the persisted session identity so the restored pane
+            // reattaches to its still-running zmx daemon: `zmx attach` is an
+            // upsert, so a session that died while the app was closed just
+            // becomes a fresh shell in the saved working directory — no
+            // staleness handling needed. Old snapshots (nil identity) get a
+            // fresh session.
+            let pane = Pane(
+                projectPath: p.workingDirectory ?? p.projectPath,
+                projectID: projectID,
+                sessionID: p.sessionID ?? UUID(),
+                sessionName: p.sessionName
+            )
             if p.needsAttention == true {
                 pane.restoreNeedsAttention()
             }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -30,6 +30,8 @@ private struct GeneralSettings: View {
 
     @AppStorage(Preferences.Keys.eagerlyStartProjectTabs)
     private var eagerlyStartProjectTabs = true
+    @AppStorage(Preferences.Keys.terminateSessionsOnQuit)
+    private var terminateSessionsOnQuit = false
     @State
     private var terminalScrollSpeed: Double = Preferences.shared.terminalScrollSpeed
     @State
@@ -100,6 +102,19 @@ private struct GeneralSettings: View {
                 Text("Runs every tab's processes when a project opens, not just the active tab. Other projects still load when focused.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
+            }
+
+            Section("Session Persistence") {
+                Toggle("Quit terminals when Macterm quits", isOn: $terminateSessionsOnQuit)
+                    .onChange(of: terminateSessionsOnQuit) { _, v in
+                        Preferences.shared.terminateSessionsOnQuit = v
+                    }
+                Text(
+                    "Off (default): shells keep running in the background after you quit and reattach on next launch. "
+                        + "On: quitting stops every terminal's processes."
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/Macterm/System/ZmxClient.swift
+++ b/Macterm/System/ZmxClient.swift
@@ -314,6 +314,22 @@ enum ZmxSessionName {
     static var maxByteCount: Int {
         prefix.utf8.count + maxSlugLength + 1 + shortHexLength
     }
+
+    /// Recover the slug from a persisted `macterm-<slug>-<hex12>` name, or nil
+    /// when the name doesn't match our construction (foreign/corrupt). Used on
+    /// restore so a split off a restored pane groups under the same project.
+    static func slug(fromName name: String) -> String? {
+        guard name.hasPrefix(prefix) else { return nil }
+        let body = name.dropFirst(prefix.count)
+        guard let dash = body.lastIndex(of: "-") else { return nil }
+        let slugPart = body[..<dash]
+        let hexPart = body[body.index(after: dash)...]
+        guard !slugPart.isEmpty,
+              hexPart.count == shortHexLength,
+              hexPart.allSatisfy(\.isHexDigit)
+        else { return nil }
+        return String(slugPart)
+    }
 }
 
 /// Pure parser for zmx's full (`ls`, non-`--short`) tab-delimited listing.

--- a/Macterm/System/ZmxForegroundResolver.swift
+++ b/Macterm/System/ZmxForegroundResolver.swift
@@ -26,14 +26,28 @@ private let logger = Logger(subsystem: appBundleID, category: "ZmxForeground")
 /// a slow reconcile. `ZmxRefreshGate` owns that policy; per-tick work here is
 /// two cheap syscalls (`kill(pid, 0)` liveness + `tcgetpgrp`).
 enum ZmxForegroundResolver {
-    /// Cached `macterm-…` name → daemon session-leader pid. Guarded by an
-    /// unfair lock; written by the off-main refresh, read on the main actor.
-    private static let cache = OSAllocatedUnfairLock<[String: pid_t]>(initialState: [:])
+    struct Entry {
+        let leaderPID: pid_t
+        /// The daemon-side pty path, resolved ONCE per refresh: `devname` falls
+        /// back to a full /dev scan (readdir + lstat per node) whenever the
+        /// dev_t misses its static cache, which pty slaves reliably do. Doing
+        /// that per foreground refresh on the main thread saturated the render
+        /// loop (observed: app wedged at ~90% CPU inside devname_r). A
+        /// session's leader keeps its tty for life, so resolve off-main here
+        /// and never again.
+        let ttyPath: String?
+    }
 
-    /// Replace the cached session→leader-pid map from a fresh `zmx ls`.
+    /// Cached `macterm-…` name → daemon leader (pid + tty). Guarded by an
+    /// unfair lock; written by the off-main refresh, read on the main actor.
+    private static let cache = OSAllocatedUnfairLock<[String: Entry]>(initialState: [:])
+
+    /// Replace the cache from a fresh `zmx ls`. Called OFF-MAIN: the per-pid
+    /// tty resolution below is the expensive devname path.
     static func updateCache(_ map: [String: pid_t]) {
-        cache.withLock { $0 = map }
-        logger.debug("updateCache: \(map.count, privacy: .public) session(s)")
+        let entries = map.mapValues { Entry(leaderPID: $0, ttyPath: ttyPath(pid: $0)) }
+        cache.withLock { $0 = entries }
+        logger.debug("updateCache: \(entries.count, privacy: .public) session(s)")
     }
 
     /// The pid of the real foreground process for `sessionName`, or nil when
@@ -49,7 +63,7 @@ enum ZmxForegroundResolver {
     /// and `proc_pidinfo` can't be used either — the leader is root's
     /// `/usr/bin/login`, unreadable across uids. The sysctl works for both.
     static func foregroundPID(sessionName: String) -> pid_t? {
-        guard let leaderPID = cache.withLock({ $0[sessionName] }) else { return nil }
+        guard let leaderPID = cache.withLock({ $0[sessionName]?.leaderPID }) else { return nil }
         guard let info = kinfoProc(pid: leaderPID) else {
             cache.withLock { $0[sessionName] = nil }
             logger.debug("resolver: leader \(leaderPID, privacy: .public) gone, evicted")
@@ -68,8 +82,7 @@ enum ZmxForegroundResolver {
     /// the daemon's pty, because the `zmx attach` client keeps the client-side
     /// pty raw permanently.
     static func daemonTTYPath(sessionName: String) -> String? {
-        guard let leaderPID = cache.withLock({ $0[sessionName] }) else { return nil }
-        return ttyPath(pid: leaderPID)
+        cache.withLock { $0[sessionName]?.ttyPath }
     }
 
     /// The kinfo_proc for `pid` via `sysctl(KERN_PROC_PID)`, or nil when the

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -527,9 +527,14 @@ struct AppStateTests {
     }
 
     @Test
-    func layout_file_wins_over_restored_snapshot() throws {
+    func reopen_restores_snapshot_silently_and_ignores_layout() throws {
+        // Reopen is always silent: a restored session snapshot wins (a layout
+        // project's panes must reattach their live zmx sessions, and its live
+        // layout is remembered), and the committed layout is NOT applied and
+        // NOT prompted for — even when it differs. The layout only seeds a
+        // genuine first open (no snapshot), covered by the next test.
         let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("macterm-layoutwins-\(UUID().uuidString)")
+            .appendingPathComponent("macterm-reopen-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let project = Project(name: "winner", path: dir.path, sortOrder: 0)
@@ -540,7 +545,7 @@ struct AppStateTests {
         let snapshotWS = Workspace(projectID: project.id, projectPath: dir.path)
         store.save(WorkspaceSerializer.snapshot([project.id: snapshotWS]))
 
-        // And a layout file declaring a two-pane split.
+        // And a layout file declaring a different (two-pane) split.
         writeLayout("""
         tabs:
           - name: "Dev"
@@ -550,13 +555,44 @@ struct AppStateTests {
               second: {}
         """, at: dir.path)
 
-        // Make it the active project so restore reopens it.
         let priorActive = Preferences.shared.activeProjectID
         Preferences.shared.activeProjectID = project.id
         defer { Preferences.shared.activeProjectID = priorActive }
 
-        // Restore: the layout file must win — the project's snapshot is skipped
-        // and its workspace is rebuilt from the layout (two panes, not one).
+        let state = makeAppState(store: store)
+        state.restoreSelection(projects: [project])
+
+        // Restored snapshot wins: one pane, layout NOT applied, NO prompt.
+        let ws = try #require(state.workspaces[project.id])
+        #expect(ws.tabs[0].splitRoot.allPanes().count == 1)
+        #expect(ws.tabs[0].customTitle != "Dev")
+        #expect(state.pendingLayoutApply == nil)
+    }
+
+    @Test
+    func layout_auto_applies_on_genuine_first_open_without_snapshot() throws {
+        // No snapshot at all → the layout still seeds the workspace on first
+        // open (pure-spawn, no prompt). The only auto-apply path left.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-firstopen-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let project = Project(name: "fresh", path: dir.path, sortOrder: 0)
+        let store = WorkspaceStore(fileURL: dir.appendingPathComponent("workspaces.json"))
+
+        writeLayout("""
+        tabs:
+          - name: "Dev"
+            split:
+              direction: horizontal
+              first:  { run: "npm run dev" }
+              second: {}
+        """, at: dir.path)
+
+        let priorActive = Preferences.shared.activeProjectID
+        Preferences.shared.activeProjectID = project.id
+        defer { Preferences.shared.activeProjectID = priorActive }
+
         let state = makeAppState(store: store)
         state.restoreSelection(projects: [project])
 
@@ -564,6 +600,7 @@ struct AppStateTests {
         #expect(ws.tabs.count == 1)
         #expect(ws.tabs[0].customTitle == "Dev")
         #expect(ws.tabs[0].splitRoot.allPanes().count == 2)
+        #expect(state.pendingLayoutApply == nil)
     }
 
     @Test

--- a/MactermTests/Persistence/WorkspaceSerializerTests.swift
+++ b/MactermTests/Persistence/WorkspaceSerializerTests.swift
@@ -241,3 +241,80 @@ struct WorkspaceSerializerTests {
         #expect(store.load().isEmpty)
     }
 }
+
+@MainActor
+struct WorkspaceSerializerSessionIdentityTests {
+    @Test
+    func round_trips_session_identity_and_working_directory() throws {
+        let projectID = UUID()
+        let pane = Pane(projectPath: "/tmp/proj", projectID: projectID)
+        let tab = TerminalTab(id: UUID(), splitRoot: .pane(pane), focusedPaneID: pane.id)
+        let ws = Workspace(projectID: projectID, tabs: [tab], activeTabID: tab.id)
+
+        let snapshots = WorkspaceSerializer.snapshot([projectID: ws])
+        let restored = try #require(
+            WorkspaceSerializer.restore(from: snapshots, validIDs: [projectID]).first
+        )
+        let restoredPane = try #require(restored.tabs.first?.splitRoot.allPanes().first)
+
+        // Session identity survives verbatim; the runtime pane id does not.
+        #expect(restoredPane.sessionID == pane.sessionID)
+        #expect(restoredPane.sessionName == pane.sessionName)
+        #expect(restoredPane.id != pane.id)
+        // With no live surface the cwd falls back to the project path.
+        #expect(restoredPane.projectPath == "/tmp/proj")
+    }
+
+    @Test
+    func old_snapshot_without_identity_gets_a_fresh_session() throws {
+        let projectID = UUID()
+        let snap = WorkspaceSnapshot(
+            projectID: projectID,
+            activeTabID: nil,
+            tabs: [TabSnapshot(
+                id: UUID(),
+                customTitle: nil,
+                focusedPaneID: nil,
+                splitRoot: .pane(PaneSnapshot(id: UUID(), projectPath: "/tmp/old"))
+            )]
+        )
+        let restored = try #require(
+            WorkspaceSerializer.restore(from: [snap], validIDs: [projectID]).first
+        )
+        let pane = try #require(restored.tabs.first?.splitRoot.allPanes().first)
+        #expect(pane.sessionName.hasPrefix(ZmxSessionName.prefix))
+        #expect(pane.projectPath == "/tmp/old")
+    }
+
+    @Test
+    func restored_pane_uses_persisted_name_over_rederivation() throws {
+        // The persisted name's slug reflects the project AT CREATION — a
+        // rename must not re-derive it, or reattach targets a dead session.
+        let projectID = UUID()
+        let sessionID = UUID()
+        let snap = WorkspaceSnapshot(
+            projectID: projectID,
+            activeTabID: nil,
+            tabs: [TabSnapshot(
+                id: UUID(),
+                customTitle: nil,
+                focusedPaneID: nil,
+                splitRoot: .pane(PaneSnapshot(
+                    id: UUID(),
+                    projectPath: "/tmp/renamed-project",
+                    sessionID: sessionID,
+                    sessionName: "macterm-oldname-aaaaaaaabbbb",
+                    workingDirectory: "/tmp/renamed-project/src"
+                ))
+            )]
+        )
+        let restored = try #require(
+            WorkspaceSerializer.restore(from: [snap], validIDs: [projectID]).first
+        )
+        let pane = try #require(restored.tabs.first?.splitRoot.allPanes().first)
+        #expect(pane.sessionName == "macterm-oldname-aaaaaaaabbbb")
+        #expect(pane.sessionID == sessionID)
+        #expect(pane.sessionSlug == "oldname")
+        #expect(pane.projectPath == "/tmp/renamed-project/src")
+    }
+}

--- a/MactermTests/System/ZmxClientTests.swift
+++ b/MactermTests/System/ZmxClientTests.swift
@@ -118,6 +118,22 @@ struct ZmxSessionNameTests {
         let b = ZmxSessionName.make(projectName: "proj", paneSessionID: UUID())
         #expect(a != b)
     }
+
+    @Test
+    func slug_round_trips_through_a_made_name() {
+        let name = ZmxSessionName.make(projectName: "My Cool App!", paneSessionID: id)
+        #expect(ZmxSessionName.slug(fromName: name) == "mycoolapp")
+    }
+
+    @Test
+    func slug_recovery_rejects_foreign_or_corrupt_names() {
+        #expect(ZmxSessionName.slug(fromName: "supa-abcdef123456") == nil)
+        #expect(ZmxSessionName.slug(fromName: "macterm-nohex") == nil)
+        #expect(ZmxSessionName.slug(fromName: "macterm--aaaaaaaabbbb") == nil)
+        // Slugs may themselves contain hex-looking segments; only a trailing
+        // 12-hex-digit component counts as the id.
+        #expect(ZmxSessionName.slug(fromName: "macterm-abc-def-aaaaaaaabbbb") == "abc-def")
+    }
 }
 
 struct ZmxReaperTests {


### PR DESCRIPTION
## What

The payoff PR of the persistence stack (#124 → #127 → this): **closing Macterm no longer kills your shells.** Quit detaches silently (no dialog); relaunch reattaches every pane to its still-running zmx daemon with scrollback and processes intact. Closes the headline gap in #103.

## How

- **Snapshot carries session identity**: `PaneSnapshot.sessionID` + `sessionName` (persisted **verbatim** — the name's slug reflects the project at creation; re-deriving after a rename would strand the session) + live `workingDirectory`. `zmx attach` is an upsert, so a session that died while the app was closed (reboot, external kill) silently respawns fresh in the saved cwd — no staleness branch needed.
- **Snapshot now beats the layout file on relaunch** (precedence flip + updated CLAUDE.md): force-applying a committed `.macterm/layout.yaml` would destroy reattachable shells on every launch. The layout only seeds a genuine first open — pinned by reworked AppStateTests.
- **Launch reaper**: kills zero-client `macterm-*` sessions no restored pane claims. Fail-closed (failed probe reaps nothing), attach-aware (`clients>0` spared), foreign prefixes (`supa-*`) spared. Collects crash leftovers and quick-terminal sessions.
- **Quick terminal stays ephemeral**: killed on every quit; a busy quick-terminal pane still prompts on quit — its destruction is real, so the confirmation follows it.
- **`unloadProject` becomes a true detach** (identity survives the snapshot round-trip).
- **Paced reattach**: warm spawns staggered 125ms apart — mass simultaneous reattach multiplies login/PAM pressure with tab count (cmux hit exactly this in production, manaflow-ai/cmux#5731).
- **Settings → Session Persistence**: terminate-on-quit toggle (default off) restores the old kill-everything + prompt behavior.

Design informed by the Supacode/cmux research (see the session-persistence prior-art notes): upsert-reattach with no staleness handling, fail-closed reaping, verbatim-name persistence, and spawn pacing are all patterns those apps converged on with real users.

## Verified

- [x] `mise run format` / `lint` / `test` green — new: serializer round-trip of session identity (+ old-snapshot back-compat, rename-safety), `slug(fromName:)` recovery, reworked restore-precedence tests
- [x] **Live end-to-end**: session `macterm-macterm-83b25adc7c79` created (clients=1) → ⌘Q exits with **no prompt** → daemon survives (clients=0) → relaunch → **same session** reattaches (clients=1, exactly one session; reaper spared it, no duplicate spawn)

## Deferred (follow-up PR)

Unexpected-client-exit recovery (zmx client hiccup ≠ shell exit: probe `zmx ls`, reattach in place if the session is alive) — Supacode's `pendingExplicitSurfaceCloseIDs` pattern. Kept out to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)