### PR TITLE
Let Apply/Save Layout be bound to a key

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -169,12 +169,12 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .renameTab: .renameTab
         case .renameProject: .renameProject
         case .copySessionID: .copySessionID
+        case .applyLayout: .applyLayout
+        case .saveLayout: .saveLayout
         case .newRemoteProject,
              .unloadProject,
              .removeProject,
              .replaceProjectPathWithCurrentDir,
-             .applyLayout,
-             .saveLayout,
              .checkForUpdate: nil
         }
     }

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -39,6 +39,8 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
     case renameTab = "rename_tab"
     case renameProject = "rename_project"
     case copySessionID = "copy_session_id"
+    case applyLayout = "apply_layout"
+    case saveLayout = "save_layout"
 
     var id: String { rawValue }
 
@@ -80,6 +82,10 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .renameTab: "cmd+r"
         case .renameProject: "none"
         case .copySessionID: "none"
+        // Unbound by default: both rewrite or replace the live pane tree, so a
+        // stray keystroke on a stock binding would be destructive.
+        case .applyLayout: "none"
+        case .saveLayout: "none"
         }
     }
 }

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -290,8 +290,11 @@ final class MainAppResponder: KeyResponder {
         // truth shared with the palette and menu bar — so the paths can't drift.
         // Rename defers begin-editing a tick (see AppCommandActions) so the
         // sidebar row's TextField exists before it takes first responder;
-        // copySessionID writes the focused pane's zmx name to the pasteboard.
-        for action in [HotkeyAction.renameTab, .renameProject, .copySessionID] {
+        // copySessionID writes the focused pane's zmx name to the pasteboard;
+        // the layout pair inherits the same enablement guards (no applicable
+        // project file → nil action → the keystroke falls through) and the same
+        // error-presenting wrappers the palette and menu bar get.
+        for action in [HotkeyAction.renameTab, .renameProject, .copySessionID, .applyLayout, .saveLayout] {
             guard HotkeyRegistry.matches(event, action: action),
                   let command = AppCommand.allCases.first(where: { $0.hotkeyAction == action })
             else { continue }

--- a/MactermTests/App/HotkeysTests.swift
+++ b/MactermTests/App/HotkeysTests.swift
@@ -322,6 +322,18 @@ struct HotkeysTests {
     }
 
     @Test
+    func layout_actions_are_unbound_by_default_and_titled_from_command() {
+        // Both ship unbound: applying or saving a layout rewrites the live pane
+        // tree, so a stock binding would make a mistyped chord destructive.
+        #expect(HotkeyAction.applyLayout.defaultShortcut == "none")
+        #expect(HotkeyAction.saveLayout.defaultShortcut == "none")
+        #expect(HotkeyAction.applyLayout.title == "Apply Layout")
+        #expect(HotkeyAction.saveLayout.title == "Save Layout")
+        #expect(AppCommand.applyLayout.hotkeyAction == .applyLayout)
+        #expect(AppCommand.saveLayout.hotkeyAction == .saveLayout)
+    }
+
+    @Test
     func all_action_ids_are_unique() {
         let ids = HotkeyAction.allCases.map(\.rawValue)
         #expect(ids.count == Set(ids).count)


### PR DESCRIPTION
## What

Makes **Apply Layout** and **Save Layout** rebindable commands. Both ship unbound (`none`) — they gain a Settings → Keymaps row and a working binding, not a default shortcut.

## Why

Both were palette-only. They're the kind of action you reach for repeatedly while iterating on a project's pane layout, and every comparable command is already bindable.

Unbound by default is deliberate rather than just conservative: Apply Layout rewrites the live pane tree and Save Layout overwrites the project file, so a stock chord would make a mistyped binding destructive. Opt-in via Settings.

## How

Follows the "Adding a New Action" recipe in CLAUDE.md:

1. `HotkeyAction` gains `applyLayout` / `saveLayout` (`apply_layout` / `save_layout`), both defaulting to `"none"`.
2. `AppCommand.hotkeyAction` links them — they move out of the `nil` group. Titles flow from `AppCommand`, so Settings renders "Apply Layout"/"Save Layout" under Projects with no new strings.
3. `MainAppResponder` appends both to the existing loop that dispatches through `AppCommand.action(in:)`.

Step 3 is what keeps this small. Neither command gets a hand-written handler, so both inherit the palette's enablement guards — Apply Layout with no applicable project file yields a `nil` action and the keystroke falls through instead of firing a no-op — plus the same error-presenting wrappers (`applyLayoutPresentingError` / `saveLayoutPresentingError`). The key path and the palette path can't drift.

Settings → Keymaps picks both up automatically via `HotkeyAction.allCases`, as does `isAppShortcut` in `GhosttyTerminalNSView`, so once bound the chord passes through the terminal instead of being typed into the shell.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [ ] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

`HotkeysTests.layout_actions_are_unbound_by_default_and_titled_from_command` pins the unbound defaults and the command↔action links, mirroring the existing `copySessionID` test. Confirmed it actually ran and passed in the xcresult rather than relying on a green suite.

Not exercised in a running app — the change is config/dispatch wiring with no default binding to press, and the dispatch path it joins is already covered by the three commands using it.

## Notes for reviewers

Apply/Save Layout have **no menu-bar items** today (palette-only), and I left that alone as outside the ask — so they gain a Settings row and a binding but no Project-menu entry. Adding them there is a reasonable follow-up.

Worth a look: the two new `HotkeyAction` raw values are persistence keys (`macterm.hotkey.apply_layout` / `…save_layout`), so renaming a case later is a stored-preference migration.
