### PR TITLE
Pin the website footer to the viewport bottom on short pages

### DIFF
--- a/website/src/tailwind.css
+++ b/website/src/tailwind.css
@@ -66,6 +66,11 @@
   body {
     background: var(--color-canvas);
     color: var(--color-ink);
+    /* Sticky footer: lay the page out as a column so the footer can be pushed
+       to the bottom of the viewport on short pages (see .site-footer). Pairs
+       with the min-h-screen utility already on <body>. */
+    display: flex;
+    flex-direction: column;
   }
 
   ::selection {
@@ -264,6 +269,9 @@
     padding: 28px var(--site-gutter);
     font-size: 13px;
     border-top: 1px solid rgba(23, 21, 15, 0.14);
+    /* Take up the slack in the body flex column so a short page still drops the
+       footer to the bottom of the viewport. */
+    margin-top: auto;
   }
   .site-footer nav {
     display: flex;


### PR DESCRIPTION
## What

Fix the website footer riding up under the content on short pages instead of sitting at the bottom of the viewport.

`<body>` already had `min-h-screen`, but the page (`nav` + content + `footer`) had no layout to distribute the leftover vertical space, so on short pages — most docs pages — the footer sat directly beneath a short paragraph with empty canvas below it.

## How

Standard sticky-footer pattern, CSS-only in `website/src/tailwind.css`:

- `body` → `display: flex; flex-direction: column` (pairs with the existing `min-h-screen` utility)
- `.site-footer` → `margin-top: auto`, absorbing the slack so the footer drops to the viewport bottom

Shared across the landing page and all docs pages — no HTML changes.

## Verification

Served `website/public` and checked layout via the browser preview:

- **Short docs page** (Quick terminal): footer's bottom edge lands exactly at 100vh (1138px), with `margin-top` auto-resolving to ~140px of slack. Gap now sits between content and footer instead of below the footer.
- **Landing page** (long, scrolling): `margin-top` resolves to `0px`, page scrolls unchanged — no regression.
- No console errors.

Note: `website/public/tailwind.css` is a gitignored build artifact regenerated by `bun run build`; only the `src` source is committed.