### PR TITLE
fix: open existing project when same path is selected

### DIFF
--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -563,8 +563,8 @@ final class AppState {
         logger.info("Imported legacy layout for \(project.name, privacy: .public)")
     }
 
-    /// Shows an open panel, adds the selected directory as a project, and selects it.
-    /// Returns the new project if one was created, nil if cancelled.
+    /// Shows an open panel, adds or finds the selected directory as a project,
+    /// and selects it. Returns the selected project, nil if cancelled.
     @discardableResult
     func openProject(store: ProjectStore) -> Project? {
         let panel = NSOpenPanel()
@@ -573,12 +573,10 @@ final class AppState {
         panel.allowsMultipleSelection = false
         panel.message = "Select a project folder"
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
-        let project = Project(
+        let project = store.findOrCreate(
             name: url.lastPathComponent,
-            path: url.path(percentEncoded: false),
-            sortOrder: store.projects.count
+            path: url.path(percentEncoded: false)
         )
-        store.add(project)
         selectProject(project)
         return project
     }

--- a/Macterm/App/BenchmarkControl.swift
+++ b/Macterm/App/BenchmarkControl.swift
@@ -129,12 +129,7 @@ enum BenchmarkControl {
             return
         }
         let path = ProcessInfo.processInfo.environment["MACTERM_BENCHMARK_DIR"] ?? NSHomeDirectory()
-        if let existing = projectStore.projects.first(where: { $0.path == path }) {
-            appState.selectProject(existing)
-            return
-        }
-        let project = Project(name: "Benchmark", path: path, sortOrder: projectStore.projects.count)
-        projectStore.add(project)
+        let project = projectStore.findOrCreate(name: "Benchmark", path: path)
         appState.selectProject(project)
     }
 

--- a/Macterm/Control/ControlHandler.swift
+++ b/Macterm/Control/ControlHandler.swift
@@ -195,14 +195,10 @@ final class ControlHandler {
             throw ControlError(code: .notFound, message: "no directory at \(canonical)")
         }
 
-        let project: Project
-        if let existing = projectStore.projects.first(where: { ProjectPath.canonicalLocal($0.path) == canonical }) {
-            project = existing
-        } else {
-            let name = args.name ?? (canonical as NSString).lastPathComponent
-            project = Project(name: name, path: canonical, sortOrder: projectStore.projects.count)
-            projectStore.add(project)
-        }
+        let project = projectStore.findOrCreate(
+            name: args.name ?? (canonical as NSString).lastPathComponent,
+            path: canonical
+        )
         if args.select == true {
             // selectProject runs the same first-open path the sidebar does —
             // including auto-applying a matching central project file, so a

--- a/Macterm/Palette/DirectorySource.swift
+++ b/Macterm/Palette/DirectorySource.swift
@@ -34,10 +34,6 @@ struct DirectorySource: PaletteSource {
         }
         guard fm.fileExists(atPath: dir) else { return [] }
 
-        let existingByPath = Dictionary(
-            uniqueKeysWithValues: context.projectStore.projects.map { ($0.path, $0) }
-        )
-
         var items: [PaletteItem] = []
 
         // Exact match at the top (when the typed path is itself a directory).
@@ -46,7 +42,7 @@ struct DirectorySource: PaletteSource {
             items.append(directoryItem(
                 name: name,
                 fullPath: exact,
-                existing: existingByPath[exact],
+                existing: context.projectStore.project(matchingPath: exact),
                 context: context,
                 score: 0
             ))
@@ -69,7 +65,7 @@ struct DirectorySource: PaletteSource {
                 return directoryItem(
                     name: name,
                     fullPath: full,
-                    existing: existingByPath[full],
+                    existing: context.projectStore.project(matchingPath: full),
                     context: context,
                     score: offset + 1
                 )
@@ -115,12 +111,10 @@ struct DirectorySource: PaletteSource {
             category: "Directories",
             score: 0
         ) { [appState = context.appState, projectStore = context.projectStore] in
-            let project = Project(
+            let project = projectStore.findOrCreate(
                 name: name,
-                path: spec,
-                sortOrder: projectStore.projects.count
+                path: spec
             )
-            projectStore.add(project)
             appState.selectProject(project)
         }
     }
@@ -150,12 +144,10 @@ struct DirectorySource: PaletteSource {
             category: "Directories",
             score: score
         ) { [appState = context.appState, projectStore = context.projectStore] in
-            let project = Project(
+            let project = projectStore.findOrCreate(
                 name: name,
-                path: fullPath,
-                sortOrder: projectStore.projects.count
+                path: fullPath
             )
-            projectStore.add(project)
             appState.selectProject(project)
         }
     }

--- a/Macterm/Persistence/ProjectStore.swift
+++ b/Macterm/Persistence/ProjectStore.swift
@@ -13,6 +13,20 @@ final class ProjectStore {
         load()
     }
 
+    func project(matchingPath path: String) -> Project? {
+        projects.first { ProjectPath.matches($0.path, path) }
+    }
+
+    @discardableResult
+    func findOrCreate(name: String, path: String, zmxPath: String? = nil) -> Project {
+        if let existing = project(matchingPath: path) {
+            return existing
+        }
+        let project = Project(name: name, path: path, sortOrder: projects.count, zmxPath: zmxPath)
+        add(project)
+        return project
+    }
+
     func add(_ project: Project) {
         projects.append(project)
         save()

--- a/Macterm/Views/NewRemoteProjectSheet.swift
+++ b/Macterm/Views/NewRemoteProjectSheet.swift
@@ -68,13 +68,11 @@ struct NewRemoteProjectSheet: View {
     private func add() {
         guard let path = composedPath else { return }
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
-        let project = Project(
+        let project = projectStore.findOrCreate(
             name: trimmedName.isEmpty ? host.trimmingCharacters(in: .whitespaces) : trimmedName,
             path: path,
-            sortOrder: projectStore.projects.count,
             zmxPath: trimmedZmxPath
         )
-        projectStore.add(project)
         appState.selectProject(project)
         dismiss()
     }

--- a/MactermTests/Palette/DirectorySourceTests.swift
+++ b/MactermTests/Palette/DirectorySourceTests.swift
@@ -44,6 +44,24 @@ struct DirectorySourceTests {
     // MARK: - Remote items
 
     @Test
+    func local_directory_switches_to_existing_matching_project() throws {
+        let (ctx, state, store) = makeContext()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-dir-source-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let existing = Project(name: "existing", path: dir.path + "/./", sortOrder: 0)
+        store.add(existing)
+
+        let items = DirectorySource().items(query: dir.path, context: ctx)
+        let item = try #require(items.first)
+        #expect(item.subtitle?.contains("Switch to project") == true)
+        item.action()
+
+        #expect(state.activeProjectID == existing.id)
+        #expect(store.projects.count == 1)
+    }
+
+    @Test
     func typed_remote_spec_offers_add_as_remote_project() throws {
         let (ctx, state, store) = makeContext()
         let items = DirectorySource().items(query: "devbox:~/dev/api", context: ctx)

--- a/MactermTests/Persistence/ProjectStoreTests.swift
+++ b/MactermTests/Persistence/ProjectStoreTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+@MainActor
+struct ProjectStoreTests {
+    private func makeStore() -> ProjectStore {
+        ProjectStore(fileURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-project-store-tests-\(UUID().uuidString).json"))
+    }
+
+    @Test
+    func find_or_create_reuses_canonical_local_path() {
+        let store = makeStore()
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-project-\(UUID().uuidString)", isDirectory: true)
+            .path
+        let existing = Project(name: "existing", path: base + "/./", sortOrder: 0)
+        store.add(existing)
+
+        let project = store.findOrCreate(name: "duplicate", path: base)
+
+        #expect(project.id == existing.id)
+        #expect(project.name == "existing")
+        #expect(store.projects.count == 1)
+    }
+
+    @Test
+    func find_or_create_reuses_matching_remote_path() {
+        let store = makeStore()
+        let existing = Project(name: "api", path: "devbox:~/dev/api", sortOrder: 0)
+        store.add(existing)
+
+        let project = store.findOrCreate(
+            name: "duplicate",
+            path: "devbox:~/dev/api",
+            zmxPath: "~/bin/zmx"
+        )
+
+        #expect(project.id == existing.id)
+        #expect(project.zmxPath == nil)
+        #expect(store.projects.count == 1)
+    }
+}


### PR DESCRIPTION
## What

Open existing project when same path is selected with ‘new project’ or ‘open project’.

## Why

Currently ‘+New Project’ and ‘Open Project’ menu creates a new project tab even if there is a project with same directory.

Duplicate project with same directory is a bug.

<!-- The motivation. Link the issue this closes, if any. -->

## How

Checks duplicate when a project is created with ProjectStore.findOrCreate.
<!-- The approach, and anything non-obvious a reviewer needs to follow it.
     Call out tradeoffs, framework limitations worked around, or design choices. -->

## Verified

<!-- How you confirmed this works. Tick what applies. -->

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

## Notes for reviewers

<!-- Optional: anything to flag — branch history detours, follow-ups deferred,
     screenshots / recordings for UI changes. -->
