### PR TITLE
Break the title-replay render loop for good

### DIFF
--- a/Macterm/System/ProcessInspector.swift
+++ b/Macterm/System/ProcessInspector.swift
@@ -150,6 +150,14 @@ enum ProcessInspector {
         // keystrokes), which would misread every wrapped pane as a raw-mode
         // TUI and break the status indicator's canonical-command detection.
         let daemonTTY = ZmxForegroundResolver.daemonTTYPath(sessionName: pane.sessionName)
+        if daemonTTY == nil, pane.nsView?.isZmxWrapped == true {
+            // A wrapped pane whose daemon tty isn't cached yet must NOT fall
+            // back to the client-side tty: the zmx attach client keeps that
+            // pty permanently raw, so the answer would flap raw/canonical
+            // across cache refreshes — each flip republishes execution state
+            // and re-renders, which is one edge of the frozen-render loop.
+            return false
+        }
         return terminalInputIsRaw(ttyPath: daemonTTY ?? pane.nsView?.ttyName)
     }
 

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -50,7 +50,14 @@ final class GhosttyTerminalNSView: NSView {
     /// boundary that drives a foreground-process refresh.
     var onTitleChange: ((String) -> Void)? {
         didSet {
-            if let title = lastReportedTitle { onTitleChange?(title) }
+            // Replay ASYNC: this setter runs inside TerminalSurface.configure,
+            // i.e. mid SwiftUI view update. A synchronous replay runs a full
+            // foreground refresh whose republishing re-invalidates SwiftUI
+            // from inside its own render transaction — with per-refresh state
+            // flaps that loop never settles (observed twice as a ~90%-CPU
+            // frozen app). Deferring one runloop turn breaks the cycle.
+            guard let title = lastReportedTitle, let callback = onTitleChange else { return }
+            DispatchQueue.main.async { callback(title) }
         }
     }
 


### PR DESCRIPTION
## What

Follow-up to the #131 freeze fix — a second live install wedged at ~91% CPU with the same render-loop stack (sampled live; this build already had the devname fix, proving the loop itself survived).

## Root cause, fully this time

`TerminalSurface.configure` re-sets `onTitleChange` on every `updateNSView`; its `didSet` replayed the last title **synchronously**, running a full foreground refresh inside SwiftUI's render transaction. For zmx-wrapped panes the raw-mode probe **flaps**: on a daemon-tty cache miss it fell back to the client pty — which the `zmx attach` client keeps permanently raw — so execution state ping-ponged canonical↔raw across cache refreshes, each flip republishing and re-invalidating the view graph. Refresh → flap → render → replay → refresh, forever.

## Fix (two independent cuts)

1. **Replay is deferred one runloop turn** — nothing reachable from `configure` may mutate observable state mid-render. This kills the cycle regardless of any future flap source.
2. **The flap source is closed** — a wrapped pane with no cached daemon tty reads as canonical (`false`) instead of probing the always-raw client pty.

## Verified

- [x] `mise run format` / `lint` / `test` green
- [ ] Needs the real test this class of bug demands: **extended daily use**. Two of these escaped short verification runs; please reinstall from this branch and drive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)