### PR TITLE
Spell out the noise floors in the benchmark footnote

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -385,13 +385,17 @@ def cmd_report(args):
             for e in entries
         ]
 
+    floors = ", ".join(
+        f"{label.replace(' (powermetrics)', '')} ≥{floor:g}"
+        for _, label, _, floor in METRICS
+    )
     lines += [
         "",
         f"_{current['seconds_per_state']}s sampling window per state; CPU % is the "
         "process CPU-time delta over the window. Runs land on different shared "
         f"runners, so treat small deltas as noise — 🔺/🔻 marks changes ≥{THRESHOLD_PCT}% "
-        "that also clear the metric's absolute noise floor, and those add the "
-        "`benchmark:regression` / `benchmark:improvement` label._",
+        f"that also clear the metric's absolute noise floor ({floors}), and those "
+        "add the `benchmark:regression` / `benchmark:improvement` label._",
     ]
     if baseline is None:
         lines.append("")


### PR DESCRIPTION
A +30% delta with no 🔺 reads as a bug when the footnote only alludes to "the metric's absolute noise floor" without stating it. The footnote now enumerates the floors (CPU % ≥0.5, RSS ≥25 MB, CPU ms/s ≥5, wakeups/s ≥50), generated from `METRICS` so it can't drift from the actual thresholds.