### PR TITLE
Fix panes failing to spawn from trailing-slash project paths (fatal under nushell; blank prompt dir under zsh)

### DIFF
--- a/Macterm/Model/ProjectPath.swift
+++ b/Macterm/Model/ProjectPath.swift
@@ -98,6 +98,18 @@ enum ProjectPath: Equatable {
         return standardized
     }
 
+    /// Storage form of a raw project path: local paths canonicalized (tilde
+    /// expanded, `.`/`..` standardized, trailing slash stripped); remote specs
+    /// and unparseable strings pass through verbatim. A stored trailing slash
+    /// would otherwise reach the spawned shell's `$PWD` verbatim — zsh adopts
+    /// the inherited value when it names the cwd, and `%c`/`%1~` render the
+    /// empty last component of `/path/dir/`, blanking the prompt's directory
+    /// segment until the first `cd`.
+    static func normalizedForStorage(_ raw: String) -> String {
+        if case let .local(path)? = parse(raw) { return canonicalLocal(path) }
+        return raw
+    }
+
     /// Convenience for call sites holding a raw path string (`Project.path`,
     /// `Pane.projectPath` — the remote spec travels and persists as a string).
     static func isRemote(_ raw: String) -> Bool {

--- a/Macterm/Model/ProjectPath.swift
+++ b/Macterm/Model/ProjectPath.swift
@@ -101,10 +101,13 @@ enum ProjectPath: Equatable {
     /// Storage form of a raw project path: local paths canonicalized (tilde
     /// expanded, `.`/`..` standardized, trailing slash stripped); remote specs
     /// and unparseable strings pass through verbatim. A stored trailing slash
-    /// would otherwise reach the spawned shell's `$PWD` verbatim — zsh adopts
-    /// the inherited value when it names the cwd, and `%c`/`%1~` render the
-    /// empty last component of `/path/dir/`, blanking the prompt's directory
-    /// segment until the first `cd`.
+    /// would otherwise reach the spawned shell's `$PWD` verbatim (libghostty
+    /// exports its `working_directory` string into the child env unmodified),
+    /// and that is FATAL under nushell: nu refuses to start ("$env.PWD
+    /// contains trailing slashes", nu-protocol `engine_state.rs`), so the
+    /// pane dies in ~150ms on ghostty's abnormal-exit screen. zsh survives
+    /// but renders `%c`/`%1~` of `/path/dir/` as the empty last component,
+    /// blanking the prompt's directory segment until the first `cd`.
     static func normalizedForStorage(_ raw: String) -> String {
         if case let .local(path)? = parse(raw) { return canonicalLocal(path) }
         return raw

--- a/Macterm/Persistence/ProjectStore.swift
+++ b/Macterm/Persistence/ProjectStore.swift
@@ -33,6 +33,8 @@ final class ProjectStore {
     }
 
     func add(_ project: Project) {
+        var project = project
+        project.path = ProjectPath.normalizedForStorage(project.path)
         projects.append(project)
         save()
     }
@@ -50,8 +52,9 @@ final class ProjectStore {
 
     func setPath(id: UUID, to newPath: String) {
         guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
-        guard projects[index].path != newPath else { return }
-        projects[index].path = newPath
+        let normalized = ProjectPath.normalizedForStorage(newPath)
+        guard projects[index].path != normalized else { return }
+        projects[index].path = normalized
         save()
     }
 
@@ -93,6 +96,12 @@ final class ProjectStore {
         do {
             projects = try JSONDecoder().decode([Project].self, from: data)
             projects.sort { $0.sortOrder < $1.sortOrder }
+            // Migrate paths stored before normalization existed (e.g. with the
+            // trailing slash `URL.path(percentEncoded:)` keeps on directories).
+            // In-memory only; the cleaned form persists on the next mutation.
+            for i in projects.indices {
+                projects[i].path = ProjectPath.normalizedForStorage(projects[i].path)
+            }
         } catch {
             // Present but undecodable — a corrupt entry or a future format.
             // Preserve the file: refuse to overwrite it until this session

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -265,12 +265,19 @@ final class GhosttyTerminalNSView: NSView {
                 config.command = cString(sshCommand)
             }
         } else {
-            // Canonicalize (trailing slash stripped): libghostty exports this
-            // verbatim as the shell's $PWD, and zsh renders `%c`/`%1~` of a
-            // trailing-slash $PWD as empty — a blank prompt directory until
-            // the first `cd`. Restored panes may still carry a slashed path
-            // persisted before ProjectStore normalized on load.
-            config.working_directory = cString(ProjectPath.canonicalLocal(workingDirectory))
+            // Canonicalize before libghostty sees it: the string is exported
+            // VERBATIM as the shell's $PWD, and a trailing slash there is
+            // fatal under nushell — nu refuses to start ("$env.PWD contains
+            // trailing slashes"), killing the pane in ~150ms on ghostty's
+            // abnormal-exit screen (the chdir itself is fine; only the string
+            // in the env matters). zsh merely blanks its `%c`/`%1~` prompt
+            // segment. This is the last line of defense: it covers panes
+            // restored from snapshots persisted before ProjectStore
+            // normalized on load, and any other path source (layout `cwd:`,
+            // split inheritance). `normalizedForStorage`, not bare
+            // `canonicalLocal`, so a non-local-shaped string passes through
+            // untouched instead of being coerced relative to the app's cwd.
+            config.working_directory = cString(ProjectPath.normalizedForStorage(workingDirectory))
 
             // Shell binary → the surface's program. nil falls back to libghostty's
             // own resolution (which honors the user's ghostty config / login shell).

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -265,7 +265,12 @@ final class GhosttyTerminalNSView: NSView {
                 config.command = cString(sshCommand)
             }
         } else {
-            config.working_directory = cString(workingDirectory)
+            // Canonicalize (trailing slash stripped): libghostty exports this
+            // verbatim as the shell's $PWD, and zsh renders `%c`/`%1~` of a
+            // trailing-slash $PWD as empty — a blank prompt directory until
+            // the first `cd`. Restored panes may still carry a slashed path
+            // persisted before ProjectStore normalized on load.
+            config.working_directory = cString(ProjectPath.canonicalLocal(workingDirectory))
 
             // Shell binary → the surface's program. nil falls back to libghostty's
             // own resolution (which honors the user's ghostty config / login shell).

--- a/MactermTests/Model/ProjectPathTests.swift
+++ b/MactermTests/Model/ProjectPathTests.swift
@@ -90,6 +90,22 @@ struct ProjectPathTests {
     }
 
     @Test
+    func normalized_for_storage_canonicalizes_local_paths() {
+        // A stored trailing slash reaches the spawned shell's $PWD verbatim
+        // and blanks zsh's `%c`/`%1~` prompt segment until the first `cd`.
+        let home = ProjectPath.currentHome
+        #expect(ProjectPath.normalizedForStorage("/a/b/") == "/a/b")
+        #expect(ProjectPath.normalizedForStorage("~/dev/") == "\(home)/dev")
+        #expect(ProjectPath.normalizedForStorage("/a/b") == "/a/b")
+    }
+
+    @Test
+    func normalized_for_storage_passes_remote_and_invalid_through() {
+        #expect(ProjectPath.normalizedForStorage("devbox:~/dev/api/") == "devbox:~/dev/api/")
+        #expect(ProjectPath.normalizedForStorage("relative/path") == "relative/path")
+    }
+
+    @Test
     func canonical_does_not_resolve_symlinks() throws {
         let fm = FileManager.default
         let base = fm.temporaryDirectory

--- a/MactermTests/Model/ProjectPathTests.swift
+++ b/MactermTests/Model/ProjectPathTests.swift
@@ -91,12 +91,27 @@ struct ProjectPathTests {
 
     @Test
     func normalized_for_storage_canonicalizes_local_paths() {
-        // A stored trailing slash reaches the spawned shell's $PWD verbatim
-        // and blanks zsh's `%c`/`%1~` prompt segment until the first `cd`.
+        // A stored trailing slash reaches the spawned shell's $PWD verbatim.
+        // Fatal under nushell (nu refuses to start: "$env.PWD contains
+        // trailing slashes" — the pane dies on ghostty's abnormal-exit
+        // screen); cosmetic under zsh (blank `%c`/`%1~` prompt segment).
         let home = ProjectPath.currentHome
         #expect(ProjectPath.normalizedForStorage("/a/b/") == "/a/b")
         #expect(ProjectPath.normalizedForStorage("~/dev/") == "\(home)/dev")
         #expect(ProjectPath.normalizedForStorage("/a/b") == "/a/b")
+    }
+
+    @Test
+    func normalized_for_storage_kills_every_noncanonical_form() {
+        // Everything handed to libghostty's `working_directory` becomes the
+        // child's $PWD string. nushell validates that string strictly, so no
+        // non-canonical form may survive normalization — not just the plain
+        // trailing slash the open panel produces.
+        #expect(ProjectPath.normalizedForStorage("/a/b//") == "/a/b")
+        #expect(ProjectPath.normalizedForStorage("/a//b/") == "/a/b")
+        #expect(ProjectPath.normalizedForStorage("/a/./b/") == "/a/b")
+        #expect(ProjectPath.normalizedForStorage("/a/b/c/../") == "/a/b")
+        #expect(ProjectPath.normalizedForStorage("~/") == ProjectPath.currentHome)
     }
 
     @Test

--- a/MactermTests/Persistence/ProjectStoreTests.swift
+++ b/MactermTests/Persistence/ProjectStoreTests.swift
@@ -90,7 +90,7 @@ struct ProjectStoreTests {
         #expect(store.projects.map(\.sortOrder) == [0, 1, 2])
     }
 
-    // MARK: - Path normalization (a trailing slash in stored paths reaches $PWD and blanks zsh's `%c` prompt)
+    // MARK: - Path normalization (a stored trailing slash reaches $PWD verbatim: fatal under nushell — the pane fails to spawn — and blanks zsh's `%c` prompt)
 
     @Test
     func add_strips_trailing_slash_from_local_path() {

--- a/MactermTests/Persistence/ProjectStoreTests.swift
+++ b/MactermTests/Persistence/ProjectStoreTests.swift
@@ -90,6 +90,45 @@ struct ProjectStoreTests {
         #expect(store.projects.map(\.sortOrder) == [0, 1, 2])
     }
 
+    // MARK: - Path normalization (a trailing slash in stored paths reaches $PWD and blanks zsh's `%c` prompt)
+
+    @Test
+    func add_strips_trailing_slash_from_local_path() {
+        let store = makeStore()
+        store.add(Project(name: "junk", path: "/tmp/junk/", sortOrder: 0))
+        #expect(store.projects.first?.path == "/tmp/junk")
+    }
+
+    @Test
+    func add_leaves_remote_path_verbatim() {
+        let store = makeStore()
+        store.add(Project(name: "api", path: "devbox:~/dev/api/", sortOrder: 0))
+        #expect(store.projects.first?.path == "devbox:~/dev/api/")
+    }
+
+    @Test
+    func setPath_normalizes_the_new_path() {
+        let store = makeStore()
+        let p = Project(name: "x", path: "/tmp/before", sortOrder: 0)
+        store.add(p)
+        store.setPath(id: p.id, to: "/tmp/after/")
+        #expect(store.projects.first { $0.id == p.id }?.path == "/tmp/after")
+    }
+
+    @Test
+    func load_migrates_paths_stored_with_trailing_slashes() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-project-store-migrate-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        // Write the legacy on-disk form directly — the store's own mutators
+        // normalize now, so a pre-fix file has to be crafted by hand.
+        let legacy = Project(name: "legacy", path: "/tmp/legacy/", sortOrder: 0)
+        try JSONEncoder().encode([legacy]).write(to: fileURL)
+
+        let store = makeStore(fileURL: fileURL)
+        #expect(store.projects.first?.path == "/tmp/legacy")
+    }
+
     // MARK: - On-disk round-trip
 
     @Test


### PR DESCRIPTION
## What

New panes in a local project spawn with a blank directory in the zsh prompt until the first `cd`. Cause: project paths are stored with a trailing slash. This PR strips it.

**Before → after** (first prompt in a fresh pane):

```
➜                          ➜  my-project
➜  git:(main)              ➜  my-project git:(main)
```

## Why it happens

```
Open panel  ──▶  URL.path(percentEncoded:)     keeps the slash: "/Users/me/dev/my-project/"
            ──▶  projects.json                 stores it verbatim
            ──▶  libghostty working_directory  exports it as $PWD
            ──▶  zsh adopts inherited $PWD     "/Users/me/dev/my-project/"
            ──▶  prompt %c / %1~               last component of ".../my-project/" = ""  ← blank
```

One-line repro:

```
$ env PWD="/Users/me/dev/my-project/" zsh -f -c 'print -rP "pc=[%c]"'
pc=[]
```

The first `cd` makes zsh recompute `$PWD` normalized — which is why the prompt "fixes itself".

## Fix

New `ProjectPath.normalizedForStorage(_:)` — locals through the existing `canonicalLocal` (slash stripped, `~` expanded, `.`/`..` standardized); remote specs pass through verbatim.

| Where | Covers |
|---|---|
| `ProjectStore.add` / `setPath` | all new paths: open panel, remote sheet, CLI `project create`, Replace Project Path |
| `ProjectStore.load()` | existing `projects.json` — migrates on next launch, persists clean on next save |
| `GhosttyTerminalNSView` spawn (local branch only) | panes restored from old workspace snapshots that persisted a slashed path |

## Verified

- [x] `format`, `lint`, full test suite (680 passing)
- [x] Ran the app: pane in a previously slash-stored project now starts with a clean `$PWD`, prompt shows the directory immediately
- [x] New tests: normalization helper, `add`/`setPath`, remote verbatim, `load` migration against a hand-crafted pre-fix `projects.json`

## Notes

- Already-running zmx shells keep their old `$PWD` until the user `cd`s once — reattach hands back a live process; nothing safe to do there.
- Old workspace snapshots aren't rewritten; the spawn-time canonicalization covers them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project paths are now stored in a consistent canonical format, including trailing-slash removal and `~/` expansion for local paths.
  * Existing saved projects are automatically normalized after loading (in memory) to match the current storage format.
  * Remote-style paths are preserved exactly, including any trailing slash.
  * Restored terminal sessions now use the correct working directory derived from the normalized stored path.

* **Tests**
  * Expanded test coverage for path normalization across adding, updating, loading legacy data, and handling local vs. remote paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update (maintainer): this bug is fatal under nushell, not just cosmetic

The trailing slash does more than blank a zsh prompt segment. libghostty exports `working_directory` **verbatim as $env.PWD**, and nushell refuses to start on a non-canonical value:

```
Error: nu::shell::error
  × $env.PWD contains trailing slashes
  crates/nu-protocol/src/engine/engine_state.rs
```

With nu as the login shell, every project added via **Cmd+O fails to spawn its pane** — the whole `zmx → login → bash → exec -l nu` chain collapses in ~150 ms and ghostty shows its abnormal-exit screen (issue reported as \"Ghostty failed to launch the requested command … Runtime: 145 ms\"). The palette path builds paths with `appendingPathComponent` (no slash), which is why only the open panel was affected.

Verified end-to-end in a hermetic app instance (throwaway $HOME + `MACTERM_BENCHMARK_DATA_DIR`, driven over the control socket): a projects.json seeded with a trailing-slash path reproduces the exact error screen pre-fix and spawns a live nu pane post-fix.

cd748ec strengthens the fix:
- Spawn-time guard uses `normalizedForStorage` instead of bare `canonicalLocal`, so a non-local-shaped string passes through untouched instead of being coerced relative to the app's own cwd
- Comments document the fatal mechanism at both layers
- New test pins every non-canonical form (`//`, `/./`, `/../`, `~/`) — nu validates the whole string, not just trailing slashes
