### PR TITLE
Make Unload Project stop the project's shells again (keeping layout)

### DIFF
--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -104,7 +104,7 @@ extension AppCommand {
             }
         case .unloadProject:
             guard let projectID, ctx.appState.isProjectLoaded(projectID) else { return nil }
-            return { ctx.appState.unloadProject(projectID) }
+            return { ctx.appState.requestUnloadProject(projectID) }
         case .removeProject:
             guard let projectID else { return nil }
             return {

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -540,9 +540,13 @@ final class AppState {
         logger.debug("unloadProject: \(projectID, privacy: .public)")
         let snapshot = WorkspaceSerializer.snapshot([projectID: ws])
         for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {
-            // Detach, don't kill: the snapshot round-trip preserves each
-            // pane's session identity, so reopening the project reattaches
-            // the still-running shells.
+            // Unload KILLS: with quit now a detach, this is the one action
+            // that stops a whole project's shells while keeping its layout
+            // (the group-kill #113 asked for). A detaching unload would be
+            // a trap — "unloaded" shells silently running forever. The
+            // snapshot keeps the layout; reopening spawns fresh shells in
+            // the saved cwds (`zmx attach` upserts over the dead names).
+            pane.killPersistentSession(using: zmx)
             pane.destroySurface()
         }
         if let restored = WorkspaceSerializer.restore(from: snapshot, validIDs: [projectID]).first {
@@ -564,6 +568,37 @@ final class AppState {
         workspaces.removeValue(forKey: projectID)
         if activeProjectID == projectID { activeProjectID = nil }
         saveWorkspaces()
+    }
+
+    /// An unload staged for confirmation because one of the project's panes
+    /// has a running foreground program — unload now stops every shell in
+    /// the project (keeping the layout), so it's destructive.
+    struct PendingUnloadProject: Equatable {
+        let projectID: UUID
+    }
+
+    var pendingUnloadProject: PendingUnloadProject?
+
+    /// Unload a project, confirming first when any pane is busy.
+    func requestUnloadProject(_ projectID: UUID) {
+        let busy = workspaces[projectID]?.tabs
+            .flatMap { $0.splitRoot.allPanes() }
+            .contains { $0.nsView?.needsConfirmQuit() == true } ?? false
+        if busy {
+            pendingUnloadProject = PendingUnloadProject(projectID: projectID)
+            return
+        }
+        unloadProject(projectID)
+    }
+
+    func confirmPendingUnloadProject() {
+        guard let pending = pendingUnloadProject else { return }
+        pendingUnloadProject = nil
+        unloadProject(pending.projectID)
+    }
+
+    func cancelPendingUnloadProject() {
+        pendingUnloadProject = nil
     }
 
     /// Run `removal` (the caller's full remove: workspace + project store)

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -50,6 +50,22 @@ struct MactermApp: App {
                     Text("A process is still running in this tab. Closing the tab ends it.")
                 }
                 .alert(
+                    "Unload project with running processes?",
+                    isPresented: Binding(
+                        get: { appState.pendingUnloadProject != nil },
+                        set: { if !$0 { appState.cancelPendingUnloadProject() } }
+                    )
+                ) {
+                    Button("Cancel", role: .cancel) {
+                        appState.cancelPendingUnloadProject()
+                    }
+                    Button("Unload", role: .destructive) {
+                        appState.confirmPendingUnloadProject()
+                    }
+                } message: {
+                    Text("A process is still running in this project. Unloading stops every process in its tabs; the layout is kept.")
+                }
+                .alert(
                     "Remove project with running processes?",
                     isPresented: Binding(
                         get: { appState.pendingRemoveProject != nil },

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -57,7 +57,7 @@ struct SidebarContent: View {
                     } onRename: {
                         projectStore.rename(id: project.id, to: $0)
                     } onUnload: {
-                        appState.unloadProject(project.id)
+                        appState.requestUnloadProject(project.id)
                     } onRemove: {
                         appState.requestRemoveProject(project.id) {
                             expandedProjects.remove(project.id)

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -804,6 +804,31 @@ struct AppStateTests {
     }
 
     @Test
+    func unloadProject_kills_every_session_but_keeps_layout() async throws {
+        let killed = KilledSessions()
+        let state = makeAppState()
+        state.zmx = recordingZmx(into: killed)
+        let p = seedProject(state)
+        state.splitPane(direction: .horizontal, projectID: p.id)
+        let names = try Set(
+            #require(state.workspaces[p.id]).tabs
+                .flatMap { $0.splitRoot.allPanes() }
+                .map(\.sessionName)
+        )
+        #expect(names.count == 2)
+
+        state.unloadProject(p.id)
+
+        await killed.settle()
+        // Sessions die (unload = stop the project's shells)…
+        #expect(await killed.names == names)
+        // …but the layout survives for the next open.
+        let ws = try #require(state.workspaces[p.id])
+        #expect(ws.tabs.count == 1)
+        #expect(ws.tabs[0].splitRoot.allPanes().count == 2)
+    }
+
+    @Test
     func moveTab_kills_nothing() async throws {
         let killed = KilledSessions()
         let state = makeAppState()


### PR DESCRIPTION
## What

Restores teeth to **Unload Project**: it kills every pane's zmx session (keeping the tab/split layout), with the same busy-confirmation as tab close / project removal. Reopening the project spawns fresh shells in the saved layout and cwds.

## Why

After #131 made quit a detach, unload's detach semantics became both a **trap** (a user picking Unload to "stop this project's stuff" silently left shells running forever) and **pointless** (occlusion parking already made unfocused surfaces free — detach-unload's only effect was freeing app-side buffers the zmx daemon duplicates anyway). Meanwhile the post-persistence action taxonomy had a hole: no way to stop one project's shells without closing tabs one-by-one (losing layout) or removing the project. This is also the per-project group-kill #113 asked for, complementing the `macterm-<project>-` prefix naming.

New taxonomy: **quit** = detach all · **close pane/tab** = kill that one · **unload project** = kill the project's shells, keep layout · **remove project** = kill + forget.

## Verified

- [x] `mise run format` / `lint` / `test` green — new test: unload kills exactly the project's session names via a recording client while the workspace/layout survives
- [x] Both callers (sidebar context menu, command palette) routed through the busy-confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)