### PR TITLE
Add a Copy Session ID action for handing a pane's zmx name to an LLM

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -29,6 +29,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
     case resizeRight
     case resizeUp
     case resizeDown
+    case copySessionID
     // Projects
     case openProject
     case newRemoteProject
@@ -72,6 +73,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .resizeRight: "Resize Pane Right"
         case .resizeUp: "Resize Pane Up"
         case .resizeDown: "Resize Pane Down"
+        case .copySessionID: "Copy Session ID"
         case .openProject: "Open Project"
         case .newRemoteProject: "New Remote Project"
         case .renameProject: "Rename Current Project"
@@ -112,7 +114,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
              .resizeLeft,
              .resizeRight,
              .resizeUp,
-             .resizeDown: .panes
+             .resizeDown,
+             .copySessionID: .panes
         case .openProject,
              .newRemoteProject,
              .renameProject,
@@ -165,6 +168,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .toggleQuickTerminal: .toggleQuickTerminal
         case .renameTab: .renameTab
         case .renameProject: .renameProject
+        case .copySessionID: .copySessionID
         case .newRemoteProject,
              .unloadProject,
              .removeProject,

--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -92,6 +92,17 @@ extension AppCommand {
         case .resizeDown:
             guard let projectID else { return nil }
             return { ctx.appState.resizePane(.down, projectID: projectID) }
+        case .copySessionID:
+            // The focused pane's zmx session name (`macterm-<slug>-<hex>`) — the
+            // id `macterm session list` prints and `zmx attach` takes. Useful for
+            // pointing an LLM at a pane's live output. Copies silently, matching
+            // the sidebar's "Copy Path".
+            guard let projectID, let pane = ctx.appState.focusedPane(for: projectID) else { return nil }
+            let sessionName = pane.sessionName
+            return {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(sessionName, forType: .string)
+            }
         case .openProject:
             return { _ = ctx.appState.openProject(store: ctx.projectStore) }
         case .newRemoteProject:

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -38,6 +38,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
     case toggleQuickTerminal = "toggle_quick_terminal"
     case renameTab = "rename_tab"
     case renameProject = "rename_project"
+    case copySessionID = "copy_session_id"
 
     var id: String { rawValue }
 
@@ -78,6 +79,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .toggleQuickTerminal: "ctrl+`"
         case .renameTab: "cmd+r"
         case .renameProject: "none"
+        case .copySessionID: "none"
         }
     }
 }

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -147,6 +147,13 @@ struct MactermApp: App {
                 CheckForUpdatesMenuItem()
             }
             CommandGroup(replacing: .saveItem) {
+                AppCommandMenuItem(
+                    command: .copySessionID,
+                    appState: appState,
+                    projectStore: projectStore,
+                    titleOverride: "Copy Session ID"
+                )
+                Divider()
                 AppCommandMenuItem(command: .closePane, appState: appState, projectStore: projectStore, titleOverride: "Close Pane")
                 AppCommandMenuItem(command: .closeWindow, appState: appState, projectStore: projectStore, titleOverride: "Close Window")
             }

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -284,11 +284,12 @@ final class MainAppResponder: KeyResponder {
             return .handled
         }
 
-        // Rename routes through AppCommand.action(in:) — the single source of
-        // truth shared with the palette and menu bar — so the three paths can't
-        // drift. The action defers begin-editing a tick (see AppCommandActions)
-        // so the sidebar row's TextField exists before it takes first responder.
-        for action in [HotkeyAction.renameTab, .renameProject] {
+        // These route through AppCommand.action(in:) — the single source of
+        // truth shared with the palette and menu bar — so the paths can't drift.
+        // Rename defers begin-editing a tick (see AppCommandActions) so the
+        // sidebar row's TextField exists before it takes first responder;
+        // copySessionID writes the focused pane's zmx name to the pasteboard.
+        for action in [HotkeyAction.renameTab, .renameProject, .copySessionID] {
             guard HotkeyRegistry.matches(event, action: action),
                   let command = AppCommand.allCases.first(where: { $0.hotkeyAction == action })
             else { continue }

--- a/MactermTests/App/HotkeysTests.swift
+++ b/MactermTests/App/HotkeysTests.swift
@@ -312,6 +312,16 @@ struct HotkeysTests {
     }
 
     @Test
+    func copySessionID_is_unbound_by_default_and_titled_from_command() {
+        // Ships unbound (opt-in via Settings → Keymaps) — a copy action has no
+        // conventional shortcut, and picking one risks shadowing a user binding.
+        #expect(HotkeyAction.copySessionID.defaultShortcut == "none")
+        // Title flows from the owning AppCommand, so the two can't drift.
+        #expect(HotkeyAction.copySessionID.title == "Copy Session ID")
+        #expect(AppCommand.copySessionID.hotkeyAction == .copySessionID)
+    }
+
+    @Test
     func all_action_ids_are_unique() {
         let ids = HotkeyAction.allCases.map(\.rawValue)
         #expect(ids.count == Set(ids).count)


### PR DESCRIPTION
## What

Adds a **Copy Session ID** action that copies the focused pane's zmx session name to the clipboard, available in the command palette, the File menu, and as a rebindable keyboard shortcut.

## Why

The zmx session name (`macterm-<slug>-<hex>`) is the id `macterm session list` prints and `zmx attach` takes, so it's the handle you paste when pointing an LLM (or another shell) at a pane's live output. Until now the only way to get it was the CLI.

Closes #159

## How

Follows the standard `AppCommand` recipe end to end, so the palette, menu, and hotkey all read from one source and can't drift:

- `AppCommand.copySessionID` — case + title ("Copy Session ID") + `.panes` category + link to a new `copySessionID` `HotkeyAction`.
- Handler in `AppCommandActions`: guards on a focused pane and copies `pane.sessionName` verbatim to the general pasteboard.
- Dispatched via the existing shared `action(in:)` loop in `MainAppResponder` (the same path rename uses), not a new bespoke `if` block.
- Menu item in the File group, above Close Pane.

Design choices worth flagging:

- **Uses `sessionName`** — the same value works for a remote pane, whose session lives on the host under that name.
- **Copies silently**, matching the sidebar's existing "Copy Path". There's no toast/HUD mechanism in the app and I didn't add one for a single action.
- **Ships unbound (`none`)** — a copy action has no conventional shortcut and binding one risks shadowing a user's key; it's opt-in via Settings → Keymaps.
- **Hides when no pane is focused** (`action(in:)` returns nil) — consistent with the other pane commands.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`); confirmed via the control CLI that the value the action reads is the focused pane's real session id (`macterm-huddle-5d70b3db2d04`), and that the palette (`CommandSource`) and menu pick the command up automatically via `AppCommand.allCases`
- [x] Added a `HotkeysTests` case locking the default-unbound binding and the title→command mapping

## Notes for reviewers

While wiring this I noticed `MainAppResponder.handle` still hand-lists ~20 near-identical `HotkeyRegistry.matches(...)` blocks even though `action(in:)` can already run all of them — the `for action in [.renameTab, .renameProject, .copySessionID]` loop this PR extends is the start of a migration away from that. Folding the plain blocks into a single `AppCommand.allCases` loop (leaving the special-cased ones — close→key-window retargeting, quick-terminal post, Cmd+N, Cmd+1-9) would make future actions a two-file change. Left out of scope here; happy to do it as a follow-up.