### PR TITLE
Keep main-window hotkeys from firing while another window is key

### DIFF
--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -335,8 +335,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let window = note.object as? NSWindow
             MainActor.assumeIsolated {
                 guard let self, let window else { return }
+                // Settings (and other auxiliary windows) also become main —
+                // only the first window to do so is the terminal window. The
+                // responder must track that same pointer; assigning `window`
+                // unconditionally handed it the Settings window whenever
+                // Settings was frontmost, defeating its key-window gate.
                 if self.mainWindow == nil { self.mainWindow = window }
-                self.mainAppResponder?.mainWindow = window
+                self.mainAppResponder?.mainWindow = self.mainWindow
             }
         }
     }

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -137,6 +137,29 @@ final class MainAppResponder: KeyResponder {
         // into the palette would fire Cmd+T's New Tab action.
         if appState.isCommandPaletteVisible { return .passThrough }
 
+        // Everything below acts on the main terminal window's workspace.
+        // When a different window is key — Settings, an alert sheet — none of
+        // it may fire: Cmd+W would close a terminal tab behind the window the
+        // user is actually looking at. Close shortcuts retarget to the key
+        // window (the macOS convention: Cmd+W closes the key window). Pass-
+        // through alone can't provide that — the system File > Close item is
+        // replaced by our "Close Pane" (CommandGroup(replacing: .saveItem)),
+        // so the menu bar would re-route Cmd+W right back to the tab. The
+        // quick-terminal panel is exempt: QuickTerminalResponder has already
+        // claimed its slice, and the app-wide keys that fall through (project
+        // nav, new tab, …) intentionally keep working while the panel is up.
+        if let keyWindow = NSApp.keyWindow, keyWindow !== mainWindow,
+           !(keyWindow is QuickTerminalPanel)
+        {
+            if HotkeyRegistry.matches(event, action: .closePane)
+                || HotkeyRegistry.matches(event, action: .closeWindow)
+            {
+                keyWindow.performClose(nil)
+                return .handled
+            }
+            return .passThrough
+        }
+
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
         // Quick-terminal toggle. The same shortcut is also a Carbon global


### PR DESCRIPTION
## Problem

Pressing ⌘W with the Settings window frontmost closed a terminal tab behind it instead of closing Settings.

## Cause

Two faults compounded:

- `MainAppResponder` matched its hotkeys regardless of which window was key — the `KeyRouter` event monitor is app-wide, so ⌘W hit `closePane` even while Settings (or an alert sheet) was frontmost.
- The `didBecomeMain` observer unconditionally handed the responder whichever window last became main — including Settings — so the responder's notion of "the main window" was wrong exactly when a key-window check would need it.

## Fix

- `MainAppResponder` now passes through when the key window is neither the main window nor the quick-terminal panel, and retargets the close shortcuts (close pane / close window) to the key window via `performClose`. Pass-through alone can't fix this: the system File > Close item is replaced by our Close Pane (⌘W) menu item (`CommandGroup(replacing: .saveItem)`), so menu dispatch would route the keystroke right back to closing a tab.
- The observer now keeps the responder pinned to the delegate's stable main-window pointer.

## Notes

- ⌘W while a confirmation alert sheet is key now beeps instead of closing a tab behind the dialog (sheets aren't closable).
- Hotkey capture in Settings still works — the capture guard runs before the new gate, so binding ⌘W itself remains possible.
- Quick-terminal behavior is unchanged: `QuickTerminalResponder` still owns its slice, and app-wide keys keep working while the panel is up.

## Testing

- `mise run format` / `lint` / `test` all pass.
- Verified manually: ⌘W in Settings closes the Settings window; terminal tabs unaffected.