### PR TITLE
Fix arrow-key shortcuts never matching live keypresses

### DIFF
--- a/Macterm/App/AppCommandMenu.swift
+++ b/Macterm/App/AppCommandMenu.swift
@@ -80,6 +80,10 @@ private func swiftUIShortcut(for command: AppCommand) -> (key: KeyEquivalent, mo
     case "space": .space
     case "escape": .escape
     case "delete": .delete
+    case "left": .leftArrow
+    case "right": .rightArrow
+    case "up": .upArrow
+    case "down": .downArrow
     default:
         keyToken.count == 1 ? KeyEquivalent(Character(keyToken)) : nil
     }

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -92,11 +92,17 @@ struct HotkeyShortcut: Identifiable {
         guard let token = HotkeyRegistry.eventToken(event),
               token == keyToken
         else { return false }
-        return event.modifierFlags.intersection(.deviceIndependentFlagsMask) == modifiers
+        return event.modifierFlags.intersection(HotkeyRegistry.comparableModifierMask) == modifiers
     }
 }
 
 enum HotkeyRegistry {
+    /// Modifier bits Macterm's shortcut grammar models. Real arrow/function-key
+    /// NSEvents also carry `.numericPad`/`.function` in `.deviceIndependentFlagsMask`,
+    /// which parsed shortcuts never include — so matching against the full mask
+    /// makes every arrow-key binding fail to match its own live event.
+    static let comparableModifierMask: NSEvent.ModifierFlags = [.command, .control, .shift, .option]
+
     private static let keyCodes: [String: UInt16] = [
         "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5,
         "z": 6, "x": 7, "c": 8, "v": 9, "b": 11,
@@ -222,7 +228,7 @@ enum HotkeyRegistry {
     }
 
     static func shortcutString(from event: NSEvent) -> String? {
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let flags = event.modifierFlags.intersection(comparableModifierMask)
         if modifierOnlyCodes.contains(event.keyCode) { return nil }
 
         var parts: [String] = []

--- a/MactermTests/App/HotkeysTests.swift
+++ b/MactermTests/App/HotkeysTests.swift
@@ -404,6 +404,29 @@ struct HotkeysTests {
         #expect(HotkeyRegistry.displayString(for: "cmd+down") == "⌘↓")
     }
 
+    /// Real hardware arrow-key NSEvents carry `.numericPad`/`.function` in
+    /// `modifierFlags` — unlike the synthetic events above, which only set the
+    /// modifiers passed in. Matching must ignore those bits (#106) or every
+    /// arrow-key binding fails against a live keypress despite passing the
+    /// hand-rolled synthetic-event tests.
+    @Test
+    func matches_arrow_key_with_real_hardware_modifier_flags() throws {
+        let shortcut = try #require(HotkeyRegistry.parseShortcut("cmd+opt+right"))
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option, .numericPad, .function],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 124 // right arrow
+        ))
+        #expect(shortcut.matches(event))
+    }
+
     // MARK: - Escape key support
 
     @Test


### PR DESCRIPTION
Fixes #106.

## The bug

Shortcuts bound to arrow keys in Settings > Keymaps (e.g. `⌘⌥→` for Next Tab) display correctly but never fire when pressed. This affects every arrow-key binding regardless of modifiers, and applies to both Macterm-level and Ghostty-config-level bindings (both funnel through `HotkeyShortcut.matches`).

## Root cause

Real hardware arrow (and function/numeric-keypad) `NSEvent`s always carry `.numericPad` **and** `.function` in their `modifierFlags`, and both bits live inside `.deviceIndependentFlagsMask`. `HotkeyShortcut.matches` compared the event's masked flags against the parsed shortcut's `modifiers` with a strict `==`:

```swift
event.modifierFlags.intersection(.deviceIndependentFlagsMask) == modifiers
```

But `parseShortcut` only ever populates `{command, control, shift, option}`. So an arrow binding's stored modifiers (`{command, option}`) could never equal the live event's masked flags (`{command, option, numericPad, function}`), and the match failed on every keypress.

Capture (`shortcutString(from:)`) strips those extra bits before serializing — which is exactly why Settings > Keymaps displayed the binding correctly while it silently never worked.

The existing arrow-key unit tests passed only because their *synthetic* `NSEvent`s (built via `NSEvent.keyEvent(with:…)`) don't set `.numericPad`/`.function` the way real hardware events do — a test-fidelity gap that masked the bug.

## Fix

- **`Hotkeys.swift`** — added `HotkeyRegistry.comparableModifierMask` (`{command, control, shift, option}`, the only modifier bits Macterm's shortcut grammar models) and used it in both `matches` and `shortcutString(from:)`, so matching ignores the keypad/function bits.
- **`AppCommandMenu.swift`** — mapped `left`/`right`/`up`/`down` tokens to SwiftUI's `.leftArrow`/`.rightArrow`/`.upArrow`/`.downArrow` in `swiftUIShortcut`. This is a separate, cosmetic bug: arrow-bound menu items previously got no `.keyboardShortcut` modifier and didn't show their accelerator in the menu bar (it did *not* contribute to the reported failure, since KeyRouter's local monitor is independent of NSMenu key equivalents — fixed here for completeness).
- **`HotkeysTests.swift`** — regression test that constructs an arrow-key event with realistic hardware flags (`.numericPad`/`.function` OR'd in) and asserts it matches; this fails pre-fix.

## Verification

Full test suite passes (all 38 suites); `swiftformat` and `swiftlint` clean.

Note: I couldn't inject a real keypress into a running GUI app from CI, so live keyboard verification wasn't possible — the fix rests on the confirmed flag-comparison mechanism plus a regression test reproducing the real event shape.