### PR TITLE
Add Shift+Enter to search for downward navigation; fix inverted chevrons

### DIFF
--- a/Macterm/Views/SearchBar.swift
+++ b/Macterm/Views/SearchBar.swift
@@ -37,10 +37,10 @@ struct TerminalSearchBar: View {
                 .clipShape(RoundedRectangle(cornerRadius: 6))
                 .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(MactermTheme.border, lineWidth: 1))
 
-                Button(action: onNavigatePrevious) {
+                Button(action: onNavigateNext) {
                     Image(systemName: "chevron.up").font(.system(size: 10, weight: .semibold))
                 }.buttonStyle(SearchButtonStyle())
-                Button(action: onNavigateNext) {
+                Button(action: onNavigatePrevious) {
                     Image(systemName: "chevron.down").font(.system(size: 10, weight: .semibold))
                 }.buttonStyle(SearchButtonStyle())
                 Button(action: onClose) {
@@ -54,6 +54,13 @@ struct TerminalSearchBar: View {
         }
         .onAppear { isFieldFocused = true }
         .onKeyPress(.escape) { onClose()
+            return .handled
+        }
+        // Ghostty search walks newest→oldest: `next` moves up the scrollback,
+        // `previous` back down. Enter = up (onSubmit above), Shift+Enter = down.
+        .onKeyPress(keys: [.return]) { press in
+            guard press.modifiers.contains(.shift) else { return .ignored }
+            onNavigatePrevious()
             return .handled
         }
         // Cmd+F again while the bar is open (and the search field has focus)


### PR DESCRIPTION
## Summary

- **Shift+Enter** in the Cmd+F search bar now navigates down the scrollback; plain **Enter** keeps navigating up.
- Fixes the chevron buttons, which were wired backwards: the up-chevron scrolled down and vice versa.

## Direction semantics

Verified against ghostty source (upstream and the `thdxg/ghostty` fork): `navigate_search:next` walks matches newest→oldest — i.e. **up** the scrollback — and `previous` walks back down. Ghostty's own macOS app maps the standard Find Next to `next` the same way.

So Enter's existing `onSubmit { onNavigateNext() }` already scrolled up; this PR adds a `.onKeyPress(keys: [.return])` handler (same pattern as the bar's Escape/Cmd+F handlers, which already fire while the field is focused) that sends `onNavigatePrevious()` when shift is held, and swaps the chevron buttons to agree with the actual scroll direction.

## Testing

- `mise run format`, `lint`, and the full test suite pass. (Search bar is SwiftUI view code, which is intentionally not unit-tested per repo conventions.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the search navigation chevron buttons so they move to the expected next and previous results.
  * Added Shift+Return support to navigate to the previous search result while leaving Return navigation unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->