### PR TITLE
Fix mise run run: environ dangling under ghostty_init + stale-bundle launch

### DIFF
--- a/Macterm/App/EnvironmentSetup.swift
+++ b/Macterm/App/EnvironmentSetup.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Every mutation of this process's environment, in one place, run once from
+/// `MactermApp.init` — strictly BEFORE anything can touch `GhosttyApp.shared`.
+///
+/// Why the ordering is load-bearing: `ghostty_init` captures `environ` as a
+/// pointer+length slice and keeps it for the life of the process — surface
+/// spawns build the child shell's environment from that cached slice, and
+/// libghostty exposes no C API to re-sync it (its own GTK runtime re-syncs via
+/// an internal `global.syncEnviron()`). A `setenv`/`unsetenv` after init can
+/// realloc `environ`, leaving ghostty's slice dangling: depending on malloc
+/// layout that is a silent stale read (panes stop inheriting the new vars) or
+/// a crash in the spawn path — observed as the debug app dying ~0.5s into
+/// launch with a null read inside libghostty's environ scan, breakpad's
+/// handler then `_exit(1)`ing with nothing on stderr.
+///
+/// SwiftUI triggers `GhosttyApp.shared` lazily during scene construction,
+/// which can run before `applicationDidFinishLaunching` — so ADFL is too late
+/// for env setup. `MactermApp.init` runs before any scene builds.
+/// `GhosttyApp.init` preconditions on `didRun` so a future regression of this
+/// ordering fails loudly instead of corrupting spawn environments.
+@MainActor
+enum EnvironmentSetup {
+    private(set) static var didRun = false
+
+    static func runOnce() {
+        guard !didRun else { return }
+        didRun = true
+
+        // A launcher terminal's zmx session marker must not leak into our
+        // panes (see ZmxEnvironment.scrubInheritedSession).
+        ZmxEnvironment.scrubInheritedSession()
+
+        // Control socket for the bundled `macterm` CLI. The path is
+        // deterministic (the server binds this same path later, in
+        // applicationDidFinishLaunching), so the env var can be exported
+        // before the server starts — every shell must inherit it via
+        // ghostty's captured environ.
+        setenv(ControlProtocol.socketEnvVar, ControlSocketServer.defaultSocketPath(), 1)
+
+        // Bundled `macterm` CLI on PATH for every pane, same inheritance
+        // path as MACTERM_SOCKET above.
+        if let binDir = Bundle.main.resourceURL?.appendingPathComponent("bin", isDirectory: true).path,
+           FileManager.default.isExecutableFile(atPath: binDir + "/macterm")
+        {
+            let existingPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
+            setenv("PATH", existingPath.isEmpty ? binDir : "\(binDir):\(existingPath)", 1)
+        }
+    }
+}

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -11,6 +11,14 @@ struct MactermApp: App {
     @State
     private var projectStore = ProjectStore()
 
+    init() {
+        // Must precede any scene construction: SwiftUI can touch
+        // `GhosttyApp.shared` while building views, and every environment
+        // mutation has to land before `ghostty_init` captures environ.
+        // See EnvironmentSetup for the full contract.
+        EnvironmentSetup.runOnce()
+    }
+
     var body: some Scene {
         WindowGroup {
             MainWindow()
@@ -284,22 +292,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
             return
         }
-        // Before anything can spawn a surface: a launcher terminal's zmx
-        // session marker must not leak into our panes (see ZmxEnvironment).
-        ZmxEnvironment.scrubInheritedSession()
-        // Control socket for the bundled `macterm` CLI. Started before any
-        // surface spawns so every shell inherits MACTERM_SOCKET and the
-        // bundled CLI on PATH (setenv mutates this process's environ, which
-        // libghostty passes to spawned shells). Requests get a `starting`
-        // error until installResponders attaches the handler.
+        // MACTERM_SOCKET, PATH, and the zmx-session scrub moved to
+        // EnvironmentSetup (run from MactermApp.init): environ must not be
+        // mutated after ghostty_init captures it, and SwiftUI can trigger
+        // GhosttyApp.shared before this method runs. Binding the socket
+        // itself can stay here — only the env var needed to move. Requests
+        // get a `starting` error until installResponders attaches the
+        // handler.
         controlServer.start()
-        setenv(ControlProtocol.socketEnvVar, controlServer.path, 1)
-        if let binDir = Bundle.main.resourceURL?.appendingPathComponent("bin", isDirectory: true).path,
-           FileManager.default.isExecutableFile(atPath: binDir + "/macterm")
-        {
-            let existingPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
-            setenv("PATH", existingPath.isEmpty ? binDir : "\(binDir):\(existingPath)", 1)
-        }
         UNUserNotificationCenter.current().delegate = NotificationHandler.shared
         if BenchmarkControl.isEnabled {
             // Under the CI benchmark, the notification-permission alert would

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -48,6 +48,17 @@ final class GhosttyApp {
     private var themeColorsCache: (version: Int, colors: ThemeResolver.Colors?)?
 
     private init() {
+        // ghostty_init captures `environ` as a pointer+length slice for the
+        // life of the process (surface spawns read it; no C API re-syncs it).
+        // Any setenv/unsetenv after that capture leaves the slice dangling —
+        // observed as a startup crash in the spawn path. App-level env
+        // mutation lives in EnvironmentSetup, which must already have run;
+        // resolveResources() below also setenvs, deliberately before the
+        // ghostty_init call on this same path.
+        precondition(
+            EnvironmentSetup.didRun,
+            "EnvironmentSetup.runOnce() must precede ghostty_init — environ is captured here"
+        )
         systemScheme = Self.readSystemScheme()
         resolveResources()
         guard ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv) == GHOSTTY_SUCCESS else {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -20,4 +20,20 @@ xcodebuild \
   | (xcbeautify --quiet 2>/dev/null || cat)
 
 APP="$DERIVED_DATA/Build/Products/Debug/Macterm.app"
-open "$APP"
+
+# `-n` forces a new instance of the bundle AT THIS PATH. Without it, `open`
+# resolves through LaunchServices, which on a dev machine has many bundles
+# registered under the same `com.thdxg.macterm.debug` ID — this checkout, every
+# `.claude/worktrees/*` copy, stray `~/Library/Developer/Xcode/DerivedData`
+# trees. It usually still picks the path given, but when a stale copy is already
+# running it can reactivate THAT instance instead: observed launching a
+# two-week-old worktree build, which even inherited the argv of the earlier
+# launch record. The freshly built app then never runs, which reads as "the
+# build worked but the app didn't start".
+#
+# Still LaunchServices rather than exec'ing Contents/MacOS/Macterm directly:
+# launch-time activation counts as user intent, so the app becomes active and
+# SwiftUI creates its window. A directly-exec'd app starts backgrounded and can
+# be denied activation indefinitely, never getting a window — the same reason
+# scripts/benchmark.py launches with `open -n`.
+open -n "$APP"


### PR DESCRIPTION
Split out of the PR 185 review session, where `mise run run` reported a successful build but the app never appeared. Two independent fixes; the first is the one that actually resolves the symptom.

## 1. Mutate environ only before `ghostty_init` captures it

The debug app died ~0.5s into launch — silently, exit code 1, nothing on stderr, no crash artifact of its own — when launched from certain environments (a Macterm pane reproduced it deterministically; a plain shell happened not to).

**Root cause:** the GhosttyKit shipped since the output-activity refresh captures `environ` at `ghostty_init` as a pointer+length slice and keeps it for the life of the process. Surface spawns build the child shell's environment from that cache, and the C API exposes no re-sync (ghostty's own GTK runtime re-syncs after env mutations via an internal `global.syncEnviron()` — `src/global.zig`). Macterm's `setenv`/`unsetenv` calls in `applicationDidFinishLaunching` ran **after** `ghostty_init` — SwiftUI touches `GhosttyApp.shared` during scene construction, before ADFL (breadcrumb-timestamped: ghostty init at +0.32s, ADFL at +0.41s). The setenv reallocs `environ` under the cached slice; depending on malloc layout the dangling read is either

- a **silent stale read** — panes quietly stop inheriting `MACTERM_SOCKET`/`PATH`, or
- a **null-deref crash** in the spawn path's environ scan (disassembly: a loop splitting env entries at `'='` loading a NULL entry pointer), which breakpad's Mach handler converts to a bare `_exit(1)` — silent, atexit skipped, wait status 256.

The env-content sensitivity (and lldb/SIGSTOP heisenbug behavior) was malloc-layout roulette on the dangling slice, not semantics.

**Fix:** `EnvironmentSetup` owns every app-level env mutation (zmx session scrub, `MACTERM_SOCKET`, `PATH`) and runs from `MactermApp.init`, before any scene can build. `GhosttyApp.init` `precondition`s on it so the ordering cannot silently regress. The control socket still binds in ADFL — only the env var moved (its path is deterministic).

**Upstream note:** libghostty embedders have no equivalent of `global.syncEnviron()`; a `ghostty_sync_environ()` C export would make this class of bug fixable without ordering constraints. Worth an upstream/fork issue.

## 2. `open -n` in scripts/run.sh

`open <path>` resolves through LaunchServices, which on a dev machine has many bundles registered under `com.thdxg.macterm.debug` (worktree builds, stray DerivedData trees). It usually honours the path, but with a stale copy already running it can reactivate that instance instead — observed launching a two-week-old worktree build that inherited the argv of an earlier launch record. `-n` forces a new instance of the bundle at this path. Launching still goes through LaunchServices (not direct exec) so launch-time activation counts as user intent and SwiftUI creates the window — same reason `scripts/benchmark.py` uses `open -n`.

## Verified

- Fixed build launched from a Macterm pane 5/5 times, visible window each time (previously 0/5)
- Full `mise run run` from a pane: builds, launches, window up
- Fresh panes in the debug app inherit the correct debug `MACTERM_SOCKET` through ghostty's captured environ; the bundled CLI answers on it
- `mise run format`, `lint`, `test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)