### PR TITLE
Add a settings slider for unfocused split pane dimming

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -75,6 +75,12 @@ final class Preferences {
         didSet { defaults.set(terminalScrollSpeed, forKey: Keys.terminalScrollSpeed) }
     }
 
+    /// How dark the overlay on an unfocused split pane gets (0–0.8, 0 = no dimming).
+    /// Capped below 1 so an unfocused pane is never fully black.
+    var paneDimOpacity: Double {
+        didSet { defaults.set(paneDimOpacity, forKey: Keys.paneDimOpacity) }
+    }
+
     // MARK: - Sidebar icons
 
     var projectIconSymbol: String {
@@ -128,6 +134,9 @@ final class Preferences {
         numberIconSquare,
         numberIconPlain,
     ]
+
+    /// Upper bound for `paneDimOpacity` — a fully black overlay reads as broken, not dim.
+    static let maxPaneDimOpacity: Double = 0.8
 
     /// Curated SF Symbols offered in Settings — keeps users from typing invalid names.
     static let projectIconChoices: [String] = [
@@ -291,6 +300,9 @@ final class Preferences {
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
         eagerlyStartProjectTabs = (defaults.object(forKey: Keys.eagerlyStartProjectTabs) as? Bool) ?? true
         terminalScrollSpeed = Self.clampScrollSpeed(defaults.double(forKey: Keys.terminalScrollSpeed), fallback: 1.0)
+        paneDimOpacity = Self.clampPaneDimOpacity(
+            (defaults.object(forKey: Keys.paneDimOpacity) as? Double) ?? 0.2
+        )
         windowOpacity = (defaults.object(forKey: Keys.windowOpacity) as? Double) ?? 1.0
         windowBlurRadius = defaults.integer(forKey: Keys.windowBlurRadius)
         windowGlassEnabled = defaults.object(forKey: Keys.windowGlassEnabled) as? Bool ?? false
@@ -314,6 +326,10 @@ final class Preferences {
     private static func clampFraction(_ v: Double, fallback: Double) -> Double {
         guard v > 0 else { return fallback }
         return max(0.2, min(1.0, v))
+    }
+
+    private static func clampPaneDimOpacity(_ v: Double) -> Double {
+        max(0.0, min(maxPaneDimOpacity, v))
     }
 
     private static func clampScrollSpeed(_ v: Double, fallback: Double) -> Double {
@@ -342,6 +358,7 @@ final class Preferences {
         static let autoTiling = "macterm.autoTiling.enabled"
         static let eagerlyStartProjectTabs = "macterm.eagerlyStartProjectTabs.enabled"
         static let terminalScrollSpeed = "macterm.terminal.scrollSpeed"
+        static let paneDimOpacity = "macterm.pane.dimOpacity"
         static let windowOpacity = "macterm.window.opacity"
         static let windowBlurRadius = "macterm.window.blurRadius"
         static let windowGlassEnabled = "macterm.window.glassEnabled"

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -248,6 +248,8 @@ private struct AppearanceSettings: View {
     private var liquidGlass: Bool = Preferences.shared.windowGlassEnabled
     @State
     private var liquidGlassStyle: WindowGlassStyle = Preferences.shared.windowGlassStyle
+    @State
+    private var paneDimOpacity: Double = Preferences.shared.paneDimOpacity
 
     var body: some View {
         Form {
@@ -292,6 +294,23 @@ private struct AppearanceSettings: View {
                 .disabled(backgroundOpacity >= 0.999 || liquidGlass)
 
                 Text(blurFootnote)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Split Panes") {
+                HStack {
+                    Text("Unfocused dimming")
+                        .frame(width: sliderLabelWidth, alignment: .leading)
+                    Slider(value: $paneDimOpacity, in: 0.0 ... Preferences.maxPaneDimOpacity)
+                    Text("\(Int((paneDimOpacity / Preferences.maxPaneDimOpacity * 100).rounded()))%")
+                        .monospacedDigit()
+                        .frame(width: 42, alignment: .trailing)
+                }
+                .onChange(of: paneDimOpacity) { _, v in
+                    Preferences.shared.paneDimOpacity = v
+                }
+                Text("How dark unfocused panes get in a split layout.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }

--- a/Macterm/Views/SplitTreeView.swift
+++ b/Macterm/Views/SplitTreeView.swift
@@ -135,7 +135,7 @@ private struct SplitLeafView: View {
             )
             .overlay {
                 if !isFocused, isSplit {
-                    Color.black.opacity(0.2)
+                    Color.black.opacity(Preferences.shared.paneDimOpacity)
                         .allowsHitTesting(false)
                 }
             }


### PR DESCRIPTION
## Summary
- Unfocused-pane dimming was a hardcoded `Color.black.opacity(0.2)` overlay in `SplitTreeView`. Added `Preferences.paneDimOpacity` and an "Unfocused dimming" slider under Settings → Appearance → Split Panes so users can tune or disable it.
- Capped the value at 0.8 (`Preferences.maxPaneDimOpacity`) so a fully black overlay isn't reachable; the slider still displays 0–100%, rescaled against that cap.

## Test plan
- [x] `mise run test --verbose`
- [x] `mise run lint --verbose`