### PR TITLE
Fix flaky RemoteForegroundResolver tests that failed on loaded CI runners

### DIFF
--- a/Macterm/System/RemoteForegroundResolver.swift
+++ b/Macterm/System/RemoteForegroundResolver.swift
@@ -23,6 +23,11 @@ final class RemoteForegroundResolver {
     private var inflight: Set<String> = []
     private var lastProbeAt: [String: Date] = [:]
 
+    /// True when no probe `Task` is outstanding. Read by tests to wait for a
+    /// probe to complete deterministically — including the failure path, whose
+    /// only effect is *not* changing a name, so there's no state edge to poll.
+    var isIdle: Bool { inflight.isEmpty }
+
     init(minInterval: TimeInterval = 3) {
         self.minInterval = minInterval
     }

--- a/MactermTests/System/RemoteForegroundResolverTests.swift
+++ b/MactermTests/System/RemoteForegroundResolverTests.swift
@@ -8,11 +8,26 @@ struct RemoteForegroundResolverTests {
         Pane(projectPath: "\(host):~/dev/api", projectID: UUID())
     }
 
-    /// Let the resolver's fire-and-forget apply Task run.
-    private func flush() async {
-        for _ in 0 ..< 4 {
-            await Task.yield()
+    /// Wait for the resolver's fire-and-forget apply `Task` to reach the state
+    /// `condition` describes, sleeping between polls until it holds. A fixed
+    /// yield count is racy — 4 yields is enough on an idle machine but not on a
+    /// loaded CI runner, where the child `Task`'s `await probe(...)` may not
+    /// have resumed yet (this was the #180 flake). We *sleep* rather than
+    /// `Task.yield()` because a tight yield loop on `@MainActor` never lets the
+    /// clock advance, so it would starve a timer-based continuation; sleeping
+    /// hands the actor back long enough for pending work to run. Polling adapts
+    /// to scheduling latency; the ~2s ceiling keeps a genuine regression
+    /// failing fast instead of hanging the suite.
+    private func waitUntil(
+        _ condition: () -> Bool,
+        _ comment: Comment? = nil,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async {
+        for _ in 0 ..< 2000 {
+            if condition() { return }
+            try? await Task.sleep(for: .milliseconds(1))
         }
+        #expect(condition(), comment, sourceLocation: sourceLocation)
     }
 
     // MARK: - Probe output parsing
@@ -48,12 +63,10 @@ struct RemoteForegroundResolverTests {
 
         resolver.refresh(panes: panes, probe: probe, now: t0)
         resolver.refresh(panes: panes, probe: probe, now: t0.addingTimeInterval(1))
-        await flush()
-        #expect(calls.value == ["devbox"])
+        await waitUntil { calls.value == ["devbox"] }
 
         resolver.refresh(panes: panes, probe: probe, now: t0.addingTimeInterval(4))
-        await flush()
-        #expect(calls.value == ["devbox", "devbox"])
+        await waitUntil { calls.value == ["devbox", "devbox"] }
     }
 
     @Test
@@ -64,8 +77,7 @@ struct RemoteForegroundResolverTests {
             if case let .remote(_, host, _) = spec { calls.mutate { $0.append(host) } }
             return [:]
         })
-        await flush()
-        #expect(Set(calls.value) == ["alpha", "beta"])
+        await waitUntil { Set(calls.value) == ["alpha", "beta"] }
     }
 
     // MARK: - Name application
@@ -76,8 +88,7 @@ struct RemoteForegroundResolverTests {
         let resolver = RemoteForegroundResolver(minInterval: 0)
         let session = pane.sessionName
         resolver.refresh(panes: [pane], probe: { _, _ in [session: "btop"] })
-        await flush()
-        #expect(pane.foregroundProcessName == "btop")
+        await waitUntil { pane.foregroundProcessName == "btop" }
     }
 
     @Test
@@ -86,7 +97,9 @@ struct RemoteForegroundResolverTests {
         pane.applyRemoteForegroundName("btop")
         let resolver = RemoteForegroundResolver(minInterval: 0)
         resolver.refresh(panes: [pane], probe: { _, _ in nil })
-        await flush()
+        // The failure path changes no name, so there's no state edge to poll —
+        // wait for the probe Task to finish, then assert the name held.
+        await waitUntil { resolver.isIdle }
         // Silent degradation: the name froze instead of flapping to nil.
         #expect(pane.foregroundProcessName == "btop")
     }


### PR DESCRIPTION
## What

Fix `RemoteForegroundResolverTests` flaking on loaded CI runners. The async tests now wait for the resolver's fire-and-forget probe `Task` by polling until the expected state holds, instead of a fixed `Task.yield()` count.

## Why

The **Checks** run on `main` (commit e2b9a0a, PR #180) failed intermittently:

```
✘ RemoteForegroundResolverTests / applies_probe_names_to_matching_panes()
  Expectation failed: (pane.foregroundProcessName → nil) == "btop"
```

`refresh()` spawns a fire-and-forget `Task { let map = await probe(...); finish(...) }`. The test's `flush()` waited for it with `for _ in 0..<4 { await Task.yield() }`. Four yields is enough on an idle machine but not on a loaded CI runner, where the child Task's `await probe(...)` may not have resumed yet — so the probed name wasn't applied and the assertion saw `nil`. It passes locally every time, which is exactly why it slipped through.

Confirmed the cause deterministically before fixing: dropping the yield count to 0 reproduces the exact CI assertion locally (three of the four async tests fail identically).

## How

Replaced the fixed-count `flush()` with `waitUntil { condition }` that polls until the assertion's own condition holds, bounded by a ~2s ceiling so a genuine regression still fails fast. The same fragile pattern lived in all four async tests in the file, so this hardens every one, not just the one that tripped.

Two non-obvious points, both worked through against a deterministic repro (injecting a 50ms `Task.sleep` into the probe to simulate CI scheduling latency):

- **The poll sleeps, it doesn't yield.** A tight `Task.yield()` loop on `@MainActor` never lets the clock advance, so it *starves a timer-based continuation* — a yield-based `waitUntil` gave up after ~17ms without the 50ms sleep ever firing. Sleeping 1ms between checks hands the actor back long enough for pending work to run; the same test then correctly waits it out (passes at 0.054s).
- **The negative-assertion test** (`failed_probe_keeps_last_known_names` — name must *not* change) has no state edge to poll. Added `var isIdle: Bool { inflight.isEmpty }` to `RemoteForegroundResolver` — an honest read of existing state, visible via `@testable import` — and poll on that. It works because `refresh()` inserts into `inflight` synchronously before spawning the Task, so `isIdle` is false right after `refresh()` and flips true only after `finish()` runs.

No production behavior changes: the only non-test change is the read-only `isIdle` accessor.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Added or updated tests for new model / persistence / palette / hotkey logic — reworked the affected tests; validated the fix against a deterministic reproduction of the race (0-yield repro fails as the CI did; 50ms-slow-probe repro passes only with the sleep-based poll)

## Notes for reviewers

Pre-existing warnings in the same CI run are **not** touched here (redundant `#require` in `RemoteSpawnTests`, a `nonisolated(unsafe)` on `AppState.observerTokens`) — they don't fail the build. Happy to fold in a cleanup if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous test synchronization by waiting for specific state changes instead of relying on scheduling assumptions.
  * Added coverage to confirm resolver idle state after probe failures.
  * Strengthened validation for probe completion, distinct destinations, and foreground process updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->