### PR TITLE
Skip format/lint/test/build when their inputs are unchanged

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -35,6 +35,26 @@ run = """
 description = "Build release app and DMG"
 depends = ["format", "lint", "test"]
 usage = 'flag "-v --verbose" help="Stream raw output instead of the spinner"'
+# The DMG name embeds $VERSION, so it can't be listed as a static output —
+# `auto` tracks a hash of the task definition instead. Inputs are everything
+# that reaches the archive: Swift sources, the xcodegen spec, the Info.plist /
+# entitlements / icon that project.yml references, and the build + embed
+# scripts. GhosttyKit and Macterm/Resources/{ghostty,terminfo,zmx} are
+# setup.sh-downloaded gitignored artifacts, refreshed by deleting them, so
+# their absence is caught by setup.sh rather than by this check.
+sources = [
+  "Macterm/**/*.swift",
+  "CLI/**/*.swift",
+  "Macterm/Info.plist",
+  "Macterm/Macterm.entitlements",
+  "Macterm/AppIcon.icon/**/*",
+  "project.yml",
+  "scripts/build.sh",
+  "scripts/setup.sh",
+  "scripts/embed-zmx.sh",
+  "scripts/_lib.sh",
+]
+outputs = { auto = true }
 run = """
   source scripts/_lib.sh
   if [[ "$usage_verbose" == "true" ]]; then
@@ -88,6 +108,11 @@ usage = '''
 flag "-v --verbose" help="Stream raw output instead of the spinner"
 flag "--check" help="Verify formatting without modifying files (CI mode)"
 '''
+# swiftformat walks the repo root minus `build,GhosttyKit,scripts`
+# (.swiftformat), which in practice is these three Swift dirs. `auto` outputs:
+# formatting rewrites its own inputs, so there's no separate artifact to stat.
+sources = ["Macterm/**/*.swift", "CLI/**/*.swift", "MactermTests/**/*.swift", ".swiftformat"]
+outputs = { auto = true }
 run = """
   source scripts/_lib.sh
   args=()
@@ -106,6 +131,17 @@ run = """
 [tasks.lint]
 description = "Run swiftlint"
 usage = 'flag "-v --verbose" help="Stream raw output instead of the spinner"'
+# Mirrors .swiftlint.yml's `included:` list, plus both configs (the nested
+# MactermTests one relaxes rules for test code). Lint writes nothing, so `auto`
+# stands in for a real output artifact.
+sources = [
+  "Macterm/**/*.swift",
+  "CLI/**/*.swift",
+  "MactermTests/**/*.swift",
+  ".swiftlint.yml",
+  "MactermTests/.swiftlint.yml",
+]
+outputs = { auto = true }
 run = """
   source scripts/_lib.sh
   if [[ "$usage_verbose" == "true" ]]; then
@@ -118,6 +154,19 @@ run = """
 [tasks.test]
 description = "Run the test suite"
 usage = 'flag "-v --verbose" help="Stream raw output instead of the spinner"'
+# Tests are hosted inside the debug app, so the app and CLI sources are inputs
+# too, as is project.yml (test.sh regenerates the Xcode project from it).
+# DerivedData is a build dir, not a stable artifact to stat, hence `auto`.
+sources = [
+  "Macterm/**/*.swift",
+  "CLI/**/*.swift",
+  "MactermTests/**/*.swift",
+  "Macterm/Info.plist",
+  "project.yml",
+  "scripts/test.sh",
+  "scripts/setup.sh",
+]
+outputs = { auto = true }
 run = """
   source scripts/_lib.sh
   if [[ "$usage_verbose" == "true" ]]; then


### PR DESCRIPTION
Adds `sources` to the `format`, `lint`, `test`, and `build` tasks so mise can skip them when nothing they read has changed. Previously a `mise run run` after a no-op edit still paid for a full format + lint pass.

## Source sets

Derived from what each tool actually reads, rather than a blanket glob:

- **format** — the three Swift dirs (`.swiftformat` excludes `build,GhosttyKit,scripts`, and Swift only lives in `Macterm`, `CLI`, `MactermTests`) plus `.swiftformat` itself.
- **lint** — `.swiftlint.yml`'s `included:` list, plus *both* configs. The nested `MactermTests/.swiftlint.yml` relaxes rules for test code and is an easy input to miss.
- **test** / **build** — Swift sources plus `project.yml` (both regenerate the Xcode project from it) and the shell scripts they invoke.

## Why `outputs` is also required

`sources` on its own is inert: mise skips a task only when the oldest `outputs` file is newer than the newest `sources` file, so with no `outputs` there is nothing to compare against and the task always runs.

None of the four produce a stable artifact to stat — format rewrites its inputs, lint writes nothing, test emits churning DerivedData, and build's DMG name embeds `$VERSION`. Each therefore pairs with `outputs = { auto = true }`, which has mise track an internal file hashed from the task definition.

## Verification

Confirmed against an isolated probe task (a real one is hard to observe, since `swiftlint --quiet` succeeds silently and has its own internal cache that muddies timings):

| run | result |
|---|---|
| 1 — cold | executed |
| 2 — no changes | **skipped** |
| 3 — after touching a source | executed |

On the real `lint` task: 0.97s cold → 0.025s warm; touching a `.swift` file invalidated it while touching `README.md` did not. `mise tasks info` resolves an output path for all four, and `format --check` and `lint` both pass on a forced run (0/137 files require formatting).

## Notes

- **CI is unaffected today, but worth knowing.** mise state lives in `~/.local/state/mise`, which runners don't persist, so every CI run is still fresh. This becomes a hazard only if that directory is ever cached — a cached `format --check` or `test` would report green from a prior run rather than a fresh one.
- `mise run --force <task>` bypasses the check. The flag goes **before** the task name; placed after, the task's own usage spec swallows it.
- `setup` was left alone (its inputs are network releases, not files). `run`, `install`, and `bench` inherit the caching transitively through their `depends`.
- Unrelated observation surfaced by the verbose format output: swiftformat also loads `/Users/…/macterm/.swiftformat` from the parent checkout via config inheritance when run inside a worktree. Pre-existing, not trackable from inside the worktree, left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)