### PR TITLE
Keep window opacity constant when the window loses focus

### DIFF
--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -349,16 +349,10 @@ private struct WindowStyler: NSViewRepresentable {
         }
 
         func windowDidBecomeKey(_ notification: Notification) {
-            if let window = notification.object as? NSWindow {
-                WindowAppearance.syncKeyStatus(window: window)
-            }
             swiftuiDelegate?.windowDidBecomeKey?(notification)
         }
 
         func windowDidResignKey(_ notification: Notification) {
-            if let window = notification.object as? NSWindow {
-                WindowAppearance.syncKeyStatus(window: window)
-            }
             swiftuiDelegate?.windowDidResignKey?(notification)
         }
 

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -19,29 +19,6 @@ extension NSView {
     }
 }
 
-// MARK: - Color helpers (for the inactive-glass tint)
-
-extension NSColor {
-    /// Perceptual luminance in 0...1, computed in sRGB. Returns 0 for colors
-    /// that can't be converted to an RGB space (e.g. pattern colors).
-    var luminance: CGFloat {
-        guard let rgb = usingColorSpace(.sRGB) else { return 0 }
-        return 0.2126 * rgb.redComponent + 0.7152 * rgb.greenComponent + 0.0722 * rgb.blueComponent
-    }
-
-    var isLightColor: Bool { luminance > 0.5 }
-
-    /// Returns a copy with its HSB saturation multiplied by `factor` (clamped
-    /// to 0...1). Used to make the inactive-window overlay read as a desaturated
-    /// version of the terminal background, matching Ghostty.
-    func adjustingSaturation(by factor: CGFloat) -> NSColor {
-        guard let hsb = usingColorSpace(.sRGB) else { return self }
-        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-        hsb.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
-        return NSColor(hue: h, saturation: min(max(s * factor, 0), 1), brightness: b, alpha: a)
-    }
-}
-
 // MARK: - Private CGS blur SPI
 
 /// `CGSSetWindowBackgroundBlurRadius` is a private CoreGraphics API that
@@ -72,23 +49,17 @@ func setWindowBackgroundBlur(_ window: NSWindow, radius: Int) {
 // MARK: - Liquid glass background
 
 /// A container that hosts a macOS 26 `NSGlassEffectView` (the real liquid
-/// glass material) plus an inactive-window tint overlay. Mirrors Ghostty's
-/// `TerminalGlassView` (`TerminalViewContainer.swift`). Macterm inserts this
-/// below the window's content view, filling the whole window — including the
-/// region under the titlebar (via a negative top inset equal to the content
-/// view's top safe-area inset) — so the glass reads as one continuous surface
-/// behind the sidebar, titlebar, and terminal.
+/// glass material). Mirrors Ghostty's `TerminalGlassView`
+/// (`TerminalViewContainer.swift`), minus its inactive-window tint overlay —
+/// Macterm keeps the window's appearance identical whether or not it's key.
+/// Macterm inserts this below the window's content view, filling the whole
+/// window — including the region under the titlebar (via a negative top inset
+/// equal to the content view's top safe-area inset) — so the glass reads as
+/// one continuous surface behind the sidebar, titlebar, and terminal.
 @available(macOS 26.0, *)
 final class MactermGlassView: NSView {
     private let glassEffectView = NSGlassEffectView()
-    private let tintOverlay = NSView()
     private var topConstraint: NSLayoutConstraint!
-
-    /// The window opacity the glass is currently configured for. The inactive
-    /// tint is scaled by this so an unfocused window never reads as more opaque
-    /// than the user asked for — at 30% opacity the desaturation overlay is far
-    /// subtler than at 100%.
-    private var backgroundOpacity: CGFloat = 1
 
     init(topOffset: CGFloat) {
         super.init(frame: .zero)
@@ -103,19 +74,6 @@ final class MactermGlassView: NSView {
             glassEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
             glassEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
-
-        // The inactive tint sits above the glass and fades in when the window
-        // resigns key, matching how the system desaturates inactive glass.
-        tintOverlay.translatesAutoresizingMaskIntoConstraints = false
-        tintOverlay.wantsLayer = true
-        tintOverlay.alphaValue = 0
-        addSubview(tintOverlay, positioned: .above, relativeTo: glassEffectView)
-        NSLayoutConstraint.activate([
-            tintOverlay.topAnchor.constraint(equalTo: glassEffectView.topAnchor),
-            tintOverlay.leadingAnchor.constraint(equalTo: glassEffectView.leadingAnchor),
-            tintOverlay.bottomAnchor.constraint(equalTo: glassEffectView.bottomAnchor),
-            tintOverlay.trailingAnchor.constraint(equalTo: glassEffectView.trailingAnchor),
-        ])
     }
 
     @available(*, unavailable)
@@ -127,36 +85,15 @@ final class MactermGlassView: NSView {
         style: NSGlassEffectView.Style,
         backgroundColor: NSColor,
         backgroundOpacity: Double,
-        cornerRadius: CGFloat?,
-        isKeyWindow: Bool
+        cornerRadius: CGFloat?
     ) {
         glassEffectView.style = style
         glassEffectView.tintColor = backgroundColor.withAlphaComponent(backgroundOpacity)
         glassEffectView.cornerRadius = cornerRadius ?? 0
-        self.backgroundOpacity = CGFloat(backgroundOpacity)
-        updateKeyStatus(isKeyWindow, backgroundColor: backgroundColor)
     }
 
     func updateTopInset(_ offset: CGFloat) {
         topConstraint.constant = offset
-    }
-
-    func updateKeyStatus(_ isKeyWindow: Bool, backgroundColor: NSColor) {
-        let tint = tintProperties(for: backgroundColor)
-        tintOverlay.layer?.backgroundColor = tint.color.cgColor
-        // Scale by the window opacity so the inactive tint stays within the
-        // translucency the user chose — otherwise an unfocused window reads as
-        // near-opaque regardless of the opacity slider.
-        tintOverlay.alphaValue = isKeyWindow ? 0 : tint.opacity * backgroundOpacity
-    }
-
-    /// A saturation-boosted tint + opacity for the inactive overlay, lifted
-    /// from Ghostty's `tintProperties`.
-    private func tintProperties(for color: NSColor) -> (color: NSColor, opacity: CGFloat) {
-        let isLight = color.isLightColor
-        let vibrant = color.adjustingSaturation(by: 1.2)
-        let overlayOpacity: CGFloat = isLight ? 0.35 : 0.85
-        return (vibrant, overlayOpacity)
     }
 }
 
@@ -247,16 +184,6 @@ enum WindowAppearance {
         }
     }
 
-    /// Update the inactive-glass tint when the window gains/loses key status.
-    /// Cheap no-op unless the glass view is currently installed.
-    static func syncKeyStatus(window: NSWindow) {
-        guard glassSupported else { return }
-        if #available(macOS 26.0, *) {
-            guard let glass = existingGlass(in: window) else { return }
-            glass.updateKeyStatus(window.isKeyWindow, backgroundColor: GhosttyApp.shared.backgroundColor)
-        }
-    }
-
     /// Liquid glass (`NSGlassEffectView`) exists only on macOS 26+. Drives both
     /// the runtime appearance path and the Settings UI's glass controls.
     static var glassSupported: Bool {
@@ -292,8 +219,7 @@ enum WindowAppearance {
             style: officialGlassStyle(Preferences.shared.windowGlassStyle),
             backgroundColor: backgroundColor,
             backgroundOpacity: opacity,
-            cornerRadius: windowCornerRadius(window),
-            isKeyWindow: window.isKeyWindow
+            cornerRadius: windowCornerRadius(window)
         )
     }
 


### PR DESCRIPTION
## Why

With liquid glass enabled, unfocusing the window faded in a desaturation tint over the glass (mirroring Ghostty's `TerminalGlassView`) — at 0.85 alpha on dark themes, a translucent window read as near-opaque the moment it lost focus. Keeping the appearance identical focused/unfocused looks better.

## What

- Remove the `tintOverlay` and its `tintProperties` (0.35 light / 0.85 dark constants) from `MactermGlassView`, plus the `backgroundOpacity` scaling that existed only to bound the tint.
- Remove `WindowAppearance.syncKeyStatus` and its `windowDidBecomeKey`/`windowDidResignKey` call sites (delegate forwarding unchanged).
- Remove the now-orphaned `NSColor.luminance`/`isLightColor`/`adjustingSaturation` helpers.
- `MactermGlassView`'s doc comment now records the deliberate divergence from Ghostty so the tint isn't reintroduced as a "missing feature".

The non-glass paths never varied with focus, so this only affects the macOS 26 glass appearance. Any residual inactive treatment the system applies to `NSGlassEffectView` itself is outside our control.

## Testing

- `mise run format` / `lint` / `test` all green.
- Verified visually in the debug build: translucent glass window now renders identically focused and unfocused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified window glass appearance handling.
  * Removed the inactive-window tint overlay, resulting in more consistent glass styling regardless of window focus.
* **Bug Fixes**
  * Window appearance no longer changes through separate key-status synchronization when windows gain or lose focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->