### PR TITLE
feat: option to move the tab switcher to the left of the title bar

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -19,6 +19,24 @@ enum TabSwitcherVisibility: String, CaseIterable, Identifiable {
     }
 }
 
+/// Which edge of the title bar the numbered tab switcher sits on (#186).
+/// `leading` maps to the `.navigation` toolbar slot, which AppKit places
+/// ahead of the inline window title — the switcher hugs the sidebar edge
+/// and the title shifts right of it.
+enum TabSwitcherPosition: String, CaseIterable, Identifiable {
+    case leading
+    case trailing
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .leading: "Left"
+        case .trailing: "Right"
+        }
+    }
+}
+
 /// Which `NSGlassEffectView.Style` the liquid-glass window background uses.
 /// Maps to AppKit's `.regular` / `.clear` (see `WindowAppearance`).
 enum WindowGlassStyle: String, CaseIterable, Identifiable {
@@ -141,6 +159,10 @@ final class Preferences {
 
     var tabSwitcherVisibility: TabSwitcherVisibility {
         didSet { defaults.set(tabSwitcherVisibility.rawValue, forKey: Keys.tabSwitcherVisibility) }
+    }
+
+    var tabSwitcherPosition: TabSwitcherPosition {
+        didSet { defaults.set(tabSwitcherPosition.rawValue, forKey: Keys.tabSwitcherPosition) }
     }
 
     /// Sentinel for "no icon" — sidebar rows skip the leading glyph when set.
@@ -359,6 +381,8 @@ final class Preferences {
         terminateSessionsOnQuit = defaults.object(forKey: Keys.terminateSessionsOnQuit) as? Bool ?? false
         tabSwitcherVisibility = (defaults.string(forKey: Keys.tabSwitcherVisibility))
             .flatMap(TabSwitcherVisibility.init(rawValue:)) ?? .whenMultiple
+        tabSwitcherPosition = (defaults.string(forKey: Keys.tabSwitcherPosition))
+            .flatMap(TabSwitcherPosition.init(rawValue:)) ?? .trailing
         Self.runOneTimeMigrations(defaults: defaults)
     }
 
@@ -414,6 +438,7 @@ final class Preferences {
         static let showNewProjectButton = "macterm.sidebar.showNewProjectButton"
         static let terminateSessionsOnQuit = "macterm.session.terminateOnQuit"
         static let tabSwitcherVisibility = "macterm.toolbar.tabSwitcherVisibility"
+        static let tabSwitcherPosition = "macterm.toolbar.tabSwitcherPosition"
         static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"
     }
 }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -370,7 +370,7 @@ private struct AppearanceSettings: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
 
-                Picker("Position", selection: $tabSwitcherPosition) {
+                Picker("Tab switcher position", selection: $tabSwitcherPosition) {
                     ForEach(TabSwitcherPosition.allCases) { option in
                         Text(option.displayName).tag(option.rawValue)
                     }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -240,6 +240,7 @@ private struct AppearanceSettings: View {
     @State private var showTabStatusIndicator: Bool = Preferences.shared.showTabStatusIndicator
     @State private var showNewProjectButton: Bool = Preferences.shared.showNewProjectButton
     @State private var tabSwitcherVisibility: String = Preferences.shared.tabSwitcherVisibility.rawValue
+    @State private var tabSwitcherPosition: String = Preferences.shared.tabSwitcherPosition.rawValue
     @State
     private var backgroundOpacity: Double = Preferences.shared.windowOpacity
     @State
@@ -366,6 +367,18 @@ private struct AppearanceSettings: View {
                     Preferences.shared.tabSwitcherVisibility = TabSwitcherVisibility(rawValue: v) ?? .whenMultiple
                 }
                 Text("Numbered control in the title bar for switching tabs by index.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+
+                Picker("Position", selection: $tabSwitcherPosition) {
+                    ForEach(TabSwitcherPosition.allCases) { option in
+                        Text(option.displayName).tag(option.rawValue)
+                    }
+                }
+                .onChange(of: tabSwitcherPosition) { _, v in
+                    Preferences.shared.tabSwitcherPosition = TabSwitcherPosition(rawValue: v) ?? .trailing
+                }
+                Text("Left places the switcher before the window title, next to the sidebar.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -13,11 +13,16 @@ struct MainWindow: View {
     private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State
     private var detailWidth: CGFloat = .infinity
+    @State
+    private var preferences = Preferences.shared
 
     var body: some View {
         // Derive bindings to the @Observable AppState via @Bindable (the
         // Observation-era idiom) rather than a hand-rolled Binding(get:set:).
         @Bindable var appState = appState
+        // Read in body, not inside the toolbar builder, so the Observation
+        // dependency is registered and a Settings change re-places the item.
+        let switcherPosition = preferences.tabSwitcherPosition
         return NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarContent()
                 .navigationSplitViewColumnWidth(min: 140, ideal: 180, max: 280)
@@ -51,8 +56,20 @@ struct MainWindow: View {
                 ToolbarItem(placement: .primaryAction) {
                     UpdateAvailableToolbarButton()
                 }
-                ToolbarItem(placement: .primaryAction) {
-                    TabSwitcherToolbarItem(availableWidth: detailWidth)
+                // Structural branch, not a placement ternary: each side is its
+                // own toolbar item identity, so flipping the preference tears
+                // down and re-places the control instead of relying on AppKit
+                // migrating an existing item between toolbar slots.
+                if switcherPosition == .leading {
+                    // `.navigation` is the leading slot — AppKit puts it ahead
+                    // of the inline window title, next to the sidebar (#186).
+                    ToolbarItem(placement: .navigation) {
+                        TabSwitcherToolbarItem(availableWidth: detailWidth)
+                    }
+                } else {
+                    ToolbarItem(placement: .primaryAction) {
+                        TabSwitcherToolbarItem(availableWidth: detailWidth)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #186.

## What

Adds **Settings → Appearance → Toolbar → Position** (Left / Right) for the numbered tab switcher. **Left** places the control in the `.navigation` toolbar slot, which AppKit lays out at the leading edge of the detail title bar — ahead of the inline window title, hugging the sidebar edge, where the issue wants it on big/ultrawide screens. The default stays **Right** (`.primaryAction`), so existing behavior is unchanged.

## How

- `TabSwitcherPosition` enum + `Preferences.tabSwitcherPosition` (`macterm.toolbar.tabSwitcherPosition`), mirroring the existing `tabSwitcherVisibility` plumbing.
- `MainWindow` reads the preference in `body` (registers the Observation dependency, so a Settings change re-places the item live) and branches structurally between two `ToolbarItem`s rather than using a placement ternary — each side is its own toolbar-item identity, so flipping the preference tears down and re-places the control instead of relying on AppKit migrating a live item between slots.
- Settings picker sits directly under the existing tab switcher visibility picker, written back through `Preferences.shared` (not `@AppStorage`, per the banned-`UserDefaults.standard` rule).

Native-only: `.navigation` is a first-class SwiftUI placement (the slot Safari/Finder use for back/forward), no titlebar customization involved. One consequence of the native slot: with **Left** selected, the window title (project name + path) shifts to the right of the switcher, since AppKit puts navigation items ahead of the inline title.

## Verification

- `mise run format` / `lint` / `test` all green.
- Verified live in a hermetic debug instance (isolated `MACTERM_BENCHMARK_DATA_DIR`, 4 tabs via the `macterm` CLI): with no preference set the switcher renders at the top right as before; with `macterm.toolbar.tabSwitcherPosition = leading` it renders at the leading edge next to the sidebar, title to its right, and Cmd+1…9 switching still works through the same picker binding.
- Live re-placement on Settings change relies on the Observation read in `body` (same mechanism as every other Settings control); not separately exercised headlessly since Settings can't be driven from the CLI.