### PR TITLE
Add a control socket and bundled macterm CLI (read-only verbs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,18 @@ A tab's auto-title is, by default, the pane's live **foreground process name** (
 - `Macterm/System/ProcessInspector.swift` — resolves a pane's foreground pid three ways: `runningCommand` (full argv via `KERN_PROCARGS2` → layout `run:`), `runningShell` (non-default shell's `exec_path` → layout `shell:`), `runningProcessName` (kernel `comm` → tab name).
 - `Macterm/Config/` — `MactermConfig` (wrapper ghostty config files), `ShellIntegrationFeatures` (override merger, #75).
 - `Macterm/Settings/SettingsView.swift` — preferences window.
+- `Macterm/Control/` — control-socket plumbing for the bundled `macterm` CLI: `ControlProtocol` (wire types, shared source with the CLI target), `ControlSocketServer`, `ControlHandler`.
+- `CLI/` — the `MactermCLI` target (`macterm` binary): ArgumentParser command tree, `ControlClient` (socket discovery + one-shot request), `Output` (human/`--json` renderers).
+
+### Control CLI (`macterm`)
+
+A bundled CLI (issue #107) controls the running app over a Unix socket at `<App Support>/control.sock` (per build flavor; `MACTERM_BENCHMARK_DATA_DIR` relocates it with the rest of app data). Built as the `MactermCLI` tool target — `PRODUCT_NAME` is `macterm` but `PRODUCT_MODULE_NAME` must stay `MactermCLI` (a `macterm` module would collide case-insensitively with the app's `Macterm.swiftmodule` in the shared products dir). A post-build script copies it to `Contents/Resources/bin/macterm`; the app prepends that dir to `PATH` and exports `MACTERM_SOCKET` before any shell spawns, so `macterm` works inside every pane.
+
+- **Wire protocol** (`ControlProtocol.swift`, compiled into both targets so the codec can't drift): one request per connection; newline-terminated JSON both ways; client half-closes after sending. Requests are `{v, id, command, args}` with `command` namespaced `noun.verb` (`pane.list`); responses echo `id` with `{ok, data}` or `{ok:false, error:{code, message, action?}}` — `action` is a human recovery hint. Errors use snake_case codes (`not_found`, `busy`, `no_surface`, `starting`…).
+- **Server** (`ControlSocketServer`): dedicated thread polling a non-blocking listen fd (20ms) — never a blocking `accept()` on a queue shared with `stop()`, which would starve shutdown. Per-connection dispatch hops to `@MainActor`. Starts in `applicationDidFinishLaunching` (skipped under xctest); the handler attaches later in `installResponders` when AppState exists — early requests get a `starting` error. `FD_CLOEXEC` on the listen fd so spawned shells can't hold the socket past quit.
+- **Handler** (`ControlHandler`): translate-and-delegate only — resolves selectors (name/UUID/1-based index for projects and tabs; conflicts and dupes are typed `ambiguous` errors) and calls the same `AppState`/`ProjectStore`/`ZmxClient` methods the UI uses. Reads zmx through `appState.zmx` so tests stub one seam.
+- **CLI client**: discovery order `--socket` (hard pin) → `MACTERM_SOCKET` (hint only — falls through to the well-known release/debug paths when stale, avoiding cmux's pinned-env trap) → per-flavor App Support paths. Refuses sockets not owned by the current user; non-blocking connect with a 250ms poll so a dead socket never hangs. Safe-fail contract: stdout only on success; exit 0 ok / 1 app error / 2 unreachable.
+- Security posture: same-user only, enforced by filesystem permissions (0600 socket, 0700 dir) — the same boundary zmx itself uses. No token auth by design; the request envelope leaves room for an `auth` field if that ever changes.
 
 ### Ghostty Config Pipeline
 

--- a/CLI/ControlClient.swift
+++ b/CLI/ControlClient.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// CLI-side of the control socket: discovery, connection, one
+/// request/response round-trip. Synchronous by design — the CLI has nothing
+/// else to do while it waits.
+struct ControlClient {
+    /// Explicit `--socket` value: a hard pin, tried alone.
+    var socketOverride: String?
+
+    struct ClientError: Error, CustomStringConvertible {
+        var description: String
+        /// True when no socket answered at all (app not running) — exit 2.
+        var isConnectionFailure: Bool
+    }
+
+    /// Send one request and return the decoded response.
+    func send(command: String, args: ControlArgs? = nil) throws -> ControlResponse {
+        let request = ControlRequest(command: command, args: args)
+        let payload = try ControlProtocol.encode(request)
+
+        var attempts: [String] = []
+        for path in candidatePaths() {
+            switch tryPath(path, payload: payload) {
+            case let .success(raw):
+                let response: ControlResponse
+                do {
+                    response = try ControlProtocol.decodeResponse(raw)
+                } catch {
+                    throw ClientError(
+                        description: "undecodable response from \(path): \(error.localizedDescription)",
+                        isConnectionFailure: false
+                    )
+                }
+                guard response.id == request.id else {
+                    throw ClientError(
+                        description: "response id mismatch from \(path)",
+                        isConnectionFailure: false
+                    )
+                }
+                return response
+            case let .failure(reason):
+                attempts.append("  \(path): \(reason)")
+            }
+        }
+        let hint = socketOverride == nil
+            ? "\nIs Macterm running? (launch it, or pass --socket for a non-default location)"
+            : ""
+        throw ClientError(
+            description: "could not reach Macterm's control socket:\n" + attempts.joined(separator: "\n") + hint,
+            isConnectionFailure: true
+        )
+    }
+
+    /// Discovery order: explicit `--socket` is a hard pin (tried alone);
+    /// otherwise the `MACTERM_SOCKET` env hint first — but only as a *hint*:
+    /// a stale exported path (app restarted since this shell spawned) falls
+    /// through to the well-known per-flavor locations instead of bricking
+    /// the CLI in that shell (cmux's documented sleep/wake trap).
+    func candidatePaths(environment: [String: String] = ProcessInfo.processInfo.environment) -> [String] {
+        if let override = socketOverride, !override.isEmpty {
+            return [override]
+        }
+        var paths: [String] = []
+        if let hinted = environment[ControlProtocol.socketEnvVar], !hinted.isEmpty {
+            paths.append(hinted)
+        }
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first ?? URL(fileURLWithPath: NSHomeDirectory() + "/Library/Application Support")
+        for flavor in ["Macterm", "Macterm Debug"] {
+            paths.append(
+                appSupport
+                    .appendingPathComponent(flavor, isDirectory: true)
+                    .appendingPathComponent(ControlProtocol.socketFilename)
+                    .path
+            )
+        }
+        var seen = Set<String>()
+        return paths.filter { seen.insert($0).inserted }
+    }
+
+    // MARK: - One connection attempt
+
+    private enum Attempt {
+        case success(Data)
+        case failure(String)
+    }
+
+    private func tryPath(_ path: String, payload: Data) -> Attempt {
+        var st = stat()
+        guard stat(path, &st) == 0 else {
+            return .failure("no socket file")
+        }
+        // Refuse sockets owned by another user — a planted socket at a
+        // predictable path must not receive our commands.
+        guard st.st_uid == getuid() else {
+            return .failure("not owned by the current user; refusing to connect")
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            return .failure("socket(): \(String(cString: strerror(errno)))")
+        }
+        defer { close(fd) }
+        var one: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = path.utf8CString
+        let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+        guard pathBytes.count <= maxLen else {
+            return .failure("path exceeds sun_path limit")
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { dst in
+            dst.withMemoryRebound(to: CChar.self, capacity: maxLen) { dstPtr in
+                pathBytes.withUnsafeBufferPointer { src in
+                    guard let srcBase = src.baseAddress else { return }
+                    dstPtr.update(from: srcBase, count: src.count)
+                }
+            }
+        }
+
+        // Non-blocking connect + short poll: a dead socket file (app crashed,
+        // listener gone) fails in ~250ms instead of hanging the CLI.
+        let flags = fcntl(fd, F_GETFL, 0)
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if connectResult != 0 {
+            guard errno == EINPROGRESS else {
+                return .failure(String(cString: strerror(errno)))
+            }
+            var pollFD = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+            guard poll(&pollFD, 1, 250) > 0, pollFD.revents & Int16(POLLERR | POLLHUP) == 0 else {
+                return .failure("connect timed out")
+            }
+            var soError: Int32 = 0
+            var len = socklen_t(MemoryLayout<Int32>.size)
+            getsockopt(fd, SOL_SOCKET, SO_ERROR, &soError, &len)
+            guard soError == 0 else {
+                return .failure(String(cString: strerror(soError)))
+            }
+        }
+        // Back to blocking for the write/read; bound the read instead.
+        _ = fcntl(fd, F_SETFL, flags)
+        var timeout = timeval(tv_sec: 10, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        guard writeAll(fd: fd, data: payload) else {
+            return .failure("write failed: \(String(cString: strerror(errno)))")
+        }
+        // Half-close: tells the server the request is complete.
+        shutdown(fd, SHUT_WR)
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 16384)
+        while true {
+            let n = read(fd, &buffer, buffer.count)
+            if n > 0 {
+                data.append(contentsOf: buffer[0 ..< n])
+            } else if n == 0 {
+                break
+            } else {
+                if errno == EINTR { continue }
+                if errno == EAGAIN || errno == EWOULDBLOCK {
+                    return .failure("timed out waiting for a response")
+                }
+                return .failure("read failed: \(String(cString: strerror(errno)))")
+            }
+        }
+        guard !data.isEmpty else {
+            return .failure("connection closed without a response")
+        }
+        return .success(data)
+    }
+
+    private func writeAll(fd: Int32, data: Data) -> Bool {
+        data.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return false }
+            var offset = 0
+            while offset < data.count {
+                let n = write(fd, base + offset, data.count - offset)
+                if n > 0 {
+                    offset += n
+                } else {
+                    if errno == EINTR { continue }
+                    return false
+                }
+            }
+            return true
+        }
+    }
+}

--- a/CLI/MactermCommand.swift
+++ b/CLI/MactermCommand.swift
@@ -1,0 +1,160 @@
+import ArgumentParser
+import Foundation
+
+/// `macterm` — control a running Macterm app from the shell.
+///
+/// Talks to the app over its Unix control socket (see `ControlProtocol`).
+/// Exit codes: 0 success, 1 the app returned an error, 2 the app couldn't
+/// be reached. stdout carries only successful output.
+@main
+struct MactermCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "macterm",
+        abstract: "Control a running Macterm: projects, tabs, panes, zmx sessions.",
+        subcommands: [Status.self, ProjectCommand.self, TabCommand.self, PaneCommand.self, SessionCommand.self]
+    )
+}
+
+/// Options every subcommand shares.
+struct ConnectionOptions: ParsableArguments {
+    @Option(help: "Control socket path (overrides discovery).")
+    var socket: String?
+
+    @Flag(help: "Print the raw JSON payload instead of a table.")
+    var json = false
+}
+
+/// Send a request, apply the safe-fail contract, render the result.
+func runControlCommand(command: String, args: ControlArgs? = nil, options: ConnectionOptions) throws {
+    let client = ControlClient(socketOverride: options.socket)
+    let response: ControlResponse
+    do {
+        response = try client.send(command: command, args: args)
+    } catch let error as ControlClient.ClientError {
+        Output.printError(error.description)
+        throw ExitCode(error.isConnectionFailure ? 2 : 1)
+    }
+    if response.ok {
+        try Output.render(response.data, asJSON: options.json)
+        return
+    }
+    let error = response.error ?? ControlError(code: .internalError, message: "unknown error")
+    Output.printError(error.message, action: error.action)
+    throw ExitCode(1)
+}
+
+// MARK: - Subcommands
+
+struct Status: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Show whether Macterm is running and which project is active."
+    )
+
+    @OptionGroup var options: ConnectionOptions
+
+    func run() throws {
+        try runControlCommand(command: "status", options: options)
+    }
+}
+
+struct ProjectCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "project",
+        abstract: "List and inspect projects.",
+        subcommands: [List.self],
+        defaultSubcommand: List.self
+    )
+
+    struct List: ParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "List all projects.")
+
+        @OptionGroup var options: ConnectionOptions
+
+        func run() throws {
+            try runControlCommand(command: "project.list", options: options)
+        }
+    }
+}
+
+struct TabCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "tab",
+        abstract: "List and inspect tabs.",
+        subcommands: [List.self],
+        defaultSubcommand: List.self
+    )
+
+    struct List: ParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "List tabs (active project by default).")
+
+        @Option(help: "Project to list (name, UUID, or index). Defaults to the active project.")
+        var project: String?
+
+        @OptionGroup var options: ConnectionOptions
+
+        func run() throws {
+            try runControlCommand(command: "tab.list", args: ControlArgs(project: project), options: options)
+        }
+    }
+}
+
+struct PaneCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "pane",
+        abstract: "List and inspect panes.",
+        subcommands: [List.self],
+        defaultSubcommand: List.self
+    )
+
+    struct List: ParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "List panes (active project by default).")
+
+        @Option(help: "Project to list (name, UUID, or index). Defaults to the active project.")
+        var project: String?
+
+        @Option(help: "Restrict to one tab (title, UUID, or index).")
+        var tab: String?
+
+        @OptionGroup var options: ConnectionOptions
+
+        func run() throws {
+            try runControlCommand(
+                command: "pane.list",
+                args: ControlArgs(project: project, tab: tab),
+                options: options
+            )
+        }
+    }
+}
+
+struct SessionCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "session",
+        abstract: "Inspect zmx-backed terminal sessions.",
+        subcommands: [List.self, Info.self],
+        defaultSubcommand: List.self
+    )
+
+    struct List: ParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "List live zmx sessions.")
+
+        @OptionGroup var options: ConnectionOptions
+
+        func run() throws {
+            try runControlCommand(command: "session.list", options: options)
+        }
+    }
+
+    struct Info: ParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "Show one zmx session.")
+
+        @Argument(help: "Session name (macterm-<slug>-<hex>).")
+        var name: String
+
+        @OptionGroup var options: ConnectionOptions
+
+        func run() throws {
+            try runControlCommand(command: "session.info", args: ControlArgs(session: name), options: options)
+        }
+    }
+}

--- a/CLI/Output.swift
+++ b/CLI/Output.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Human and JSON renderers for control responses. The safe-fail contract:
+/// stdout carries ONLY successful command output; every diagnostic goes to
+/// stderr so scripted callers can trust what they capture.
+enum Output {
+    /// Render a successful response: `--json` prints the raw `data` payload;
+    /// otherwise the human formatter for the fields present.
+    static func render(_ data: ControlData?, asJSON: Bool) throws {
+        if asJSON {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let payload = try encoder.encode(data ?? ControlData())
+            print(String(decoding: payload, as: UTF8.self))
+            return
+        }
+        guard let data else { return }
+        if let status = data.status { renderStatus(status) }
+        if let projects = data.projects { renderProjects(projects) }
+        if let tabs = data.tabs { renderTabs(tabs) }
+        if let panes = data.panes { renderPanes(panes) }
+        if let sessions = data.sessions { renderSessions(sessions) }
+    }
+
+    private static func renderStatus(_ status: ControlStatusInfo) {
+        var line = "Macterm \(status.version) (pid \(status.pid))"
+        if let project = status.activeProject {
+            line += " — active project: \(project)"
+        }
+        print(line)
+    }
+
+    private static func renderProjects(_ projects: [ControlProjectInfo]) {
+        let rows = projects.enumerated().map { index, project -> [String] in
+            let tabs = project.tabCount.map { "\($0) tab\($0 == 1 ? "" : "s")" } ?? "—"
+            return [
+                "project:\(index + 1)",
+                project.active ? "*" : " ",
+                project.name,
+                project.loaded ? tabs : "not loaded",
+                project.path,
+            ]
+        }
+        printColumns(rows)
+    }
+
+    private static func renderTabs(_ tabs: [ControlTabInfo]) {
+        let rows = tabs.map { tab -> [String] in
+            [
+                "tab:\(tab.index)",
+                tab.active ? "*" : " ",
+                tab.title,
+                "\(tab.paneCount) pane\(tab.paneCount == 1 ? "" : "s")",
+            ]
+        }
+        printColumns(rows)
+    }
+
+    private static func renderPanes(_ panes: [ControlPaneInfo]) {
+        let rows = panes.map { pane -> [String] in
+            [
+                "tab:\(pane.tabIndex)",
+                "pane:\(pane.index)",
+                pane.focused ? "*" : " ",
+                pane.session,
+                pane.process ?? "-",
+                pane.cwd ?? "-",
+            ]
+        }
+        printColumns(rows)
+    }
+
+    private static func renderSessions(_ sessions: [ControlSessionInfo]) {
+        let rows = sessions.map { session -> [String] in
+            let clients = session.clients.map(String.init) ?? "?"
+            return [
+                session.name,
+                "clients:\(clients)",
+                session.leaderPID.map { "pid:\($0)" } ?? "pid:-",
+                session.paneID != nil ? "attached-pane" : "orphan",
+            ]
+        }
+        printColumns(rows)
+    }
+
+    /// Left-align columns to the widest cell in each.
+    private static func printColumns(_ rows: [[String]]) {
+        guard !rows.isEmpty else { return }
+        let columnCount = rows.map(\.count).max() ?? 0
+        var widths = [Int](repeating: 0, count: columnCount)
+        for row in rows {
+            for (i, cell) in row.enumerated() {
+                widths[i] = max(widths[i], cell.count)
+            }
+        }
+        for row in rows {
+            let line = row.enumerated()
+                .map { i, cell in i == row.count - 1 ? cell : cell.padding(toLength: widths[i], withPad: " ", startingAt: 0) }
+                .joined(separator: "  ")
+            print(line)
+        }
+    }
+
+    /// Print an error to stderr, with its recovery hint when present.
+    static func printError(_ message: String, action: String? = nil) {
+        FileHandle.standardError.write(Data("macterm: \(message)\n".utf8))
+        if let action {
+            FileHandle.standardError.write(Data("  hint: \(action)\n".utf8))
+        }
+    }
+}

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -242,6 +242,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var appFocusObservers: [Any] = []
     private var mainAppResponder: MainAppResponder?
     private var hasInstalledResponders = false
+    private var controlServer: ControlSocketServer?
+    private var controlHandler: ControlHandler?
 
     func applicationDidFinishLaunching(_: Notification) {
         // Skip the heavy launch path when the app is hosting unit tests.
@@ -255,6 +257,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Before anything can spawn a surface: a launcher terminal's zmx
         // session marker must not leak into our panes (see ZmxEnvironment).
         ZmxEnvironment.scrubInheritedSession()
+        // Control socket for the bundled `macterm` CLI. Started before any
+        // surface spawns so every shell inherits MACTERM_SOCKET and the
+        // bundled CLI on PATH (setenv mutates this process's environ, which
+        // libghostty passes to spawned shells). Requests get a `starting`
+        // error until installResponders attaches the handler.
+        let controlServer = ControlSocketServer(socketPath: ControlSocketServer.defaultSocketPath())
+        controlServer.start()
+        self.controlServer = controlServer
+        setenv(ControlProtocol.socketEnvVar, controlServer.path, 1)
+        if let binDir = Bundle.main.resourceURL?.appendingPathComponent("bin", isDirectory: true).path,
+           FileManager.default.isExecutableFile(atPath: binDir + "/macterm")
+        {
+            let existingPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
+            setenv("PATH", existingPath.isEmpty ? binDir : "\(binDir):\(existingPath)", 1)
+        }
         UNUserNotificationCenter.current().delegate = NotificationHandler.shared
         if BenchmarkControl.isEnabled {
             // Under the CI benchmark, the notification-permission alert would
@@ -329,6 +346,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if BenchmarkControl.isEnabled {
             BenchmarkControl.connect(appState: appState, projectStore: projectStore)
         }
+        if let controlServer {
+            let handler = ControlHandler(appState: appState, projectStore: projectStore)
+            controlHandler = handler
+            controlServer.attach { raw in await handler.handle(raw) }
+        }
         KeyRouter.shared.register(PaletteResponder(appState: appState))
         KeyRouter.shared.register(QuickTerminalResponder())
         let mainResponder = MainAppResponder(appState: appState, projectStore: projectStore)
@@ -348,6 +370,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_: Notification) {
+        controlServer?.stop()
         onTerminate?()
         // Quit is a DETACH by default: workspace panes' sessions survive and
         // reattach on relaunch (the snapshot saved by onTerminate carries each

--- a/Macterm/Control/ControlHandler.swift
+++ b/Macterm/Control/ControlHandler.swift
@@ -1,0 +1,295 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: appBundleID, category: "ControlHandler")
+
+/// Dispatches decoded control-socket requests into app state. Pure
+/// translate-and-delegate: every operation calls the same `AppState` /
+/// `ProjectStore` / `ZmxClient` methods the UI uses — no business logic of
+/// its own. Injectable stores make it fully testable with the tempdir
+/// pattern used by `AppStateTests`.
+@MainActor
+final class ControlHandler {
+    private let appState: AppState
+    private let projectStore: ProjectStore
+    /// Follows `appState.zmx` so tests that stub the client (the established
+    /// AppStateTests pattern) drive this handler too.
+    private var zmx: ZmxClient { appState.zmx }
+
+    init(appState: AppState, projectStore: ProjectStore) {
+        self.appState = appState
+        self.projectStore = projectStore
+    }
+
+    /// Data-level entry point for `ControlSocketServer`: decode, dispatch,
+    /// encode. Never throws — every failure becomes an error response.
+    func handle(_ raw: Data) async -> Data {
+        let request: ControlRequest
+        do {
+            request = try ControlProtocol.decodeRequest(raw)
+        } catch {
+            return ControlProtocol.encode(.failure(
+                id: "",
+                error: ControlError(code: .badRequest, message: "undecodable request: \(error.localizedDescription)")
+            ))
+        }
+        let response = await handle(request)
+        return ControlProtocol.encode(response)
+    }
+
+    func handle(_ request: ControlRequest) async -> ControlResponse {
+        logger.debug("control request: \(request.command, privacy: .public)")
+        do {
+            let data = try await dispatch(request)
+            return .success(id: request.id, data: data)
+        } catch let error as ControlError {
+            return .failure(id: request.id, error: error)
+        } catch {
+            return .failure(
+                id: request.id,
+                error: ControlError(code: .internalError, message: error.localizedDescription)
+            )
+        }
+    }
+
+    private func dispatch(_ request: ControlRequest) async throws -> ControlData {
+        let args = request.args ?? ControlArgs()
+        switch request.command {
+        case "status": return status()
+        case "project.list": return projectList()
+        case "tab.list": return try tabList(args)
+        case "pane.list": return try paneList(args)
+        case "session.list": return try await sessionList()
+        case "session.info": return try await sessionInfo(args)
+        default:
+            throw ControlError(
+                code: .unknownCommand,
+                message: "unknown command \"\(request.command)\"",
+                action: "run `macterm --help` for the supported commands"
+            )
+        }
+    }
+
+    // MARK: - Queries
+
+    private func status() -> ControlData {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        let active = projectStore.projects.first { $0.id == appState.activeProjectID }
+        return ControlData(status: ControlStatusInfo(
+            version: version,
+            pid: getpid(),
+            activeProject: active?.name,
+            activeProjectID: active?.id.uuidString
+        ))
+    }
+
+    private func projectList() -> ControlData {
+        let infos = projectStore.projects.map { project in
+            ControlProjectInfo(
+                id: project.id.uuidString,
+                name: project.name,
+                path: project.path,
+                active: project.id == appState.activeProjectID,
+                // "Loaded" = a workspace exists (tabs/panes addressable over
+                // this protocol) — NOT `AppState.isProjectLoaded`, which asks
+                // whether live terminal *surfaces* exist and is false for a
+                // restored-but-never-shown project.
+                loaded: appState.workspaces[project.id] != nil,
+                tabCount: appState.workspaces[project.id]?.tabs.count
+            )
+        }
+        return ControlData(projects: infos)
+    }
+
+    private func tabList(_ args: ControlArgs) throws -> ControlData {
+        let (_, workspace) = try resolveWorkspace(args)
+        return ControlData(tabs: tabInfos(in: workspace))
+    }
+
+    private func paneList(_ args: ControlArgs) throws -> ControlData {
+        let (_, workspace) = try resolveWorkspace(args)
+        let tabs: [(Int, TerminalTab)]
+        if args.tab != nil {
+            let (index, tab) = try resolveTab(args, in: workspace)
+            tabs = [(index, tab)]
+        } else {
+            tabs = Array(zip(1..., workspace.tabs))
+        }
+        var infos: [ControlPaneInfo] = []
+        for (tabIndex, tab) in tabs {
+            for (paneIndex, pane) in zip(1..., tab.splitRoot.allPanes()) {
+                infos.append(ControlPaneInfo(
+                    index: paneIndex,
+                    id: pane.id.uuidString,
+                    session: pane.sessionName,
+                    tabIndex: tabIndex,
+                    tabID: tab.id.uuidString,
+                    title: pane.displayTitle,
+                    process: pane.foregroundProcessName,
+                    cwd: pane.nsView?.currentPwd ?? pane.projectPath,
+                    focused: tab.id == workspace.activeTabID && pane.id == tab.focusedPaneID
+                ))
+            }
+        }
+        return ControlData(panes: infos)
+    }
+
+    private func sessionList() async throws -> ControlData {
+        guard let entries = await zmx.listSessionsWithClients() else {
+            throw ControlError(
+                code: .internalError,
+                message: "zmx session listing unavailable",
+                action: "check Settings → session persistence for details"
+            )
+        }
+        let leaders = await zmx.sessionLeaderPIDs()
+        let paneBySession = paneIDsBySessionName()
+        let infos = entries.map { entry in
+            ControlSessionInfo(
+                name: entry.name,
+                clients: entry.clients,
+                leaderPID: leaders[entry.name],
+                paneID: paneBySession[entry.name]
+            )
+        }
+        return ControlData(sessions: infos)
+    }
+
+    private func sessionInfo(_ args: ControlArgs) async throws -> ControlData {
+        guard let name = args.session, !name.isEmpty else {
+            throw ControlError(code: .badRequest, message: "session.info requires a session name")
+        }
+        let data = try await sessionList()
+        guard let match = data.sessions?.first(where: { $0.name == name }) else {
+            throw ControlError(
+                code: .notFound,
+                message: "no zmx session named \"\(name)\"",
+                action: "run `macterm session list` to see live sessions"
+            )
+        }
+        return ControlData(sessions: [match])
+    }
+
+    // MARK: - Selector resolution
+
+    /// Resolve the project selector (name, UUID, or 1-based list index) to a
+    /// project with a live workspace; defaults to the active project.
+    private func resolveWorkspace(_ args: ControlArgs) throws -> (Project, Workspace) {
+        let project = try resolveProject(args.project)
+        guard let workspace = appState.workspaces[project.id] else {
+            throw ControlError(
+                code: .notFound,
+                message: "project \"\(project.name)\" has no loaded workspace",
+                action: "select it first: `macterm project select \(project.name)`"
+            )
+        }
+        return (project, workspace)
+    }
+
+    private func resolveProject(_ selector: String?) throws -> Project {
+        guard let selector, !selector.isEmpty else {
+            guard let active = projectStore.projects.first(where: { $0.id == appState.activeProjectID }) else {
+                throw ControlError(
+                    code: .notFound,
+                    message: "no active project",
+                    action: "pass --project or select one in the app"
+                )
+            }
+            return active
+        }
+        let projects = projectStore.projects
+        if let id = UUID(uuidString: selector), let match = projects.first(where: { $0.id == id }) {
+            return match
+        }
+        if let index = parseIndex(selector, prefix: "project"), projects.indices.contains(index - 1) {
+            return projects[index - 1]
+        }
+        let byName = projects.filter { $0.name == selector }
+        switch byName.count {
+        case 1: return byName[0]
+        case 0:
+            throw ControlError(
+                code: .notFound,
+                message: "no project matches \"\(selector)\"",
+                action: "run `macterm project list`"
+            )
+        default:
+            throw ControlError(
+                code: .ambiguous,
+                message: "\(byName.count) projects are named \"\(selector)\"",
+                action: "target by UUID from `macterm project list --json`"
+            )
+        }
+    }
+
+    /// Resolve the tab selector (1-based index, `tab:N` ref, UUID, or exact
+    /// title) within a workspace.
+    private func resolveTab(_ args: ControlArgs, in workspace: Workspace) throws -> (Int, TerminalTab) {
+        guard let selector = args.tab, !selector.isEmpty else {
+            guard let active = workspace.activeTab,
+                  let index = workspace.tabs.firstIndex(where: { $0.id == active.id })
+            else {
+                throw ControlError(code: .notFound, message: "the workspace has no active tab")
+            }
+            return (index + 1, active)
+        }
+        if let id = UUID(uuidString: selector),
+           let index = workspace.tabs.firstIndex(where: { $0.id == id })
+        {
+            return (index + 1, workspace.tabs[index])
+        }
+        if let index = parseIndex(selector, prefix: "tab"), workspace.tabs.indices.contains(index - 1) {
+            return (index, workspace.tabs[index - 1])
+        }
+        let byTitle = workspace.tabs.enumerated().filter { $0.element.sidebarTitle == selector }
+        switch byTitle.count {
+        case 1: return (byTitle[0].offset + 1, byTitle[0].element)
+        case 0:
+            throw ControlError(
+                code: .notFound,
+                message: "no tab matches \"\(selector)\"",
+                action: "run `macterm tab list`"
+            )
+        default:
+            throw ControlError(
+                code: .ambiguous,
+                message: "\(byTitle.count) tabs are titled \"\(selector)\"",
+                action: "target by index or UUID from `macterm tab list --json`"
+            )
+        }
+    }
+
+    /// Accepts `3` or `prefix:3` (the ref form the CLI renders).
+    private func parseIndex(_ selector: String, prefix: String) -> Int? {
+        var text = Substring(selector)
+        if text.hasPrefix("\(prefix):") { text = text.dropFirst(prefix.count + 1) }
+        guard let value = Int(text), value >= 1 else { return nil }
+        return value
+    }
+
+    // MARK: - Shared projections
+
+    private func tabInfos(in workspace: Workspace) -> [ControlTabInfo] {
+        zip(1..., workspace.tabs).map { index, tab in
+            ControlTabInfo(
+                index: index,
+                id: tab.id.uuidString,
+                title: tab.sidebarTitle,
+                active: tab.id == workspace.activeTabID,
+                paneCount: tab.splitRoot.allPanes().count
+            )
+        }
+    }
+
+    private func paneIDsBySessionName() -> [String: String] {
+        var map: [String: String] = [:]
+        for workspace in appState.workspaces.values {
+            for tab in workspace.tabs {
+                for pane in tab.splitRoot.allPanes() {
+                    map[pane.sessionName] = pane.id.uuidString
+                }
+            }
+        }
+        return map
+    }
+}

--- a/Macterm/Control/ControlProtocol.swift
+++ b/Macterm/Control/ControlProtocol.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+/// Wire types for the Macterm control socket — the IPC contract between the
+/// running app (`ControlSocketServer` + `ControlHandler`) and the bundled
+/// `macterm` CLI. This file is compiled into BOTH targets (app and CLI) so
+/// the codec can never drift; it must stay free of app-only dependencies
+/// (AppKit, FileStorage, AppState).
+///
+/// Framing: one request per connection. The client writes a single
+/// newline-terminated JSON `ControlRequest` line and half-closes its write
+/// end; the server replies with a single newline-terminated JSON
+/// `ControlResponse` line and closes. Newline-delimited JSON keeps the
+/// protocol debuggable with `nc`/`socat` and leaves room for streaming later.
+enum ControlProtocol {
+    /// Bumped only for breaking changes; additive fields are always safe
+    /// (both sides decode with optional fields).
+    static let version = 1
+
+    /// Socket file inside the app-support directory (per build flavor:
+    /// `Macterm/` vs `Macterm Debug/`).
+    static let socketFilename = "control.sock"
+
+    /// Exported by the app into every spawned shell. A *hint*, not a pin:
+    /// clients fall back to the well-known per-flavor paths when the hinted
+    /// socket doesn't answer (a pinned stale path otherwise breaks every
+    /// shell spawned before an app restart).
+    static let socketEnvVar = "MACTERM_SOCKET"
+
+    /// Injected per-pane so `macterm` invoked inside a pane can target the
+    /// pane it runs in. Session names are restart-stable (persisted verbatim
+    /// in the workspace snapshot), unlike pane UUIDs.
+    static let sessionEnvVar = "MACTERM_SESSION"
+}
+
+// MARK: - Request
+
+struct ControlRequest: Codable {
+    var v: Int
+    /// Client-generated; echoed in the response.
+    var id: String
+    /// Namespaced verb, e.g. `status`, `project.list`, `pane.list`.
+    var command: String
+    var args: ControlArgs?
+
+    init(command: String, args: ControlArgs? = nil) {
+        v = ControlProtocol.version
+        id = UUID().uuidString
+        self.command = command
+        self.args = args
+    }
+}
+
+/// Flat bag of every argument any command accepts (all optional). A single
+/// struct instead of per-command payloads keeps the codec trivial and makes
+/// unknown/extra fields harmless across versions — the same shape Zentty's
+/// battle-tested `AgentIPCRequest` uses.
+struct ControlArgs: Codable, Equatable {
+    /// Project selector: name, UUID, or 1-based index as rendered by
+    /// `project list`.
+    var project: String?
+    /// Tab selector: title, UUID, or 1-based index (`tab:3` or `3`).
+    var tab: String?
+    /// Pane selector: UUID or 1-based index within its tab.
+    var pane: String?
+    /// zmx session name (`macterm-<slug>-<hex12>`) — the restart-stable pane
+    /// address.
+    var session: String?
+
+    init(
+        project: String? = nil,
+        tab: String? = nil,
+        pane: String? = nil,
+        session: String? = nil
+    ) {
+        self.project = project
+        self.tab = tab
+        self.pane = pane
+        self.session = session
+    }
+}
+
+// MARK: - Response
+
+struct ControlResponse: Codable {
+    var v: Int
+    var id: String
+    var ok: Bool
+    var data: ControlData?
+    var error: ControlError?
+
+    static func success(id: String, data: ControlData? = nil) -> ControlResponse {
+        ControlResponse(v: ControlProtocol.version, id: id, ok: true, data: data, error: nil)
+    }
+
+    static func failure(id: String, error: ControlError) -> ControlResponse {
+        ControlResponse(v: ControlProtocol.version, id: id, ok: false, data: nil, error: error)
+    }
+}
+
+struct ControlError: Codable, Equatable, Error {
+    var code: ControlErrorCode
+    var message: String
+    /// Optional recovery hint shown to humans, e.g. "launch Macterm first".
+    var action: String?
+}
+
+enum ControlErrorCode: String, Codable {
+    /// The socket is up but AppState hasn't attached yet (app mid-launch).
+    case starting
+    case unknownCommand = "unknown_command"
+    case badRequest = "bad_request"
+    case notFound = "not_found"
+    case ambiguous
+    /// The operation was staged for user confirmation instead of executing
+    /// (e.g. closing a busy tab without `--force`).
+    case busy
+    /// The target pane exists but its terminal surface hasn't been created.
+    case noSurface = "no_surface"
+    case internalError = "internal"
+}
+
+/// Union-of-optionals result payload (one struct for every command, like
+/// Zentty's `AgentIPCResponseResult`): each command populates exactly the
+/// fields it owns, and old clients ignore fields they don't know.
+struct ControlData: Codable {
+    var status: ControlStatusInfo?
+    var projects: [ControlProjectInfo]?
+    var tabs: [ControlTabInfo]?
+    var panes: [ControlPaneInfo]?
+    var sessions: [ControlSessionInfo]?
+
+    init(
+        status: ControlStatusInfo? = nil,
+        projects: [ControlProjectInfo]? = nil,
+        tabs: [ControlTabInfo]? = nil,
+        panes: [ControlPaneInfo]? = nil,
+        sessions: [ControlSessionInfo]? = nil
+    ) {
+        self.status = status
+        self.projects = projects
+        self.tabs = tabs
+        self.panes = panes
+        self.sessions = sessions
+    }
+}
+
+struct ControlStatusInfo: Codable, Equatable {
+    var version: String
+    var pid: Int32
+    var activeProject: String?
+    var activeProjectID: String?
+}
+
+struct ControlProjectInfo: Codable, Equatable {
+    var id: String
+    var name: String
+    var path: String
+    var active: Bool
+    /// Whether a live workspace exists for the project this launch.
+    var loaded: Bool
+    var tabCount: Int?
+}
+
+struct ControlTabInfo: Codable, Equatable {
+    /// 1-based position in the sidebar, rendered as `tab:N`.
+    var index: Int
+    var id: String
+    var title: String
+    var active: Bool
+    var paneCount: Int
+}
+
+struct ControlPaneInfo: Codable, Equatable {
+    /// 1-based position within its tab (split-tree order), rendered `pane:N`.
+    var index: Int
+    var id: String
+    /// zmx session name — the stable address for scripting.
+    var session: String
+    var tabIndex: Int
+    var tabID: String
+    var title: String
+    /// Live foreground process name, if the poll has resolved one.
+    var process: String?
+    var cwd: String?
+    var focused: Bool
+}
+
+struct ControlSessionInfo: Codable, Equatable {
+    var name: String
+    /// Attached client count from `zmx ls`; nil when the daemon reported the
+    /// session in a state the parser couldn't count (err/status line).
+    var clients: Int?
+    /// Daemon leader pid, when resolved.
+    var leaderPID: Int32?
+    /// The live pane currently bound to this session, if any (a session with
+    /// no pane is an orphan awaiting reap or reattach).
+    var paneID: String?
+}
+
+// MARK: - Codec
+
+extension ControlProtocol {
+    static func encode(_ request: ControlRequest) throws -> Data {
+        var data = try JSONEncoder().encode(request)
+        data.append(0x0A)
+        return data
+    }
+
+    static func encode(_ response: ControlResponse) -> Data {
+        // A response that fails to encode is a programming error; fall back to
+        // a hand-built internal error so the client always gets valid JSON.
+        if var data = try? JSONEncoder().encode(response) {
+            data.append(0x0A)
+            return data
+        }
+        let fallback = #"{"v":1,"id":"","ok":false,"error":{"code":"internal","message":"response encoding failed"}}"#
+        return Data((fallback + "\n").utf8)
+    }
+
+    static func decodeRequest(_ data: Data) throws -> ControlRequest {
+        try JSONDecoder().decode(ControlRequest.self, from: trimmed(data))
+    }
+
+    static func decodeResponse(_ data: Data) throws -> ControlResponse {
+        try JSONDecoder().decode(ControlResponse.self, from: trimmed(data))
+    }
+
+    /// Strip the trailing newline (and any stray whitespace) before decoding.
+    private static func trimmed(_ data: Data) -> Data {
+        var slice = data[...]
+        while let last = slice.last, last == 0x0A || last == 0x0D || last == 0x20 {
+            slice = slice.dropLast()
+        }
+        return Data(slice)
+    }
+}

--- a/Macterm/Control/ControlSocketServer.swift
+++ b/Macterm/Control/ControlSocketServer.swift
@@ -1,0 +1,260 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: appBundleID, category: "ControlSocketServer")
+
+/// App-side listener for the `macterm` control CLI. Accepts one request per
+/// connection on a Unix-domain socket, reads a newline-terminated JSON line
+/// (the client half-closes after sending), and hands it to the attached
+/// `@MainActor` handler, whose JSON response is written back before close.
+///
+/// The accept loop runs on its own thread against a NON-BLOCKING listen
+/// socket polled every 20ms — never a blocking `accept()` on a queue shared
+/// with `stop()`, which would starve shutdown behind the block. Connection
+/// handling hops to the main actor via a Task that owns the fd from then on,
+/// so a slow handler never stalls the accept loop.
+///
+/// Started at app launch, before AppState exists; requests arriving before
+/// `attach(handler:)` get a `starting` error so a fast CLI poll (e.g. the
+/// benchmark harness waiting for readiness) sees a well-formed response
+/// instead of a hang.
+final class ControlSocketServer: @unchecked Sendable {
+    typealias Handler = @MainActor @Sendable (Data) async -> Data
+
+    private let socketPath: String
+    /// Guards `listenFD`, `isRunning`, and `handler` — touched by the control
+    /// methods (main thread) and the accept thread.
+    private let lock = NSLock()
+    private var listenFD: Int32 = -1
+    private var isRunning = false
+    private var handler: Handler?
+    private var acceptThread: Thread?
+
+    init(socketPath: String) {
+        self.socketPath = socketPath
+    }
+
+    /// The path exported to spawned shells via `MACTERM_SOCKET`.
+    var path: String { socketPath }
+
+    /// The per-flavor well-known socket location (`Macterm/` vs
+    /// `Macterm Debug/`, or the benchmark's `MACTERM_BENCHMARK_DATA_DIR`).
+    static func defaultSocketPath() -> String {
+        FileStorage.fileURL(filename: ControlProtocol.socketFilename).path
+    }
+
+    func start() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isRunning else { return }
+        guard bindAndListen() else { return }
+        isRunning = true
+        logger.info("control socket listening at \(self.socketPath, privacy: .public)")
+        let thread = Thread { [weak self] in self?.acceptLoop() }
+        thread.name = "com.thdxg.macterm.control-socket"
+        thread.stackSize = 512 * 1024
+        acceptThread = thread
+        thread.start()
+    }
+
+    /// Wire up request dispatch once AppState/ProjectStore exist (the server
+    /// itself starts earlier, at applicationDidFinishLaunching).
+    func attach(handler: @escaping Handler) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.handler = handler
+    }
+
+    func stop() {
+        lock.lock()
+        isRunning = false
+        if listenFD >= 0 {
+            close(listenFD)
+            listenFD = -1
+        }
+        lock.unlock()
+        unlink(socketPath)
+    }
+
+    private var running: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isRunning
+    }
+
+    private var currentListenFD: Int32 {
+        lock.lock()
+        defer { lock.unlock() }
+        return listenFD
+    }
+
+    private var currentHandler: Handler? {
+        lock.lock()
+        defer { lock.unlock() }
+        return handler
+    }
+
+    // MARK: - Socket setup
+
+    private func bindAndListen() -> Bool {
+        // Ensure the parent dir exists and any stale socket (crashed previous
+        // run) is gone before binding.
+        let dir = (socketPath as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700]
+        )
+        unlink(socketPath)
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            logger.error("socket() failed: \(String(cString: strerror(errno)), privacy: .public)")
+            return false
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketPath.utf8CString
+        // sun_path is a fixed ~104-byte C array; refuse overlong paths rather
+        // than truncate (a truncated bind would listen somewhere else).
+        let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+        guard pathBytes.count <= maxLen else {
+            logger.error("socket path too long (\(pathBytes.count, privacy: .public) > \(maxLen, privacy: .public))")
+            close(fd)
+            return false
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { dst in
+            dst.withMemoryRebound(to: CChar.self, capacity: maxLen) { dstPtr in
+                pathBytes.withUnsafeBufferPointer { src in
+                    guard let srcBase = src.baseAddress else { return }
+                    dstPtr.update(from: srcBase, count: src.count)
+                }
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            logger.error("bind() failed: \(String(cString: strerror(errno)), privacy: .public)")
+            close(fd)
+            return false
+        }
+        // Same-user only: filesystem permissions are the auth boundary.
+        chmod(socketPath, 0o600)
+        guard listen(fd, 16) == 0 else {
+            logger.error("listen() failed: \(String(cString: strerror(errno)), privacy: .public)")
+            close(fd)
+            return false
+        }
+        // Non-blocking listen socket: the accept loop polls and re-checks
+        // `running`, so `stop()` takes effect within one poll tick.
+        let flags = fcntl(fd, F_GETFL, 0)
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+        // Shells spawned by the app must not inherit the listen fd — a
+        // long-lived child holding it would keep the socket alive past quit.
+        _ = fcntl(fd, F_SETFD, FD_CLOEXEC)
+        listenFD = fd
+        return true
+    }
+
+    private func acceptLoop() {
+        while running {
+            let fd = currentListenFD
+            guard fd >= 0 else { break }
+            let clientFD = accept(fd, nil, nil)
+            if clientFD < 0 {
+                if errno == EINTR { continue }
+                if errno == EAGAIN || errno == EWOULDBLOCK {
+                    usleep(20000) // 20ms; bounds stop() latency without busy-wait
+                    continue
+                }
+                if running {
+                    logger.error("accept() failed: \(String(cString: strerror(errno)), privacy: .public)")
+                }
+                break
+            }
+            _ = fcntl(clientFD, F_SETFD, FD_CLOEXEC)
+            // A disappeared client must surface as EPIPE on write, not a
+            // process-killing SIGPIPE.
+            var one: Int32 = 1
+            setsockopt(clientFD, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout<Int32>.size))
+            // Backstop read timeout — the client half-closes right after
+            // sending, so a stalled read means a broken client.
+            var timeout = timeval(tv_sec: 10, tv_usec: 0)
+            setsockopt(clientFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+            handleConnection(clientFD)
+        }
+    }
+
+    // MARK: - Per-connection handling
+
+    /// Read the request synchronously on the accept thread (fast — one small
+    /// line, then EOF), then hand the fd to a `@MainActor` task for dispatch
+    /// and response. The task owns the fd from then on.
+    private func handleConnection(_ fd: Int32) {
+        guard let raw = Self.readAll(fd: fd), !raw.isEmpty else {
+            Self.write(fd: fd, data: ControlProtocol.encode(.failure(
+                id: "",
+                error: ControlError(code: .badRequest, message: "empty or unreadable request")
+            )))
+            close(fd)
+            return
+        }
+        guard let handler = currentHandler else {
+            // Echo the request id when it parses so the client can correlate.
+            let id = (try? ControlProtocol.decodeRequest(raw))?.id ?? ""
+            Self.write(fd: fd, data: ControlProtocol.encode(.failure(
+                id: id,
+                error: ControlError(
+                    code: .starting,
+                    message: "Macterm is still starting up",
+                    action: "retry in a moment"
+                )
+            )))
+            close(fd)
+            return
+        }
+        Task { @MainActor in
+            let response = await handler(raw)
+            Self.write(fd: fd, data: response)
+            close(fd)
+        }
+    }
+
+    // MARK: - Socket IO
+
+    /// Read until EOF (the client half-closes its write end after sending).
+    private static func readAll(fd: Int32) -> Data? {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 16384)
+        while true {
+            let n = read(fd, &buffer, buffer.count)
+            if n > 0 {
+                data.append(contentsOf: buffer[0 ..< n])
+            } else if n == 0 {
+                return data
+            } else {
+                if errno == EINTR { continue }
+                return nil
+            }
+        }
+    }
+
+    private static func write(fd: Int32, data: Data) {
+        data.withUnsafeBytes { raw in
+            guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return }
+            var offset = 0
+            while offset < data.count {
+                let n = Darwin.write(fd, base + offset, data.count - offset)
+                if n > 0 {
+                    offset += n
+                } else {
+                    if errno == EINTR { continue }
+                    break
+                }
+            }
+        }
+    }
+}

--- a/MactermTests/Control/ControlHandlerTests.swift
+++ b/MactermTests/Control/ControlHandlerTests.swift
@@ -1,0 +1,286 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+@MainActor
+struct ControlHandlerTests {
+    // MARK: - Setup helpers (tempdir stores, mirroring AppStateTests)
+
+    private func makeAppState() -> AppState {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-control-tests-\(UUID().uuidString).json")
+        let projectsDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-control-tests-projects-\(UUID().uuidString)", isDirectory: true)
+        return AppState(
+            workspaceStore: WorkspaceStore(fileURL: tmp),
+            projectFiles: ProjectFileStore(directoryURL: projectsDir)
+        )
+    }
+
+    private func makeHandler(
+        state: AppState? = nil,
+        store: ProjectStore? = nil
+    ) -> (ControlHandler, AppState, ProjectStore) {
+        let appState = state ?? makeAppState()
+        let projectStore = store ?? ProjectStore(fileURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-control-tests-store-\(UUID().uuidString).json"))
+        let handler = ControlHandler(appState: appState, projectStore: projectStore)
+        return (handler, appState, projectStore)
+    }
+
+    private func seedProject(
+        _ appState: AppState,
+        _ projectStore: ProjectStore,
+        name: String = "demo",
+        path: String = "/tmp",
+        select: Bool = true
+    ) -> Project {
+        let project = Project(name: name, path: path, sortOrder: projectStore.projects.count)
+        projectStore.add(project)
+        if select { appState.selectProject(project) }
+        return project
+    }
+
+    private func request(_ command: String, args: ControlArgs? = nil) -> ControlRequest {
+        ControlRequest(command: command, args: args)
+    }
+
+    // MARK: - Envelope behavior
+
+    @Test
+    func unknown_command_yields_typed_error_with_hint() async {
+        let (handler, _, _) = makeHandler()
+        let response = await handler.handle(request("frobnicate"))
+        #expect(!response.ok)
+        #expect(response.error?.code == .unknownCommand)
+        #expect(response.error?.action?.contains("--help") == true)
+    }
+
+    @Test
+    func undecodable_data_yields_bad_request() async {
+        let (handler, _, _) = makeHandler()
+        let raw = await handler.handle(Data("not json\n".utf8))
+        let response = try? ControlProtocol.decodeResponse(raw)
+        #expect(response?.ok == false)
+        #expect(response?.error?.code == .badRequest)
+    }
+
+    @Test
+    func response_echoes_request_id() async {
+        let (handler, _, _) = makeHandler()
+        var req = request("status")
+        req.id = "custom-id-123"
+        let response = await handler.handle(req)
+        #expect(response.id == "custom-id-123")
+    }
+
+    // MARK: - status
+
+    @Test
+    func status_reports_pid_and_active_project() async {
+        let (handler, appState, projectStore) = makeHandler()
+        let project = seedProject(appState, projectStore, name: "alpha")
+        let response = await handler.handle(request("status"))
+        #expect(response.ok)
+        #expect(response.data?.status?.pid == getpid())
+        #expect(response.data?.status?.activeProject == "alpha")
+        #expect(response.data?.status?.activeProjectID == project.id.uuidString)
+    }
+
+    @Test
+    func status_with_no_active_project_omits_it() async {
+        let (handler, _, _) = makeHandler()
+        let response = await handler.handle(request("status"))
+        #expect(response.ok)
+        #expect(response.data?.status?.activeProject == nil)
+    }
+
+    // MARK: - project.list
+
+    @Test
+    func project_list_marks_active_and_loaded() async {
+        let (handler, appState, projectStore) = makeHandler()
+        let selected = seedProject(appState, projectStore, name: "one")
+        _ = seedProject(appState, projectStore, name: "two", select: false)
+        let response = await handler.handle(request("project.list"))
+        let projects = response.data?.projects
+        #expect(projects?.count == 2)
+        let one = projects?.first { $0.name == "one" }
+        let two = projects?.first { $0.name == "two" }
+        #expect(one?.active == true)
+        #expect(one?.loaded == true)
+        #expect(one?.id == selected.id.uuidString)
+        #expect(one?.tabCount == 1)
+        #expect(two?.active == false)
+        #expect(two?.loaded == false)
+        #expect(two?.tabCount == nil)
+    }
+
+    // MARK: - tab.list
+
+    @Test
+    func tab_list_defaults_to_active_project() async {
+        let (handler, appState, projectStore) = makeHandler()
+        let project = seedProject(appState, projectStore)
+        appState.createTab(projectID: project.id, projectPath: project.path)
+        let response = await handler.handle(request("tab.list"))
+        let tabs = response.data?.tabs
+        #expect(tabs?.count == 2)
+        #expect(tabs?.map(\.index) == [1, 2])
+        // createTab selects the new tab.
+        #expect(tabs?.last?.active == true)
+        #expect(tabs?.allSatisfy { $0.paneCount == 1 } == true)
+    }
+
+    @Test
+    func tab_list_resolves_project_by_name_index_and_uuid() async {
+        let (handler, appState, projectStore) = makeHandler()
+        let first = seedProject(appState, projectStore, name: "first")
+        let second = seedProject(appState, projectStore, name: "second")
+        appState.createTab(projectID: second.id, projectPath: second.path)
+
+        for selector in ["first", "project:1", "1", first.id.uuidString] {
+            let response = await handler.handle(request("tab.list", args: ControlArgs(project: selector)))
+            #expect(response.data?.tabs?.count == 1, "selector \(selector)")
+        }
+        let response = await handler.handle(request("tab.list", args: ControlArgs(project: "second")))
+        #expect(response.data?.tabs?.count == 2)
+    }
+
+    @Test
+    func tab_list_unknown_project_is_not_found() async {
+        let (handler, appState, projectStore) = makeHandler()
+        _ = seedProject(appState, projectStore)
+        let response = await handler.handle(request("tab.list", args: ControlArgs(project: "ghost")))
+        #expect(response.error?.code == .notFound)
+    }
+
+    @Test
+    func tab_list_unloaded_project_is_not_found_with_hint() async {
+        let (handler, appState, projectStore) = makeHandler()
+        _ = seedProject(appState, projectStore, name: "loaded")
+        _ = seedProject(appState, projectStore, name: "cold", select: false)
+        let response = await handler.handle(request("tab.list", args: ControlArgs(project: "cold")))
+        #expect(response.error?.code == .notFound)
+        #expect(response.error?.action?.contains("project select") == true)
+    }
+
+    @Test
+    func no_active_project_is_not_found() async {
+        let (handler, _, _) = makeHandler()
+        let response = await handler.handle(request("tab.list"))
+        #expect(response.error?.code == .notFound)
+    }
+
+    @Test
+    func ambiguous_project_name_is_reported() async {
+        let (handler, appState, projectStore) = makeHandler()
+        _ = seedProject(appState, projectStore, name: "twin")
+        _ = seedProject(appState, projectStore, name: "twin", select: false)
+        let response = await handler.handle(request("tab.list", args: ControlArgs(project: "twin")))
+        #expect(response.error?.code == .ambiguous)
+    }
+
+    // MARK: - pane.list
+
+    @Test
+    func pane_list_walks_splits_and_marks_focus() async {
+        let (handler, appState, projectStore) = makeHandler()
+        let project = seedProject(appState, projectStore)
+        appState.splitPane(direction: .horizontal, projectID: project.id)
+        let response = await handler.handle(request("pane.list"))
+        let panes = response.data?.panes
+        #expect(panes?.count == 2)
+        #expect(panes?.map(\.index) == [1, 2])
+        #expect(panes?.allSatisfy { $0.tabIndex == 1 } == true)
+        // splitPane focuses the new (second) pane.
+        #expect(panes?.filter(\.focused).count == 1)
+        #expect(panes?.last?.focused == true)
+        #expect(panes?.allSatisfy { $0.session.hasPrefix("macterm-") } == true)
+        #expect(panes?.allSatisfy { $0.cwd == project.path } == true)
+    }
+
+    @Test
+    func pane_list_scopes_to_a_tab_selector() async {
+        let (handler, appState, projectStore) = makeHandler()
+        let project = seedProject(appState, projectStore)
+        appState.createTab(projectID: project.id, projectPath: project.path)
+        appState.splitPane(direction: .vertical, projectID: project.id)
+
+        let all = await handler.handle(request("pane.list"))
+        #expect(all.data?.panes?.count == 3)
+
+        let scoped = await handler.handle(request("pane.list", args: ControlArgs(tab: "tab:2")))
+        #expect(scoped.data?.panes?.count == 2)
+
+        let first = await handler.handle(request("pane.list", args: ControlArgs(tab: "1")))
+        #expect(first.data?.panes?.count == 1)
+
+        let missing = await handler.handle(request("pane.list", args: ControlArgs(tab: "9")))
+        #expect(missing.error?.code == .notFound)
+    }
+
+    // MARK: - session.list / session.info
+
+    private func stubZmx(
+        _ appState: AppState,
+        entries: [ZmxSessionListParser.Entry]?,
+        leaders: [String: pid_t] = [:]
+    ) {
+        appState.zmx = ZmxClient(
+            executableURL: { nil },
+            isBundled: { true },
+            killSession: { _ in },
+            listSessionsWithClients: { entries },
+            sessionLeaderPIDs: { leaders }
+        )
+    }
+
+    @Test
+    func session_list_maps_entries_and_live_panes() async throws {
+        let (handler, appState, projectStore) = makeHandler()
+        let project = seedProject(appState, projectStore)
+        let pane = try #require(appState.workspaces[project.id]?.activeTab?.splitRoot.allPanes().first)
+        stubZmx(
+            appState,
+            entries: [
+                .init(name: pane.sessionName, clients: 1),
+                .init(name: "macterm-orphan-aaaabbbbcccc", clients: 0),
+            ],
+            leaders: [pane.sessionName: 4242]
+        )
+        let response = await handler.handle(request("session.list"))
+        let sessions = response.data?.sessions
+        #expect(sessions?.count == 2)
+        let live = sessions?.first { $0.name == pane.sessionName }
+        #expect(live?.paneID == pane.id.uuidString)
+        #expect(live?.leaderPID == 4242)
+        #expect(live?.clients == 1)
+        let orphan = sessions?.first { $0.name == "macterm-orphan-aaaabbbbcccc" }
+        #expect(orphan?.paneID == nil)
+    }
+
+    @Test
+    func session_list_probe_failure_is_internal_error() async {
+        let (handler, appState, _) = makeHandler()
+        stubZmx(appState, entries: nil)
+        let response = await handler.handle(request("session.list"))
+        #expect(response.error?.code == .internalError)
+    }
+
+    @Test
+    func session_info_finds_by_name_or_404s() async {
+        let (handler, appState, _) = makeHandler()
+        stubZmx(appState, entries: [.init(name: "macterm-x-000011112222", clients: 0)])
+
+        let hit = await handler.handle(request("session.info", args: ControlArgs(session: "macterm-x-000011112222")))
+        #expect(hit.ok)
+        #expect(hit.data?.sessions?.count == 1)
+
+        let miss = await handler.handle(request("session.info", args: ControlArgs(session: "macterm-y-000011112222")))
+        #expect(miss.error?.code == .notFound)
+
+        let empty = await handler.handle(request("session.info"))
+        #expect(empty.error?.code == .badRequest)
+    }
+}

--- a/MactermTests/Control/ControlProtocolTests.swift
+++ b/MactermTests/Control/ControlProtocolTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+struct ControlProtocolTests {
+    // MARK: - Framing
+
+    @Test
+    func request_roundtrips_with_newline_framing() throws {
+        let request = ControlRequest(command: "pane.list", args: ControlArgs(project: "demo", tab: "tab:2"))
+        let encoded = try ControlProtocol.encode(request)
+        #expect(encoded.last == 0x0A)
+        let decoded = try ControlProtocol.decodeRequest(encoded)
+        #expect(decoded.id == request.id)
+        #expect(decoded.command == "pane.list")
+        #expect(decoded.args == ControlArgs(project: "demo", tab: "tab:2"))
+        #expect(decoded.v == ControlProtocol.version)
+    }
+
+    @Test
+    func response_roundtrips_success_and_failure() throws {
+        let success = ControlResponse.success(
+            id: "abc",
+            data: ControlData(status: ControlStatusInfo(version: "1.0", pid: 42, activeProject: "p", activeProjectID: nil))
+        )
+        let decodedSuccess = try ControlProtocol.decodeResponse(ControlProtocol.encode(success))
+        #expect(decodedSuccess.ok)
+        #expect(decodedSuccess.id == "abc")
+        #expect(decodedSuccess.data?.status?.pid == 42)
+        #expect(decodedSuccess.error == nil)
+
+        let failure = ControlResponse.failure(
+            id: "def",
+            error: ControlError(code: .notFound, message: "nope", action: "look elsewhere")
+        )
+        let decodedFailure = try ControlProtocol.decodeResponse(ControlProtocol.encode(failure))
+        #expect(!decodedFailure.ok)
+        #expect(decodedFailure.error?.code == .notFound)
+        #expect(decodedFailure.error?.action == "look elsewhere")
+    }
+
+    /// The wire format the CLI emits, hand-built: guards against accidental
+    /// key renames on the app side.
+    @Test
+    func app_decodes_hand_built_cli_request() throws {
+        let json = #"{"v":1,"id":"x1","command":"session.info","args":{"session":"macterm-demo-abc123"}}"#
+        let decoded = try ControlProtocol.decodeRequest(Data((json + "\n").utf8))
+        #expect(decoded.command == "session.info")
+        #expect(decoded.args?.session == "macterm-demo-abc123")
+    }
+
+    /// Unknown args keys must be ignored (forward compatibility: a newer CLI
+    /// against an older app).
+    @Test
+    func unknown_args_fields_are_ignored() throws {
+        let json = #"{"v":1,"id":"x2","command":"status","args":{"future_flag":"yes"}}"#
+        let decoded = try ControlProtocol.decodeRequest(Data((json + "\n").utf8))
+        #expect(decoded.command == "status")
+        #expect(decoded.args == ControlArgs())
+    }
+
+    @Test
+    func error_codes_use_snake_case_raw_values() {
+        #expect(ControlErrorCode.notFound.rawValue == "not_found")
+        #expect(ControlErrorCode.unknownCommand.rawValue == "unknown_command")
+        #expect(ControlErrorCode.noSurface.rawValue == "no_surface")
+        #expect(ControlErrorCode.badRequest.rawValue == "bad_request")
+        #expect(ControlErrorCode.internalError.rawValue == "internal")
+    }
+
+    @Test
+    func decode_tolerates_trailing_whitespace_and_crlf() throws {
+        let json = #"{"v":1,"id":"x3","command":"status"}"#
+        let decoded = try ControlProtocol.decodeRequest(Data((json + "\r\n").utf8))
+        #expect(decoded.command == "status")
+    }
+}

--- a/MactermTests/Control/ControlSocketServerTests.swift
+++ b/MactermTests/Control/ControlSocketServerTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+/// Exercises the real Unix socket end to end against a temp path — bind,
+/// connect, request/response framing, and lifecycle hygiene. The "client"
+/// here is a minimal raw-socket writer so these tests cover the server
+/// contract independently of the CLI's `ControlClient`.
+@MainActor
+struct ControlSocketServerTests {
+    private func makeSocketPath() -> String {
+        // Keep it short: sun_path caps at ~104 bytes and the default tempdir
+        // path can be long.
+        "/tmp/macterm-test-\(UInt32.random(in: 0 ..< UInt32.max)).sock"
+    }
+
+    /// Run the raw round-trip off the main actor so the server's MainActor
+    /// response task can execute while the client blocks on read.
+    private func awaitResponse(path: String, line: Data) async -> Data? {
+        let payload = line
+        return await Task.detached {
+            roundTripDetached(path: path, line: payload)
+        }.value
+    }
+
+    // MARK: - Lifecycle
+
+    @Test
+    func start_creates_socket_and_stop_unlinks_it() {
+        let path = makeSocketPath()
+        let server = ControlSocketServer(socketPath: path)
+        server.start()
+        #expect(FileManager.default.fileExists(atPath: path))
+        server.stop()
+        #expect(!FileManager.default.fileExists(atPath: path))
+    }
+
+    @Test
+    func start_is_idempotent_and_replaces_a_stale_socket_file() {
+        let path = makeSocketPath()
+        // Simulate a crashed previous run: a dead socket file at the path.
+        FileManager.default.createFile(atPath: path, contents: nil)
+        let server = ControlSocketServer(socketPath: path)
+        server.start()
+        server.start() // second start is a no-op, not a rebind
+        #expect(FileManager.default.fileExists(atPath: path))
+        server.stop()
+        #expect(!FileManager.default.fileExists(atPath: path))
+    }
+
+    @Test
+    func stop_before_start_is_safe() {
+        let server = ControlSocketServer(socketPath: makeSocketPath())
+        server.stop()
+    }
+
+    // MARK: - Request handling
+
+    @Test
+    func request_before_attach_gets_starting_error_echoing_id() async throws {
+        let path = makeSocketPath()
+        let server = ControlSocketServer(socketPath: path)
+        server.start()
+        defer { server.stop() }
+
+        var request = ControlRequest(command: "status")
+        request.id = "early-bird"
+        let raw = try #require(await awaitResponse(path: path, line: ControlProtocol.encode(request)))
+        let response = try ControlProtocol.decodeResponse(raw)
+        #expect(!response.ok)
+        #expect(response.error?.code == .starting)
+        #expect(response.id == "early-bird")
+    }
+
+    @Test
+    func attached_handler_round_trips_a_response() async throws {
+        let path = makeSocketPath()
+        let server = ControlSocketServer(socketPath: path)
+        server.start()
+        defer { server.stop() }
+        server.attach { raw in
+            let request = (try? ControlProtocol.decodeRequest(raw))
+            return ControlProtocol.encode(.success(
+                id: request?.id ?? "",
+                data: ControlData(status: ControlStatusInfo(
+                    version: "test", pid: 7, activeProject: nil, activeProjectID: nil
+                ))
+            ))
+        }
+
+        let request = ControlRequest(command: "status")
+        let raw = try #require(await awaitResponse(path: path, line: ControlProtocol.encode(request)))
+        let response = try ControlProtocol.decodeResponse(raw)
+        #expect(response.ok)
+        #expect(response.id == request.id)
+        #expect(response.data?.status?.version == "test")
+    }
+
+    @Test
+    func empty_request_gets_bad_request() async throws {
+        let path = makeSocketPath()
+        let server = ControlSocketServer(socketPath: path)
+        server.start()
+        defer { server.stop() }
+
+        let raw = try #require(await awaitResponse(path: path, line: Data()))
+        let response = try ControlProtocol.decodeResponse(raw)
+        #expect(response.error?.code == .badRequest)
+    }
+
+    @Test
+    func overlong_socket_path_refuses_to_start() {
+        let path = "/tmp/" + String(repeating: "x", count: 200) + ".sock"
+        let server = ControlSocketServer(socketPath: path)
+        server.start()
+        #expect(!FileManager.default.fileExists(atPath: path))
+        server.stop()
+    }
+
+    @Test
+    func default_socket_path_lives_in_app_support() {
+        let path = ControlSocketServer.defaultSocketPath()
+        #expect(path.hasSuffix("/" + ControlProtocol.socketFilename))
+    }
+}
+
+/// Free function so the detached task doesn't capture the MainActor test
+/// struct. Mirrors the private helper above.
+private func roundTripDetached(path: String, line: Data) -> Data? {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else { return nil }
+    defer { close(fd) }
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let bytes = path.utf8CString
+    let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+    guard bytes.count <= maxLen else { return nil }
+    withUnsafeMutablePointer(to: &addr.sun_path) { dst in
+        dst.withMemoryRebound(to: CChar.self, capacity: maxLen) { dstPtr in
+            bytes.withUnsafeBufferPointer { src in
+                guard let base = src.baseAddress else { return }
+                dstPtr.update(from: base, count: src.count)
+            }
+        }
+    }
+    let connected = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard connected == 0 else { return nil }
+    var timeout = timeval(tv_sec: 5, tv_usec: 0)
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+    if !line.isEmpty {
+        let sent = line.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            return write(fd, base, line.count) == line.count
+        }
+        guard sent else { return nil }
+    }
+    shutdown(fd, SHUT_WR)
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let n = read(fd, &buffer, buffer.count)
+        if n > 0 { data.append(contentsOf: buffer[0 ..< n]) } else { break }
+    }
+    return data
+}

--- a/project.yml
+++ b/project.yml
@@ -38,6 +38,9 @@ packages:
   Yams:
     url: https://github.com/jpsim/Yams
     from: "5.0.0"
+  ArgumentParser:
+    url: https://github.com/apple/swift-argument-parser
+    from: "1.3.0"
 
 targets:
   Macterm:
@@ -117,6 +120,10 @@ targets:
           PRODUCT_BUNDLE_IDENTIFIER: com.thdxg.macterm.debug
           PRODUCT_DISPLAY_NAME: Macterm Debug
     dependencies:
+      # Build ordering only: the post-build script copies the CLI binary into
+      # the bundle, so it must exist before the app target finishes.
+      - target: MactermCLI
+        embed: false
       - framework: GhosttyKit.xcframework
         embed: false
       - package: Sparkle
@@ -141,6 +148,37 @@ targets:
       - script: "${SRCROOT}/scripts/embed-zmx.sh"
         name: "Embed zmx"
         basedOnDependencyAnalysis: false
+    postBuildScripts:
+      # Bundle the control CLI at Contents/Resources/bin/macterm. The app
+      # prepends this dir to PATH for spawned shells; scripts outside the app
+      # (the CI benchmark) invoke it by bundle path.
+      - name: "Bundle macterm CLI"
+        basedOnDependencyAnalysis: false
+        script: |
+          set -e
+          BIN_DIR="$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/Resources/bin"
+          mkdir -p "$BIN_DIR"
+          cp "$BUILT_PRODUCTS_DIR/macterm" "$BIN_DIR/macterm"
+
+  # The bundled control CLI (`macterm`). Shares ControlProtocol.swift with the
+  # app target so the wire codec can never drift between the two.
+  MactermCLI:
+    type: tool
+    platform: macOS
+    sources:
+      - path: CLI
+      - path: Macterm/Control/ControlProtocol.swift
+    dependencies:
+      - package: ArgumentParser
+        product: ArgumentParser
+    settings:
+      base:
+        PRODUCT_NAME: macterm
+        # The binary is `macterm` but the MODULE must not collide with the
+        # app's `Macterm` module (case-insensitive .swiftmodule paths in the
+        # shared products dir would otherwise clash).
+        PRODUCT_MODULE_NAME: MactermCLI
+        PRODUCT_BUNDLE_IDENTIFIER: com.thdxg.macterm.cli
 
   MactermTests:
     type: bundle.unit-test


### PR DESCRIPTION
First of three PRs for #107 (Macterm CLI) — also groundwork for realistic CI benchmark workloads (#129 follow-up). This slice ships the IPC control plane and the read-only command set; mutations (project create/select, tab new, pane split/run, grid, session kill, layout apply/save) come in PR 2, and the benchmark workload integration in PR 3.

## What's here

- **`Macterm/Control/ControlProtocol.swift`** — wire types, compiled into both the app and CLI targets so the codec can't drift. One request per connection: newline-terminated JSON both ways, client half-closes after sending. Requests are `{v, id, command, args}` with `noun.verb` commands; responses echo `id` with `{ok, data}` or a typed error `{code, message, action?}` where `action` is a human recovery hint.
- **`ControlSocketServer`** — Unix socket at `<App Support>/control.sock` (per build flavor; follows `MACTERM_BENCHMARK_DATA_DIR`). Dedicated thread polling a non-blocking listen fd — never a blocking `accept()` on a queue shared with `stop()`. Per-connection dispatch hops to `@MainActor`. Starts at launch; requests before AppState exists get a `starting` error (so a readiness poll sees a well-formed response). `FD_CLOEXEC` keeps spawned shells from holding the socket past quit; socket file is 0600 and unlinked on quit.
- **`ControlHandler`** — translate-and-delegate only: resolves selectors (name / UUID / 1-based index for projects and tabs; duplicates surface as typed `ambiguous` errors) and calls the same `AppState`/`ProjectStore`/`ZmxClient` paths the UI uses. Reads zmx via `appState.zmx` so tests stub one seam.
- **`CLI/` (`MactermCLI` tool target → `Contents/Resources/bin/macterm`)** — swift-argument-parser command tree: `status`, `project list`, `tab list`, `pane list`, `session list|info`, all with `--json`. The app prepends the bundled bin dir to `PATH` and exports `MACTERM_SOCKET` before any shell spawns, so `macterm` works inside every pane.

## Design notes (from reading cmux, Zentty, Supacode source)

- **Socket-ownership check** before connect (cmux #389): refuse a socket not owned by the current user.
- **Env var is a discovery hint, not a pin** (cmux #5146): a stale `MACTERM_SOCKET` export falls through to the well-known release/debug paths instead of bricking every already-spawned shell after an app restart. Only `--socket` pins.
- **Non-blocking connect + 250ms poll** so a dead socket file never hangs the CLI; safe-fail contract (stdout only on success; exit 0/1/2 = ok / app error / unreachable).
- Security posture: same-user only via filesystem permissions — the same boundary zmx itself uses. No token auth by design; the envelope leaves room for an `auth` field.

Gotcha worth knowing: the CLI target's `PRODUCT_NAME` is `macterm`, but `PRODUCT_MODULE_NAME` must stay `MactermCLI` — a `macterm` module collides case-insensitively with the app's `Macterm.swiftmodule` in the shared products dir and breaks the hosted test target's `@testable import`.

## Testing

- `mise run format/lint/test` green — new suites: `ControlProtocolTests` (codec round-trips, forward-compat, hand-built CLI JSON), `ControlHandlerTests` (queries + selector resolution + zmx stubs against real `AppState` with tempdir stores), `ControlSocketServerTests` (real socket round-trips, `starting` before attach, stale-file replacement, overlong-path refusal, unlink on stop).
- Verified live against the debug app: `status`, `project list`, `tab list`, `pane list --json`, `session list` (cross-checked against `zmx ls` — sessions from another running Macterm instance correctly show as unbound), `session info` hit/miss, exit-2-with-paths-tried when the app is quit, and socket unlink on quit.