### PR TITLE
Show search matches as scrollbar tick marks, colored like the text highlights

### DIFF
--- a/Macterm/Config/SearchHighlightColors.swift
+++ b/Macterm/Config/SearchHighlightColors.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Resolves the colors ghostty's renderer paints search highlights with
+/// (`search-background` for candidate matches, `search-selected-background`
+/// for the focused one), so the scrollbar ticks match the highlighted text.
+///
+/// These keys are `TerminalColor` unions in ghostty and that union has no
+/// `cval`, so `ghostty_config_get` returns false for them — the resolved
+/// values can't be read through the C API. Instead the user's config text is
+/// scanned directly, with the same pattern and limitation as
+/// `ShellIntegrationFeatures`: last occurrence wins, and a value set in a
+/// `config-file` include isn't seen.
+enum SearchHighlightColors {
+    struct RGB: Equatable {
+        let r, g, b: UInt8
+    }
+
+    /// Ghostty's documented defaults (`src/config/Config.zig`): candidate
+    /// matches on golden yellow, the selected match on soft peach.
+    static let defaultMatch = RGB(r: 0xFF, g: 0xE0, b: 0x82)
+    static let defaultSelected = RGB(r: 0xF2, g: 0xA5, b: 0x7E)
+
+    static func matchBackground(inConfigText text: String?) -> RGB {
+        value(forKey: "search-background", in: text) ?? defaultMatch
+    }
+
+    static func selectedBackground(inConfigText text: String?) -> RGB {
+        value(forKey: "search-selected-background", in: text) ?? defaultSelected
+    }
+
+    /// Last-wins scan for `key = #RRGGBB`. Named X11 colors and
+    /// `cell-foreground`/`cell-background` are valid ghostty values a tick
+    /// can't reproduce (no X11 table, no per-cell color), so they — like an
+    /// empty value, which resets the key — fall back to the default.
+    private static func value(forKey key: String, in text: String?) -> RGB? {
+        guard let text else { return nil }
+        var raw: String?
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            guard line[line.startIndex ..< eq].trimmingCharacters(in: .whitespaces) == key else { continue }
+            var value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            if value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") {
+                value = String(value.dropFirst().dropLast())
+            }
+            raw = value
+        }
+        return raw.flatMap(parseHex)
+    }
+
+    private static func parseHex(_ value: String) -> RGB? {
+        let hex = value.hasPrefix("#") ? String(value.dropFirst()) : value
+        guard hex.count == 6, let n = UInt32(hex, radix: 16) else { return nil }
+        return RGB(r: UInt8(n >> 16 & 0xFF), g: UInt8(n >> 8 & 0xFF), b: UInt8(n & 0xFF))
+    }
+}

--- a/Macterm/Ghostty/Theme.swift
+++ b/Macterm/Ghostty/Theme.swift
@@ -48,16 +48,32 @@ enum MactermTheme {
         GhosttyApp.shared.paletteColor(at: 2).map { Color(nsColor: $0) } ?? .green
     }
 
-    /// Scrollbar search-tick colors (NSColor: drawn by an AppKit overlay).
-    /// Plain matches use the theme's ANSI yellow; the selected match is
-    /// orange, which has no ANSI slot, so it's the one fixed system color.
+    /// Scrollbar search-tick colors (NSColor: drawn by an AppKit overlay),
+    /// mirroring the renderer's search highlight backgrounds
+    /// (`search-background` / `search-selected-background`) so the ticks read
+    /// as the same yellow/orange as the highlighted text in the terminal.
     @MainActor
     static var nsSearchTick: NSColor {
-        GhosttyApp.shared.paletteColor(at: 3) ?? .systemYellow
+        nsColor(SearchHighlightColors.matchBackground(inConfigText: userGhosttyConfigText()))
     }
 
     @MainActor
-    static var nsSearchTickSelected: NSColor { .systemOrange }
+    static var nsSearchTickSelected: NSColor {
+        nsColor(SearchHighlightColors.selectedBackground(inConfigText: userGhosttyConfigText()))
+    }
+
+    /// Same read as `MactermConfig.userGhosttyConfigText` — the search
+    /// highlight keys live in the user's ghostty config, not ours.
+    @MainActor
+    private static func userGhosttyConfigText() -> String? {
+        let path = Preferences.shared.expandedUserGhosttyConfigPath
+        guard !path.isEmpty else { return nil }
+        return try? String(contentsOfFile: path, encoding: .utf8)
+    }
+
+    private static func nsColor(_ rgb: SearchHighlightColors.RGB) -> NSColor {
+        NSColor(srgbRed: CGFloat(rgb.r) / 255, green: CGFloat(rgb.g) / 255, blue: CGFloat(rgb.b) / 255, alpha: 1)
+    }
 
     /// A translucent overlay that dims an unfocused pane, at the user-configured
     /// `opacity` (#156). Derived from the theme rather than a fixed black so it

--- a/Macterm/Ghostty/Theme.swift
+++ b/Macterm/Ghostty/Theme.swift
@@ -48,6 +48,17 @@ enum MactermTheme {
         GhosttyApp.shared.paletteColor(at: 2).map { Color(nsColor: $0) } ?? .green
     }
 
+    /// Scrollbar search-tick colors (NSColor: drawn by an AppKit overlay).
+    /// Plain matches use the theme's ANSI yellow; the selected match is
+    /// orange, which has no ANSI slot, so it's the one fixed system color.
+    @MainActor
+    static var nsSearchTick: NSColor {
+        GhosttyApp.shared.paletteColor(at: 3) ?? .systemYellow
+    }
+
+    @MainActor
+    static var nsSearchTickSelected: NSColor { .systemOrange }
+
     /// A translucent overlay that dims an unfocused pane, at the user-configured
     /// `opacity` (#156). Derived from the theme rather than a fixed black so it
     /// reads correctly on light themes too: on a light theme, dimming toward the

--- a/Macterm/Model/SearchTicks.swift
+++ b/Macterm/Model/SearchTicks.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Computes which scrollback rows contain search matches, for the scrollbar
+/// tick overlay. libghostty's search only reports match *counts*
+/// (`SEARCH_TOTAL`/`SEARCH_SELECTED`), never positions, so rows are recovered
+/// Macterm-side: scan the scrollback text (`ghostty_surface_read_text`) with
+/// the same ASCII-case-insensitive literal match ghostty's search uses
+/// (`std.ascii.indexOfIgnoreCase`), re-wrapping logical lines at the surface
+/// width to map text offsets onto visual rows.
+enum SearchTicks {
+    /// One entry per match (rows repeat when a row holds several matches, so
+    /// indices stay 1:1 with ghostty's match list), each the 0-based visual
+    /// row — counted from the top of history — where the match starts.
+    ///
+    /// Columns are counted as UTF-8 code points; a double-width cell drifts a
+    /// tick by one row at most, invisible at scrollbar scale. Matches are
+    /// non-overlapping, mirroring ghostty's sliding-window scan.
+    static func matchRows(text: String, needle: String, cols: Int) -> [Int] {
+        guard cols > 0, !needle.isEmpty, !needle.contains("\n") else { return [] }
+        let hay = Array(text.utf8)
+        let ndl = Array(needle.utf8).map(asciiLower)
+        let needleCodePoints = ndl.count(where: isCodePointStart)
+
+        var rows: [Int] = []
+        var lineRow = 0 // visual row where the current logical line starts
+        var cpInLine = 0 // code points consumed within the current logical line
+        var i = 0
+        while i < hay.count {
+            if hay[i] == UInt8(ascii: "\n") {
+                lineRow += rowsConsumed(byLineOf: cpInLine, cols: cols)
+                cpInLine = 0
+                i += 1
+                continue
+            }
+            if matches(hay, at: i, needle: ndl) {
+                rows.append(lineRow + cpInLine / cols)
+                i += ndl.count
+                cpInLine += needleCodePoints
+                continue
+            }
+            if isCodePointStart(hay[i]) { cpInLine += 1 }
+            i += 1
+        }
+        return rows
+    }
+
+    /// Map ghostty's selected index — counted from the *end* of the match list
+    /// (0 = newest, bottom-most) — onto `matchRows` output. nil when there is
+    /// no selection or our scan disagrees with ghostty's count (index out of
+    /// range): the ticks still draw, just without a selected highlight.
+    static func selectedRow(rows: [Int], selectedFromEnd: Int?) -> Int? {
+        guard let idx = selectedFromEnd, idx >= 0, idx < rows.count else { return nil }
+        return rows[rows.count - 1 - idx]
+    }
+
+    /// Rows a logical line of `codePoints` occupies when soft-wrapped at
+    /// `cols`. An empty line still occupies one row.
+    private static func rowsConsumed(byLineOf codePoints: Int, cols: Int) -> Int {
+        max(1, (codePoints + cols - 1) / cols)
+    }
+
+    private static func matches(_ hay: [UInt8], at i: Int, needle: [UInt8]) -> Bool {
+        guard i + needle.count <= hay.count else { return false }
+        for j in 0 ..< needle.count where asciiLower(hay[i + j]) != needle[j] {
+            return false
+        }
+        return true
+    }
+
+    private static func asciiLower(_ b: UInt8) -> UInt8 {
+        b >= UInt8(ascii: "A") && b <= UInt8(ascii: "Z") ? b + 32 : b
+    }
+
+    /// True for any byte that begins a UTF-8 code point (not a continuation).
+    private static func isCodePointStart(_ b: UInt8) -> Bool {
+        b & 0xC0 != 0x80
+    }
+}

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -609,6 +609,8 @@ final class Pane: Identifiable {
         return scroll
     }
 
+    var scrollView: SurfaceScrollView? { _scrollView }
+
     /// Tear down the ghostty surface and null out callbacks. Call when the
     /// pane is removed from the tree. Safe to call multiple times.
     func destroySurface() {

--- a/Macterm/Views/Terminal/SearchTickOverlay.swift
+++ b/Macterm/Views/Terminal/SearchTickOverlay.swift
@@ -49,8 +49,8 @@ final class SearchTickOverlay: NSView {
     }
 
     private func tickPath(at fraction: CGFloat) -> NSBezierPath {
-        let tickHeight: CGFloat = 2
-        let inset: CGFloat = 3
+        let tickHeight: CGFloat = 4
+        let inset: CGFloat = 2
         // AppKit Y is up; fraction 0 (top of history) draws at the top.
         let y = (bounds.height - tickHeight) * (1 - fraction)
         let rect = NSRect(x: inset, y: y, width: bounds.width - inset * 2, height: tickHeight)

--- a/Macterm/Views/Terminal/SearchTickOverlay.swift
+++ b/Macterm/Views/Terminal/SearchTickOverlay.swift
@@ -1,0 +1,59 @@
+import AppKit
+
+/// Tick marks over the scroller track showing where search matches live in the
+/// scrollback (Xcode-style). Pure presentation: rows come from `SearchTicks`,
+/// geometry mirrors the scroller (fraction of total scrollback rows). The view
+/// never participates in hit testing, so the scroller underneath keeps full
+/// click/drag behavior.
+final class SearchTickOverlay: NSView {
+    var tickColor: NSColor = .systemYellow
+    var selectedColor: NSColor = .systemOrange
+
+    /// Distinct tick fractions (0 = top of history, 1 = bottom), deduped so a
+    /// pathological needle can't queue thousands of overlapping draw rects.
+    private var fractions: [CGFloat] = []
+    private var selectedFraction: CGFloat?
+
+    func update(matchRows: [Int], selectedRow: Int?, totalRows: Int) {
+        guard totalRows > 0, !matchRows.isEmpty else {
+            fractions = []
+            selectedFraction = nil
+            needsDisplay = true
+            return
+        }
+        let unique = Set(matchRows)
+        fractions = unique.map { Self.fraction(row: $0, totalRows: totalRows) }.sorted()
+        selectedFraction = selectedRow.map { Self.fraction(row: $0, totalRows: totalRows) }
+        needsDisplay = true
+    }
+
+    static func fraction(row: Int, totalRows: Int) -> CGFloat {
+        (CGFloat(row) + 0.5) / CGFloat(totalRows)
+    }
+
+    override func hitTest(_: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func draw(_: NSRect) {
+        guard !fractions.isEmpty, bounds.height > 0 else { return }
+        for f in fractions where f != selectedFraction {
+            tickColor.setFill()
+            tickPath(at: f).fill()
+        }
+        // Selected last, so it always wins overlapping ticks.
+        if let selectedFraction {
+            selectedColor.setFill()
+            tickPath(at: selectedFraction).fill()
+        }
+    }
+
+    private func tickPath(at fraction: CGFloat) -> NSBezierPath {
+        let tickHeight: CGFloat = 2
+        let inset: CGFloat = 3
+        // AppKit Y is up; fraction 0 (top of history) draws at the top.
+        let y = (bounds.height - tickHeight) * (1 - fraction)
+        let rect = NSRect(x: inset, y: y, width: bounds.width - inset * 2, height: tickHeight)
+        return NSBezierPath(roundedRect: rect, xRadius: 1, yRadius: 1)
+    }
+}

--- a/Macterm/Views/Terminal/SurfaceScrollView.swift
+++ b/Macterm/Views/Terminal/SurfaceScrollView.swift
@@ -46,6 +46,16 @@ final class SurfaceScrollView: NSScrollView {
     /// Last row index sent to the core via `scroll_to_row`, to dedupe spam.
     private var lastSentRow: Int = -1
 
+    /// Search-match tick marks drawn over the scroller track (see #176).
+    private let searchTicks = SearchTickOverlay()
+
+    /// The needle the search core is currently matching (last one actually
+    /// sent, not the live field text) and the rows/selection recovered for it.
+    private var searchNeedle = ""
+    private var searchMatchRows: [Int] = []
+    private var searchSelectedFromEnd: Int?
+    private var searchTickScanScheduled = false
+
     /// iTerm-style vertical scroll-wheel accumulator. It turns AppKit's messy
     /// wheel/trackpad deltas into whole terminal-row movement, including
     /// momentum events, instead of trying to pixel-scroll terminal contents.
@@ -77,6 +87,7 @@ final class SurfaceScrollView: NSScrollView {
         spacer.translatesAutoresizingMaskIntoConstraints = true
         spacer.addSubview(surfaceView)
         documentView = spacer
+        addSubview(searchTicks)
 
         wireObservers()
         surfaceView.onScrollbarUpdate = { [weak self] total, offset, len in
@@ -137,6 +148,16 @@ final class SurfaceScrollView: NSScrollView {
         synchronize()
     }
 
+    override func tile() {
+        super.tile()
+        // Keep the tick overlay glued to the scroller track. `addSubview` in
+        // init put it above the scroller, so ticks stay visible even while the
+        // overlay scroller is faded out.
+        if let scroller = verticalScroller {
+            searchTicks.frame = scroller.frame
+        }
+    }
+
     /// Pin the surface to fill the currently visible rect of the document.
     private func layoutSurface() {
         let visible = contentView.documentVisibleRect
@@ -174,10 +195,75 @@ final class SurfaceScrollView: NSScrollView {
     // MARK: - Core → UI
 
     private func applyScrollbar(total: UInt64, offset: UInt64, len: UInt64) {
+        let totalChanged = total != self.total
         self.total = total
         self.offset = offset
         self.len = len
         synchronize()
+        // Tick fractions are row/total, so a scrollback growth shifts them.
+        if totalChanged, !searchMatchRows.isEmpty {
+            pushSearchTicks()
+        }
+    }
+
+    // MARK: - Search ticks
+
+    /// Record the needle just sent to the search core. Match totals arriving
+    /// after this belong to it — the live field text may already be newer.
+    func noteSearchNeedle(_ needle: String) {
+        searchNeedle = needle
+        if needle.isEmpty { clearSearchTicks() }
+    }
+
+    /// Recompute match rows from the scrollback text. Called on every
+    /// `SEARCH_TOTAL` update; those stream while the core scans history, so
+    /// coalesce with a trailing delay rather than re-reading the full
+    /// scrollback each time.
+    func refreshSearchTicks() {
+        guard !searchTickScanScheduled else { return }
+        searchTickScanScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self else { return }
+            searchTickScanScheduled = false
+            scanSearchTicks()
+        }
+    }
+
+    func setSearchSelected(_ indexFromEnd: Int?) {
+        searchSelectedFromEnd = indexFromEnd
+        pushSearchTicks()
+    }
+
+    func clearSearchTicks() {
+        searchMatchRows = []
+        searchSelectedFromEnd = nil
+        pushSearchTicks()
+    }
+
+    private func scanSearchTicks() {
+        guard !searchNeedle.isEmpty,
+              let size = surfaceView.surfaceSize, size.columns > 0,
+              let text = surfaceView.readText(scrollback: true)
+        else {
+            clearSearchTicks()
+            return
+        }
+        searchMatchRows = SearchTicks.matchRows(
+            text: text,
+            needle: searchNeedle,
+            cols: Int(size.columns)
+        )
+        pushSearchTicks()
+    }
+
+    private func pushSearchTicks() {
+        searchTicks.tickColor = MactermTheme.nsSearchTick
+        searchTicks.selectedColor = MactermTheme.nsSearchTickSelected
+        searchTicks.update(
+            matchRows: searchMatchRows,
+            selectedRow: SearchTicks.selectedRow(rows: searchMatchRows, selectedFromEnd: searchSelectedFromEnd),
+            totalRows: Int(min(total, UInt64(Int.max)))
+        )
     }
 
     // MARK: - UI → Core

--- a/Macterm/Views/Terminal/SurfaceScrollView.swift
+++ b/Macterm/Views/Terminal/SurfaceScrollView.swift
@@ -253,12 +253,14 @@ final class SurfaceScrollView: NSScrollView {
             needle: searchNeedle,
             cols: Int(size.columns)
         )
+        // Once per scan, not per push: resolving these reads the user's
+        // ghostty config file.
+        searchTicks.tickColor = MactermTheme.nsSearchTick
+        searchTicks.selectedColor = MactermTheme.nsSearchTickSelected
         pushSearchTicks()
     }
 
     private func pushSearchTicks() {
-        searchTicks.tickColor = MactermTheme.nsSearchTick
-        searchTicks.selectedColor = MactermTheme.nsSearchTickSelected
         searchTicks.update(
             matchRows: searchMatchRows,
             selectedRow: SearchTicks.selectedRow(rows: searchMatchRows, selectedFromEnd: searchSelectedFromEnd),

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -156,7 +156,12 @@ private struct TerminalSurface: NSViewRepresentable {
             }
             if let needle, !needle.isEmpty { pane.searchState.needle = needle }
             pane.searchState.isVisible = true
-            pane.searchState.startPublishing { [weak view] q in view?.sendSearchQuery(q) }
+            pane.searchState.startPublishing { [weak pane, weak view] q in
+                view?.sendSearchQuery(q)
+                // The tick scan must run against the needle the core actually
+                // searched, not the live (possibly newer) field text.
+                pane?.scrollView?.noteSearchNeedle(q)
+            }
             if !pane.searchState.needle.isEmpty { pane.searchState.pushNeedle() }
         }
         view.onSearchEnd = { [weak pane] in
@@ -166,9 +171,21 @@ private struct TerminalSurface: NSViewRepresentable {
             pane.searchState.needle = ""
             pane.searchState.total = nil
             pane.searchState.selected = nil
+            pane.scrollView?.clearSearchTicks()
         }
-        view.onSearchTotal = { [weak pane] total in pane?.searchState.total = total }
-        view.onSearchSelected = { [weak pane] sel in pane?.searchState.selected = sel }
+        view.onSearchTotal = { [weak pane] total in
+            guard let pane else { return }
+            pane.searchState.total = total
+            if total == nil {
+                pane.scrollView?.clearSearchTicks()
+            } else {
+                pane.scrollView?.refreshSearchTicks()
+            }
+        }
+        view.onSearchSelected = { [weak pane] sel in
+            pane?.searchState.selected = sel
+            pane?.scrollView?.setSearchSelected(sel)
+        }
         view.onDesktopNotification = { [weak pane, weak view] title, body in
             guard let pane else { return }
             guard !(NSApp.isActive && view?.isFocused == true) else { return }

--- a/MactermTests/Config/SearchHighlightColorsTests.swift
+++ b/MactermTests/Config/SearchHighlightColorsTests.swift
@@ -1,0 +1,65 @@
+@testable import Macterm
+import Testing
+
+struct SearchHighlightColorsTests {
+    @Test
+    func defaults_match_ghosttys_documented_values() {
+        #expect(SearchHighlightColors.matchBackground(inConfigText: nil)
+            == SearchHighlightColors.RGB(r: 0xFF, g: 0xE0, b: 0x82))
+        #expect(SearchHighlightColors.selectedBackground(inConfigText: nil)
+            == SearchHighlightColors.RGB(r: 0xF2, g: 0xA5, b: 0x7E))
+    }
+
+    @Test
+    func hex_overrides_are_honored_with_and_without_hash() {
+        let text = """
+        search-background = #102030
+        search-selected-background = A0B0C0
+        """
+        #expect(SearchHighlightColors.matchBackground(inConfigText: text)
+            == SearchHighlightColors.RGB(r: 0x10, g: 0x20, b: 0x30))
+        #expect(SearchHighlightColors.selectedBackground(inConfigText: text)
+            == SearchHighlightColors.RGB(r: 0xA0, g: 0xB0, b: 0xC0))
+    }
+
+    @Test
+    func last_occurrence_wins() {
+        let text = """
+        search-background = #111111
+        search-background = #222222
+        """
+        #expect(SearchHighlightColors.matchBackground(inConfigText: text)
+            == SearchHighlightColors.RGB(r: 0x22, g: 0x22, b: 0x22))
+    }
+
+    @Test
+    func comments_and_other_keys_are_ignored() {
+        let text = """
+        # search-background = #111111
+        search-selected-background = #333333
+        background = #444444
+        """
+        #expect(SearchHighlightColors.matchBackground(inConfigText: text)
+            == SearchHighlightColors.defaultMatch)
+    }
+
+    @Test
+    func quoted_values_are_unwrapped() {
+        let text = "search-background = \"#555555\""
+        #expect(SearchHighlightColors.matchBackground(inConfigText: text)
+            == SearchHighlightColors.RGB(r: 0x55, g: 0x55, b: 0x55))
+    }
+
+    @Test
+    func unrepresentable_values_fall_back_to_the_default() {
+        // Named X11 colors and cell-* are valid ghostty values a tick can't
+        // reproduce; an empty value resets the key. All take the default —
+        // even when an earlier occurrence was a parseable hex, since the last
+        // occurrence is what ghostty renders.
+        for value in ["cell-foreground", "goldenrod", ""] {
+            let text = "search-background = #111111\nsearch-background = \(value)"
+            #expect(SearchHighlightColors.matchBackground(inConfigText: text)
+                == SearchHighlightColors.defaultMatch)
+        }
+    }
+}

--- a/MactermTests/Model/SearchTicksTests.swift
+++ b/MactermTests/Model/SearchTicksTests.swift
@@ -1,0 +1,91 @@
+@testable import Macterm
+import Testing
+
+struct SearchTicksTests {
+    @Test
+    func finds_matches_on_their_lines() {
+        let text = "alpha\nbeta\nalpha again"
+        #expect(SearchTicks.matchRows(text: text, needle: "alpha", cols: 80) == [0, 2])
+    }
+
+    @Test
+    func matching_is_ascii_case_insensitive() {
+        let text = "Error\nerror\nERROR"
+        #expect(SearchTicks.matchRows(text: text, needle: "eRRor", cols: 80) == [0, 1, 2])
+    }
+
+    @Test
+    func multiple_matches_on_one_row_repeat_the_row() {
+        // One entry per match keeps indices 1:1 with ghostty's match list.
+        let text = "foo foo foo"
+        #expect(SearchTicks.matchRows(text: text, needle: "foo", cols: 80) == [0, 0, 0])
+    }
+
+    @Test
+    func matches_do_not_overlap() {
+        // Mirrors ghostty's sliding-window scan: "aaaa" holds two "aa", not three.
+        #expect(SearchTicks.matchRows(text: "aaaa", needle: "aa", cols: 80) == [0, 0])
+    }
+
+    @Test
+    func long_lines_wrap_at_cols() {
+        // 10-wide grid: 25 chars of padding occupy rows 0–2, the needle starts
+        // at code point 25 → row 2; next logical line starts at row 3.
+        let text = String(repeating: "x", count: 25) + "hit\nhit"
+        let rows = SearchTicks.matchRows(text: text, needle: "hit", cols: 10)
+        #expect(rows == [2, 3])
+    }
+
+    @Test
+    func wrapped_match_row_is_its_start_row() {
+        // Needle starting at code point 8 of a 10-wide row sits on row 0 even
+        // though it spills onto row 1.
+        let text = String(repeating: "x", count: 8) + "needle"
+        #expect(SearchTicks.matchRows(text: text, needle: "needle", cols: 10) == [0])
+    }
+
+    @Test
+    func empty_lines_still_occupy_a_row() {
+        let text = "top\n\n\nbottom"
+        #expect(SearchTicks.matchRows(text: text, needle: "bottom", cols: 80) == [3])
+    }
+
+    @Test
+    func line_exactly_cols_wide_occupies_one_row() {
+        let text = String(repeating: "x", count: 10) + "\nhit"
+        #expect(SearchTicks.matchRows(text: text, needle: "hit", cols: 10) == [1])
+    }
+
+    @Test
+    func multibyte_text_counts_code_points_not_bytes() {
+        // "é" is 2 UTF-8 bytes but 1 code point/cell; 10 of them fill exactly
+        // one 10-wide row, so the needle on the next line sits on row 1.
+        let text = String(repeating: "é", count: 10) + "\nhit"
+        #expect(SearchTicks.matchRows(text: text, needle: "hit", cols: 10) == [1])
+    }
+
+    @Test
+    func degenerate_inputs_return_no_rows() {
+        #expect(SearchTicks.matchRows(text: "abc", needle: "", cols: 80).isEmpty)
+        #expect(SearchTicks.matchRows(text: "abc", needle: "abc", cols: 0).isEmpty)
+        #expect(SearchTicks.matchRows(text: "", needle: "abc", cols: 80).isEmpty)
+        #expect(SearchTicks.matchRows(text: "a\nb", needle: "a\nb", cols: 80).isEmpty)
+    }
+
+    @Test
+    func selected_index_counts_from_the_end() {
+        // ghostty's SEARCH_SELECTED index 0 is the newest (bottom-most) match.
+        let rows = [1, 5, 9]
+        #expect(SearchTicks.selectedRow(rows: rows, selectedFromEnd: 0) == 9)
+        #expect(SearchTicks.selectedRow(rows: rows, selectedFromEnd: 2) == 1)
+    }
+
+    @Test
+    func selected_index_out_of_range_is_nil() {
+        let rows = [1, 5]
+        #expect(SearchTicks.selectedRow(rows: rows, selectedFromEnd: nil) == nil)
+        #expect(SearchTicks.selectedRow(rows: rows, selectedFromEnd: 2) == nil)
+        #expect(SearchTicks.selectedRow(rows: rows, selectedFromEnd: -1) == nil)
+        #expect(SearchTicks.selectedRow(rows: [], selectedFromEnd: 0) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Cmd+F now marks every match's position in the scrollbar track (Xcode-style ticks), so you can see where matches live in the scrollback at a glance. The selected match's tick is drawn last and in the selected-highlight color, so it stands out from candidate matches.

## Design

**libghostty never reports match positions** — its search API only emits counts (`SEARCH_TOTAL` / `SEARCH_SELECTED`). So tick rows are recovered Macterm-side:

- **`SearchTicks`** (pure, unit-tested): reads the scrollback via the existing `ghostty_surface_read_text` path and scans it with the same ASCII-case-insensitive literal match ghostty's search uses (`std.ascii.indexOfIgnoreCase` in `sliding_window.zig`), re-wrapping logical lines at the surface's column count to map matches to visual rows. The match list stays 1:1 with ghostty's, so the `SEARCH_SELECTED` index (counted from the newest match) picks the selected tick; if the counts ever disagree, the selected highlight is dropped rather than drawn on the wrong tick.
- **`SearchTickOverlay`**: an `NSView` pinned to the scroller track in `tile()`, above the overlay scroller so ticks stay visible while it fades out, with hit-testing disabled so scrollbar click/drag is untouched.
- **Wiring**: `SurfaceScrollView` re-scans on `SEARCH_TOTAL` updates (coalesced 100ms — totals stream while ghostty walks history), recolors the selected tick on `SEARCH_SELECTED`, clears on search end. The scan runs against the needle actually sent to the core, not the live (possibly newer) field text.

**Tick colors mirror the renderer's search highlight backgrounds** (`search-background` / `search-selected-background`, defaults golden yellow `#FFE082` / soft peach `#F2A57E`), so ticks read as the same colors as the highlighted text. Those keys are `TerminalColor` unions with no `cval`, so `ghostty_config_get` can't return them — a new pure `SearchHighlightColors` helper scans the user's config text (same pattern and config-file-include limitation as `ShellIntegrationFeatures`), honoring hex overrides and falling back to the defaults for named-X11 / `cell-*` values a tick can't reproduce.

## Known approximations (noted in code comments)

- Columns are counted as UTF-8 code points, so double-width cells can drift a tick by one row — invisible at scrollbar scale.
- A match spanning a hard line break isn't found (ghostty itself is ambiguous there).

## Testing

- Unit tests for `SearchTicks` (wrap arithmetic, case-insensitivity, non-overlap, selected-from-end mapping, multibyte counting) and `SearchHighlightColors` (defaults, hex/quoted parsing, last-wins, fallback semantics).
- `mise run format`, `lint`, and the full suite pass. Overlay drawing is AppKit view code, intentionally not unit-tested per repo conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scrollbar markers showing the locations of terminal search matches.
  * Highlighted the currently selected match with a distinct marker.
  * Search markers update as queries, selections, and scrollback content change.
  * Marker colors now follow configured search highlight colors, with sensible defaults.

* **Bug Fixes**
  * Improved search matching across wrapped lines, mixed case, and multibyte text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->