### PR TITLE
Track the system appearance instead of reading back our own pinned one

### DIFF
--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -22,6 +22,12 @@ final class GhosttyApp {
     private var resourcesDir: String?
     @ObservationIgnored
     private var appearanceObserver: NSKeyValueObservation?
+    @ObservationIgnored
+    private var systemAppearanceObserver: (any NSObjectProtocol)?
+    /// The OS-level light/dark scheme. Split resolution must key off this —
+    /// never an `effectiveAppearance`, which our own `.preferredColorScheme`
+    /// pins, latching the theme after one system switch (issue #144).
+    private(set) var systemScheme: ThemeResolver.Scheme = .light
     /// Chrome colors as libghostty resolved them for a live surface — the
     /// active `theme = light:X,dark:Y` side already applied. Populated from
     /// `GHOSTTY_ACTION_CONFIG_CHANGE` (see `adoptResolvedColors`) and preferred
@@ -31,6 +37,7 @@ final class GhosttyApp {
     private var resolvedColors: ResolvedColors?
 
     private init() {
+        systemScheme = Self.readSystemScheme()
         resolveResources()
         guard ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv) == GHOSTTY_SUCCESS else {
             logger.error("ghostty_init failed")
@@ -75,31 +82,63 @@ final class GhosttyApp {
         RunLoop.main.add(timer, forMode: .common)
         tickTimer = timer
 
-        // React to system light/dark switches. The chrome colors derive from
-        // the appearance-resolved `theme = light:X,dark:Y` side (issue #38), so
-        // they change with the OS appearance — but they read `NSApp` and theme
-        // files, not observable state, so SwiftUI won't recompute on its own.
-        // On each change we bump `configVersion` (observed by the root view) and
-        // post `.mactermConfigDidChange` so the chrome re-reads MactermTheme.
-        // Terminal surfaces handle their own switch via
-        // viewDidChangeEffectiveAppearance.
+        // React to system light/dark switches. Two triggers: the KVO goes
+        // silent once our own preferredColorScheme pins the app's appearance
+        // (issue #144); the distributed notification always fires.
         //
         // Deferred off the init stack: observing `NSApp.effectiveAppearance`
-        // (or the first callback it may fire) can re-enter `GhosttyApp.shared`
-        // while this `static let` is still initializing, deadlocking its
+        // can re-enter `GhosttyApp.shared` mid-init, deadlocking its
         // dispatch_once.
         DispatchQueue.main.async { [weak self] in
-            self?.appearanceObserver = NSApp.observe(\.effectiveAppearance, options: [.new]) { _, _ in
-                MainActor.assumeIsolated { GhosttyApp.shared.appearanceDidChange() }
+            guard let self else { return }
+            appearanceObserver = NSApp.observe(\.effectiveAppearance, options: [.new]) { _, _ in
+                MainActor.assumeIsolated { GhosttyApp.shared.systemAppearanceMayHaveChanged() }
+            }
+            systemAppearanceObserver = DistributedNotificationCenter.default().addObserver(
+                forName: Notification.Name("AppleInterfaceThemeChangedNotification"),
+                object: nil,
+                queue: .main
+            ) { _ in
+                MainActor.assumeIsolated { GhosttyApp.shared.systemAppearanceMayHaveChanged() }
             }
         }
     }
 
-    /// Bump the observable version so SwiftUI re-reads appearance-derived theme
-    /// colors, and notify AppKit chrome (window tint) to re-sync.
-    private func appearanceDidChange() {
+    /// Re-resolve everything appearance-derived against the new system scheme.
+    /// Deduped — an ordinary (unpinned) switch fires both observers.
+    private func systemAppearanceMayHaveChanged() {
+        let scheme = Self.readSystemScheme()
+        guard scheme != systemScheme else { return }
+        systemScheme = scheme
+        logger.info("system appearance changed: \(scheme == .dark ? "dark" : "light", privacy: .public)")
+
+        // A window held by preferredColorScheme never delivers
+        // viewDidChangeEffectiveAppearance — push the scheme to surfaces
+        // directly; each push re-emits CONFIG_CHANGE with the new side.
+        for view in GhosttyTerminalNSView.allLiveViews() {
+            view.syncColorScheme()
+        }
+        // Stale until those re-emits land (and no surface may be alive to
+        // emit) — fall back to the theme file meanwhile.
+        resolvedColors = nil
+
         configVersion += 1
         NotificationCenter.default.post(name: .mactermConfigDidChange, object: nil)
+    }
+
+    /// Inputs for `ThemeResolver.systemScheme` (the tested decision logic).
+    /// CFPreferences because `AppleInterfaceStyle` is OS global-domain state,
+    /// not app state.
+    private static func readSystemScheme() -> ThemeResolver.Scheme {
+        let style = CFPreferencesCopyAppValue(
+            "AppleInterfaceStyle" as CFString,
+            kCFPreferencesAnyApplication
+        ) as? String
+        return ThemeResolver.systemScheme(
+            appHasAppearanceOverride: NSApp.appearance != nil,
+            effectiveAppearanceIsDark: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua,
+            globalInterfaceStyle: style
+        )
     }
 
     func tick() {
@@ -371,7 +410,7 @@ final class GhosttyApp {
             configText += "\n" + userText
         }
         guard let themeValue = ThemeResolver.themeValue(inConfigText: configText),
-              let side = ThemeResolver.resolve(themeValue: themeValue, scheme: currentScheme)
+              let side = ThemeResolver.resolve(themeValue: themeValue, scheme: systemScheme)
         else { return nil }
 
         // A theme value is either a bare name (resolved against the bundled
@@ -383,10 +422,6 @@ final class GhosttyApp {
                 : resourcesDir + "/themes/" + side
         guard let themeText = try? String(contentsOfFile: themeFile, encoding: .utf8) else { return nil }
         return ThemeResolver.colors(inThemeFile: themeText)
-    }
-
-    private var currentScheme: ThemeResolver.Scheme {
-        NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light
     }
 
     // MARK: - Surface-resolved chrome colors (Ghostty's CONFIG_CHANGE pattern)

--- a/Macterm/Ghostty/ThemeResolver.swift
+++ b/Macterm/Ghostty/ThemeResolver.swift
@@ -20,6 +20,21 @@ enum ThemeResolver {
         case dark
     }
 
+    /// The *system* scheme from raw inputs (pure, for tests). A pinned app's
+    /// effective appearance echoes our own `preferredColorScheme` (issue
+    /// #144), so it's trusted only unpinned; otherwise the OS-maintained
+    /// `AppleInterfaceStyle` global default ("Dark"/absent) decides.
+    static func systemScheme(
+        appHasAppearanceOverride: Bool,
+        effectiveAppearanceIsDark: Bool,
+        globalInterfaceStyle: String?
+    ) -> Scheme {
+        guard appHasAppearanceOverride else {
+            return effectiveAppearanceIsDark ? .dark : .light
+        }
+        return globalInterfaceStyle?.caseInsensitiveCompare("Dark") == .orderedSame ? .dark : .light
+    }
+
     /// The subset of theme-file colors Macterm's chrome needs.
     struct Colors: Equatable {
         var background: String?

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -326,8 +326,7 @@ final class GhosttyTerminalNSView: NSView {
             NotificationCenter.default.post(name: .zmxSessionsChanged, object: nil)
         }
 
-        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
+        syncColorScheme()
 
         if let screen = window?.screen ?? NSScreen.main,
            let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? UInt32
@@ -471,8 +470,15 @@ final class GhosttyTerminalNSView: NSView {
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
+        syncColorScheme()
+    }
+
+    /// Push the split-resolution scheme into libghostty — keyed off the
+    /// tracked system scheme, never this view's `effectiveAppearance`, which
+    /// our own preferredColorScheme pins (issue #144).
+    func syncColorScheme() {
         guard let surface else { return }
-        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let isDark = GhosttyApp.shared.systemScheme == .dark
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
     }
 

--- a/MactermTests/Ghostty/ThemeResolverTests.swift
+++ b/MactermTests/Ghostty/ThemeResolverTests.swift
@@ -114,4 +114,39 @@ struct ThemeResolverTests {
         let text = "# background = #ffffff\nbackground = #000000\n"
         #expect(ThemeResolver.colors(inThemeFile: text).background == "#000000")
     }
+
+    // MARK: - systemScheme(appHasAppearanceOverride:effectiveAppearanceIsDark:globalInterfaceStyle:)
+
+    @Test
+    func unpinned_app_trusts_effective_appearance() {
+        #expect(ThemeResolver.systemScheme(
+            appHasAppearanceOverride: false, effectiveAppearanceIsDark: true, globalInterfaceStyle: nil
+        ) == .dark)
+        #expect(ThemeResolver.systemScheme(
+            appHasAppearanceOverride: false, effectiveAppearanceIsDark: false, globalInterfaceStyle: "Dark"
+        ) == .light)
+    }
+
+    @Test
+    func pinned_app_ignores_its_own_effective_appearance() {
+        // The latch in issue #144: the app pinned itself dark, the system went
+        // back to light. The echoed effective appearance must lose to the
+        // OS-maintained global default (absent = light).
+        #expect(ThemeResolver.systemScheme(
+            appHasAppearanceOverride: true, effectiveAppearanceIsDark: true, globalInterfaceStyle: nil
+        ) == .light)
+        #expect(ThemeResolver.systemScheme(
+            appHasAppearanceOverride: true, effectiveAppearanceIsDark: false, globalInterfaceStyle: "Dark"
+        ) == .dark)
+    }
+
+    @Test
+    func interface_style_compares_case_insensitively() {
+        #expect(ThemeResolver.systemScheme(
+            appHasAppearanceOverride: true, effectiveAppearanceIsDark: false, globalInterfaceStyle: "dark"
+        ) == .dark)
+        #expect(ThemeResolver.systemScheme(
+            appHasAppearanceOverride: true, effectiveAppearanceIsDark: false, globalInterfaceStyle: "Light"
+        ) == .light)
+    }
 }


### PR DESCRIPTION
Fixes #144.

## Problem

With a `theme = light:X,dark:Y` split, toggling the system appearance flipped Macterm once — and then it latched. Dark → light never came back.

## Cause

A feedback loop. `AppColorScheme` applies `.preferredColorScheme` derived from the *resolved theme*, which holds the window appearance (and on newer macOS, the app's). But every input to theme resolution read that same appearance back:

- the change detector was a KVO on `NSApp.effectiveAppearance`, which goes silent once the appearance is pinned;
- chrome split resolution (`currentScheme`) read `NSApp.effectiveAppearance`;
- surfaces re-derived their split side only in `viewDidChangeEffectiveAppearance`, which a window held by our own `preferredColorScheme` never delivers.

After one switch, every input echoed our own output and nothing re-resolved.

## Fix

Break the cycle at both ends:

- **Detection**: `GhosttyApp` now tracks the OS-level scheme. The decision logic is pure and tested (`ThemeResolver.systemScheme`): trust `effectiveAppearance` only while no app-level override is pinned (this also tracks "Auto" mode precisely); otherwise read the global-domain `AppleInterfaceStyle` default via CFPreferences, which nothing the app pins can shadow. A `DistributedNotificationCenter` observer for `AppleInterfaceThemeChangedNotification` joins the existing KVO — the OS posts it on every toggle regardless of pinning. Handling is deduped on the resolved scheme since an unpinned switch fires both.
- **Application**: surfaces key `ghostty_surface_set_color_scheme` off the tracked system scheme (creation + `viewDidChangeEffectiveAppearance` re-assert), and on a system switch the scheme is pushed to every live surface directly. Each push soft-reloads config and re-emits `CONFIG_CHANGE`, refreshing the chrome's `resolvedColors` with the new side; the stale snapshot is dropped up front so color accessors fall back to the theme file for the new scheme in the interim (also covers the zero-surface case).

A `system appearance changed: dark|light` log line (subsystem `GhosttyApp`) makes future diagnosis of this class of bug one `mise run logs` away.

## Testing

- New unit tests for the pure scheme decision (`ThemeResolverTests`), including the exact #144 latch case (app pinned dark, system back to light, global default absent → light).
- `mise run format` / `lint` / `test` all pass (one unrelated flaky failure in `AppStateTests.closePane_kills_only_that_panes_session` on a single run; passes on re-run and is untouched by this change).
- Not yet verified live on macOS 27 beta (the reporter's environment)