### PR TITLE
Make eager tab start and session persistence unconditional

### DIFF
--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -541,12 +541,9 @@ final class AppState {
     /// active one — so a multi-tab project (e.g. from a declarative layout) has
     /// all its processes running on open. Other projects stay lazy. The active
     /// tab is created by SwiftUI as usual; the rest are warmed off-screen via
-    /// `SurfaceIncubator`. No-op when the toggle is off.
+    /// `SurfaceIncubator`.
     func warmFocusedProject() {
-        guard Preferences.shared.eagerlyStartProjectTabs,
-              let projectID = activeProjectID,
-              let ws = workspaces[projectID]
-        else { return }
+        guard let projectID = activeProjectID, let ws = workspaces[projectID] else { return }
         // Stagger the spawns: each warm is a login shell (PAM, rc files) and —
         // when restoring — a `zmx attach` reattaching a daemon. Firing them all
         // in one tick multiplies launch pressure with tab count (cmux hit a

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -503,47 +503,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_: Notification) {
         controlServer.stop()
         onTerminate?()
-        // Quit is a DETACH by default: workspace panes' sessions survive and
+        // Quit is always a DETACH: workspace panes' sessions survive and
         // reattach on relaunch (the snapshot saved by onTerminate carries each
         // pane's session identity). Quick-terminal sessions are ephemeral —
-        // never persisted — so they're always killed; leaving them would only
-        // feed the next launch's reaper. The terminate-on-quit setting opts
-        // into killing everything. Kills block briefly so they land before
+        // never persisted — so they're the only ones killed here; leaving them
+        // would only feed the next launch's reaper. Those are local, so no
+        // remote sweep is needed. The kills block briefly so they land before
         // the process exits (a detached Task is never scheduled during
         // teardown), bounded by ZmxClient's timeouts.
-        var names = QuickTerminalService.shared.splitState.tab.splitRoot.allPanes().map(\.sessionName)
-        var remoteKills: [ZmxClient.RemoteKill] = []
-        if Preferences.shared.terminateSessionsOnQuit {
-            for pane in (appState?.workspaces.values ?? [:].values)
-                .flatMap(\.tabs)
-                .flatMap({ $0.splitRoot.allPanes() })
-            {
-                // "Kill everything" includes remote sessions — routed over
-                // ssh; a local kill of a remote name would silently no-op
-                // and strand the session running on the host.
-                if let remote = ProjectPath.remote(from: pane.projectPath) {
-                    remoteKills.append(.init(
-                        remote: remote, sessionID: pane.sessionName, zmxPath: pane.remoteZmxPath
-                    ))
-                } else {
-                    names.append(pane.sessionName)
-                }
-            }
-        }
+        let names = QuickTerminalService.shared.splitState.tab.splitRoot.allPanes().map(\.sessionName)
         (appState?.zmx ?? .live).killSessionsBlocking(names)
-        (appState?.zmx ?? .live).killRemoteSessionsBlocking(remoteKills)
     }
 
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
         // Silent quit when persistence is active: workspace sessions detach
         // and reattach next launch, so there's nothing to confirm for them.
-        // The full prompt returns when the user opted into terminate-on-quit,
-        // or when zmx is unavailable (sessions genuinely die with the app).
-        // Quick-terminal sessions are ephemeral and die on every quit, so a
-        // busy quick-terminal pane still confirms even on a silent quit —
-        // the confirmation follows the destruction.
+        // The full prompt returns only when zmx is unavailable (sessions
+        // genuinely die with the app). Quick-terminal sessions are ephemeral
+        // and die on every quit, so a busy quick-terminal pane still confirms
+        // even on a silent quit — the confirmation follows the destruction.
         let persistenceActive = (appState?.zmx ?? .live).isBundled()
-            && !Preferences.shared.terminateSessionsOnQuit
         if persistenceActive {
             let qtRows = collectQuickTerminalRows()
             if qtRows.isEmpty || QuitConfirmation.runModal(rows: qtRows) {

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -141,15 +141,6 @@ final class Preferences {
         didSet { defaults.set(showNewProjectButton, forKey: Keys.showNewProjectButton) }
     }
 
-    /// When true, quitting Macterm kills every pane's zmx session so nothing
-    /// keeps running in the background. Default off — session persistence
-    /// (shells survive quit and reattach on relaunch) is the point, so quit
-    /// detaches rather than terminates. Macterm-side only; never touches the
-    /// ghostty config pipeline.
-    var terminateSessionsOnQuit: Bool {
-        didSet { defaults.set(terminateSessionsOnQuit, forKey: Keys.terminateSessionsOnQuit) }
-    }
-
     /// Which appcast channel auto-updates come from. Read by `Updater`'s
     /// `allowedChannelsForUpdater`, so `.beta` makes prerelease items visible to
     /// both the scheduled check and "Check for Updates…". Defaults to `.stable`:
@@ -403,7 +394,6 @@ final class Preferences {
         showAgentIcons = defaults.object(forKey: Keys.showAgentIcons) as? Bool ?? true
         showTabStatusIndicator = defaults.object(forKey: Keys.showTabStatusIndicator) as? Bool ?? false
         showNewProjectButton = defaults.object(forKey: Keys.showNewProjectButton) as? Bool ?? true
-        terminateSessionsOnQuit = defaults.object(forKey: Keys.terminateSessionsOnQuit) as? Bool ?? false
         updateChannel = (defaults.string(forKey: Keys.updateChannel))
             .flatMap(UpdateChannel.init(rawValue:)) ?? .stable
         tabSwitcherVisibility = (defaults.string(forKey: Keys.tabSwitcherVisibility))
@@ -440,12 +430,14 @@ final class Preferences {
             defaults.removeObject(forKey: "macterm.input.optionAsAlt")
             defaults.set(true, forKey: Keys.migrationV2GhosttyConfigOwned)
         }
-        // Eager tab start is unconditional now, so its key is dead. Drop a
-        // stored `false` rather than leave it to silently take effect again if
-        // anything is ever wired back onto that key.
-        if !defaults.bool(forKey: Keys.migrationEagerTabStartAlways) {
+        // Eager tab start and session persistence are both unconditional now,
+        // so their keys are dead. Drop the stored values rather than leave them
+        // to silently take effect again if anything is ever wired back onto
+        // those keys.
+        if !defaults.bool(forKey: Keys.migrationRetiredToggleKeys) {
             defaults.removeObject(forKey: "macterm.eagerlyStartProjectTabs.enabled")
-            defaults.set(true, forKey: Keys.migrationEagerTabStartAlways)
+            defaults.removeObject(forKey: "macterm.session.terminateOnQuit")
+            defaults.set(true, forKey: Keys.migrationRetiredToggleKeys)
         }
     }
 
@@ -469,11 +461,10 @@ final class Preferences {
         static let showAgentIcons = "macterm.sidebar.showAgentIcons"
         static let showTabStatusIndicator = "macterm.sidebar.showTabStatusIndicator"
         static let showNewProjectButton = "macterm.sidebar.showNewProjectButton"
-        static let terminateSessionsOnQuit = "macterm.session.terminateOnQuit"
         static let updateChannel = "macterm.updates.channel"
         static let tabSwitcherVisibility = "macterm.toolbar.tabSwitcherVisibility"
         static let tabSwitcherPosition = "macterm.toolbar.tabSwitcherPosition"
         static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"
-        static let migrationEagerTabStartAlways = "macterm.migration.eager_tab_start_always"
+        static let migrationRetiredToggleKeys = "macterm.migration.retired_toggle_keys"
     }
 }

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -103,12 +103,6 @@ final class Preferences {
         }
     }
 
-    /// Start every tab of the focused project immediately (off-screen) rather
-    /// than only the active tab. Defaults to on.
-    var eagerlyStartProjectTabs: Bool {
-        didSet { defaults.set(eagerlyStartProjectTabs, forKey: Keys.eagerlyStartProjectTabs) }
-    }
-
     /// Multiplier applied to terminal scroll wheel / trackpad row deltas.
     var terminalScrollSpeed: Double {
         didSet { defaults.set(terminalScrollSpeed, forKey: Keys.terminalScrollSpeed) }
@@ -390,7 +384,6 @@ final class Preferences {
     private init(defaults: UserDefaults) {
         self.defaults = defaults
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
-        eagerlyStartProjectTabs = (defaults.object(forKey: Keys.eagerlyStartProjectTabs) as? Bool) ?? true
         terminalScrollSpeed = Self.clampScrollSpeed(defaults.double(forKey: Keys.terminalScrollSpeed), fallback: 1.0)
         paneDimOpacity = Self.clampPaneDimOpacity(
             (defaults.object(forKey: Keys.paneDimOpacity) as? Double) ?? 0.2
@@ -447,13 +440,19 @@ final class Preferences {
             defaults.removeObject(forKey: "macterm.input.optionAsAlt")
             defaults.set(true, forKey: Keys.migrationV2GhosttyConfigOwned)
         }
+        // Eager tab start is unconditional now, so its key is dead. Drop a
+        // stored `false` rather than leave it to silently take effect again if
+        // anything is ever wired back onto that key.
+        if !defaults.bool(forKey: Keys.migrationEagerTabStartAlways) {
+            defaults.removeObject(forKey: "macterm.eagerlyStartProjectTabs.enabled")
+            defaults.set(true, forKey: Keys.migrationEagerTabStartAlways)
+        }
     }
 
     // MARK: - UserDefaults keys
 
     enum Keys {
         static let autoTiling = "macterm.autoTiling.enabled"
-        static let eagerlyStartProjectTabs = "macterm.eagerlyStartProjectTabs.enabled"
         static let terminalScrollSpeed = "macterm.terminal.scrollSpeed"
         static let paneDimOpacity = "macterm.pane.dimOpacity"
         static let windowOpacity = "macterm.window.opacity"
@@ -475,5 +474,6 @@ final class Preferences {
         static let tabSwitcherVisibility = "macterm.toolbar.tabSwitcherVisibility"
         static let tabSwitcherPosition = "macterm.toolbar.tabSwitcherPosition"
         static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"
+        static let migrationEagerTabStartAlways = "macterm.migration.eager_tab_start_always"
     }
 }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -386,7 +386,6 @@ private struct GeneralSettings: View {
     // NOT `@AppStorage`, which binds to `UserDefaults.standard` — banned by the
     // project, and it diverged from the `.onChange` write-through under test.
     @State private var autoTilingEnabled: Bool = Preferences.shared.autoTilingEnabled
-    @State private var eagerlyStartProjectTabs: Bool = Preferences.shared.eagerlyStartProjectTabs
     @State private var terminateSessionsOnQuit: Bool = Preferences.shared.terminateSessionsOnQuit
 
     /// Why session persistence is inactive, when it is. Missing binary is a
@@ -455,13 +454,6 @@ private struct GeneralSettings: View {
                         Preferences.shared.autoTilingEnabled = v
                     }
                 Text("Distributes pane sizes evenly on split and close.")
-                    .settingsCaption()
-
-                Toggle("Start all tabs of the focused project", isOn: $eagerlyStartProjectTabs)
-                    .onChange(of: eagerlyStartProjectTabs) { _, v in
-                        Preferences.shared.eagerlyStartProjectTabs = v
-                    }
-                Text("Runs every tab's processes when a project opens, not just the active tab.")
                     .settingsCaption()
             }
 

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -381,12 +381,11 @@ extension View {
 // MARK: - General
 
 private struct GeneralSettings: View {
-    // Seeded from and written back through `Preferences` (the single
-    // UserDefaults seam that redirects to a wiped side-suite under XCTest).
-    // NOT `@AppStorage`, which binds to `UserDefaults.standard` — banned by the
-    // project, and it diverged from the `.onChange` write-through under test.
+    /// Seeded from and written back through `Preferences` (the single
+    /// UserDefaults seam that redirects to a wiped side-suite under XCTest).
+    /// NOT `@AppStorage`, which binds to `UserDefaults.standard` — banned by the
+    /// project, and it diverged from the `.onChange` write-through under test.
     @State private var autoTilingEnabled: Bool = Preferences.shared.autoTilingEnabled
-    @State private var terminateSessionsOnQuit: Bool = Preferences.shared.terminateSessionsOnQuit
 
     /// Why session persistence is inactive, when it is. Missing binary is a
     /// dev-build state; an over-budget socket path is an environment problem
@@ -457,18 +456,13 @@ private struct GeneralSettings: View {
                     .settingsCaption()
             }
 
-            Section("Session Persistence") {
-                Toggle("Quit terminals when Macterm quits", isOn: $terminateSessionsOnQuit)
-                    .onChange(of: terminateSessionsOnQuit) { _, v in
-                        Preferences.shared.terminateSessionsOnQuit = v
-                    }
-                Text("Off: shells keep running after you quit and reattach on next launch.")
-                    .settingsCaption()
-
-                // Persistence can be silently unavailable (Supacode shipped the
-                // same probe and users only noticed via a buried log line) —
-                // say so where the toggle lives.
-                if ZmxClient.live.executableURL() == nil {
+            // Shells always keep running after quit and reattach on the next
+            // launch — there's no setting, so the section exists only to report
+            // that persistence is unavailable. It can be silently so (Supacode
+            // shipped the same probe and users only noticed via a buried log
+            // line), which is the whole reason to say it in the UI at all.
+            if ZmxClient.live.executableURL() == nil {
+                Section("Session Persistence") {
                     Label {
                         Text(zmxUnavailableReason)
                     } icon: {

--- a/Macterm/System/ZmxClient.swift
+++ b/Macterm/System/ZmxClient.swift
@@ -220,29 +220,6 @@ extension ZmxClient {
         runKillsBlocking(sessionIDs.map { id in { await kill(id) } }, timeout: timeout)
     }
 
-    /// Remote counterpart of `killSessionsBlocking`, for the quit path's
-    /// terminate-on-quit sweep. Longer default cap: each kill is an ssh
-    /// round-trip (BatchMode, so it fails fast rather than prompting — an
-    /// unreachable host just forfeits its kills when the cap lands).
-    /// One remote session to tear down on quit: its host spec, session name,
-    /// and the project's optional explicit zmx path.
-    struct RemoteKill {
-        let remote: ProjectPath
-        let sessionID: String
-        let zmxPath: String?
-    }
-
-    nonisolated func killRemoteSessionsBlocking(
-        _ kills: [RemoteKill],
-        timeout: Duration = .seconds(12)
-    ) {
-        let kill = killRemoteSession
-        runKillsBlocking(
-            kills.map { k in { await kill(k.remote, k.sessionID, k.zmxPath) } },
-            timeout: timeout
-        )
-    }
-
     nonisolated private func runKillsBlocking(
         _ kills: [@Sendable () async -> Void],
         timeout: Duration


### PR DESCRIPTION
Two settings that only ever offered a way to opt *out* of a feature the app is built around. Both shipped defaulting to the on behaviour, neither had a story for the off path, and nothing pointed users toward either. This makes both unconditional and removes the settings.

## Eager tab start

Starting every tab of the focused project (not just the active one) is what a multi-tab project — typically from a declarative layout — wants on open.

- `AppState.warmFocusedProject` loses its preference guard. The staggered 125ms warm loop and `panesToWarm` (active tab excluded — SwiftUI starts it) are unchanged.
- Settings → General → Layout loses the "Start all tabs of the focused project" toggle. The section keeps auto-tiling.

## Session persistence

Quit already detached by default: shells keep running under their zmx session and reattach on relaunch. The toggle's only job was to turn that off.

- `applicationWillTerminate` no longer sweeps workspace sessions. Only the ephemeral quick-terminal ones are killed — and those are local, so the remote sweep goes with it.
- `applicationShouldTerminate` takes the silent-quit path whenever zmx is bundled. The full quit prompt is now reached only when zmx is unavailable, i.e. when sessions genuinely die with the app.
- `ZmxClient.killRemoteSessionsBlocking` and its `RemoteKill` struct are removed — the terminate-on-quit sweep was their only caller. Per-pane remote teardown still goes through `killRemoteSession`, untouched.
- Settings → General → Session Persistence now renders **only** when persistence is unavailable, since the zmx-missing warning is the one thing left worth saying there. An always-visible section holding nothing but a conditional warning would otherwise show an empty header.

The docs page needed no change — [session persistence](website/docs/pages/60-session-persistence.md) already described quit as an unconditional detach with no confirmation dialog, so the code now matches what was already documented.

## Retiring the stored keys

Users who flipped either toggle have a value sitting in their defaults that nothing reads after this change. Both keys are dropped by a one-time migration alongside the existing v2 cleanup, for the reason that cleanup already records in the source: a lingering value would silently take effect again if anything were ever wired back onto those keys.

## Testing

`mise run format`, `lint`, and `test` all pass.

The two `panesToWarm` unit tests cover the pure selection logic and are untouched — the guard that was removed sat above them in the caller. Nothing referenced the removed preferences or the remote quit sweep from tests, the e2e suite, or the benchmark harness.

No GUI verification run: the quit path's *default* behaviour is unchanged by this (the pref already defaulted to detach), so what's removed is the opt-out branch rather than the path everyone exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)