### PR TITLE
Stop stale and phantom tab state after a command finishes

### DIFF
--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -165,6 +165,17 @@ struct TerminalExecutionTracker {
         return false
     }
 
+    /// Whether the shell is sitting at a prompt — see `shellIsAtPrompt`. Read by
+    /// the naming path so a prompt hook can't rename the tab.
+    var isShellAtPrompt: Bool { shellIsAtPrompt }
+
+    /// Record that the shell returned to a prompt, WITHOUT touching run state.
+    /// The status-indicator pref gates `markCommandFinished`, but the naming
+    /// path needs the prompt fact regardless of whether the spinner is shown.
+    mutating func notePromptReturned() {
+        shellIsAtPrompt = true
+    }
+
     /// ORDERING CONTRACT: this CLEARS the in-place start arming, so a caller
     /// that reports both an interaction and a submission for the same event
     /// must call this FIRST — `recordCommandSubmission` arms, and an
@@ -611,6 +622,34 @@ final class Pane: Identifiable {
         )
     }
 
+    /// Whether a foreground sample must be ignored for this pane's IDENTITY
+    /// (its name and agent icon).
+    ///
+    /// A hook-heavy shell forks a REAL process every time it draws a prompt —
+    /// `starship prompt`, `mise hook-env`, `zoxide` — and each is briefly the
+    /// pane's foreground. Publishing one renamed the tab to `starship`, and
+    /// because the poll STOPS while the window is occluded and the app is
+    /// inactive (`PollCadence.mode` → `.paused`), that wrong name then stuck
+    /// until something re-sampled: clicking the app, or any keystroke.
+    ///
+    /// While the shell sits at a prompt nothing the user launched is running,
+    /// so a non-shell foreground there can only be such a hook. A shell name
+    /// (and `nil`) is always allowed through, so returning to the prompt
+    /// restores the shell name at once. Shell-ness is decided by basename
+    /// (`/etc/shells` + login shell + `$SHELL` — a set lookup, no syscall)
+    /// rather than the caller's `foregroundIsShell`, which is only computed
+    /// when the status-indicator pref turns the expensive path on.
+    ///
+    /// This gates the name and icon only. `programTitle` expiry stays keyed on
+    /// the foreground pid, so a title can never be misattributed. A long-lived
+    /// program (claude, hx) reports no completion while it runs, so the gate is
+    /// never armed underneath it, and a shell with no OSC 133 integration never
+    /// arms it at all — those panes keep exactly today's naming behavior.
+    private func ignoresForegroundIdentity(_ name: String?) -> Bool {
+        guard executionTracker.isShellAtPrompt, let name else { return false }
+        return !ProcessInspector.isShellProcessName(name)
+    }
+
     /// Testable core of `refreshForegroundProcess`: publish a changed process
     /// name, and expire `programTitle` when the pid that set it no longer
     /// holds the foreground. When `applyExecutionState` is false (the status
@@ -624,15 +663,20 @@ final class Pane: Identifiable {
         applyExecutionState: Bool = true,
         argv0: () -> String? = { nil }
     ) {
-        let nameChanged = name != foregroundProcessName
-        if nameChanged { foregroundProcessName = name }
-        // A steady foreground (same pid, same comm) keeps the cached icon; a
-        // change re-matches — argv[0] is only read when comm alone doesn't
-        // identify an agent.
-        if nameChanged || foregroundPID != agentIconPID {
-            agentIconPID = foregroundPID
-            let icon = foregroundPID == nil ? nil : AgentIcon.match(comm: name, argv0: argv0)
-            if icon != agentIcon { agentIcon = icon }
+        // A prompt hook must not rename the tab. Title expiry below is NOT
+        // gated: a changed pid means the title's owner lost the foreground, and
+        // a title must never be misattributed to a different process.
+        if !ignoresForegroundIdentity(name) {
+            let nameChanged = name != foregroundProcessName
+            if nameChanged { foregroundProcessName = name }
+            // A steady foreground (same pid, same comm) keeps the cached icon; a
+            // change re-matches — argv[0] is only read when comm alone doesn't
+            // identify an agent.
+            if nameChanged || foregroundPID != agentIconPID {
+                agentIconPID = foregroundPID
+                let icon = foregroundPID == nil ? nil : AgentIcon.match(comm: name, argv0: argv0)
+                if icon != agentIcon { agentIcon = icon }
+            }
         }
         if programTitle != nil, programTitlePID != foregroundPID {
             programTitle = nil
@@ -655,6 +699,13 @@ final class Pane: Identifiable {
     func markCommandFinished() {
         executionState = executionTracker.markCommandFinished(currentState: executionState)
         cancelActivityQuietPollIfNeeded()
+    }
+
+    /// The shell returned to a prompt (OSC 133;D) — recorded even when the
+    /// status indicator is off, because the naming path uses it to reject
+    /// prompt-hook processes.
+    func notePromptReturned() {
+        executionTracker.notePromptReturned()
     }
 
     func markProgressFinished() {

--- a/Macterm/Model/SplitNode.swift
+++ b/Macterm/Model/SplitNode.swift
@@ -140,6 +140,25 @@ struct TerminalExecutionTracker {
     /// redraw or grow rows. Suppress those start signals briefly so an empty
     /// submission cannot flash the spinner.
     private var blankSubmissionAt: Date?
+    /// True while the shell has reported a command finished (OSC 133;D) and has
+    /// not been handed a new submission — i.e. it is sitting at a prompt.
+    ///
+    /// Returning to a prompt is not quiet: a hook-heavy shell forks a REAL
+    /// external process per prompt (`starship prompt`, `mise hook-env`,
+    /// `zoxide`), and the poll cannot tell one from a user command — same
+    /// canonical tty, same non-shell foreground. Attributing one to the user is
+    /// worse than a brief wrong glyph, because such a process is typically
+    /// already dead when the poll spots it: nothing remains to observe a
+    /// transition on, and a foreground-owned run has no self-settling wake of
+    /// its own (unlike activity-owned runs). With the window occluded and the
+    /// app inactive `PollCadence` returns `.paused` — no timer at all — so the
+    /// phantom spinner stays up until something wakes the poll, which is why it
+    /// looked like it "refreshed when I clicked on the app".
+    ///
+    /// Only foreground *starts* are gated. Output/progress evidence still
+    /// applies, and a shell with no OSC 133 integration (bash 3.2) never sets
+    /// this, so it keeps exactly today's foreground behavior.
+    private var shellIsAtPrompt = false
 
     var isActivitySourced: Bool {
         if case .activity = runningSource { return true }
@@ -175,12 +194,20 @@ struct TerminalExecutionTracker {
         progressQuiesced = nil
         pendingProgressQuiesce = false
         blankSubmissionAt = nil
+        // The shell has been handed work, so a foreground process from here on
+        // is that work rather than prompt-hook noise. A BLANK submission
+        // deliberately does not clear this (it launches nothing), which is why
+        // this sits after the `hasContent` guard.
+        shellIsAtPrompt = false
         pendingOutputStart = allowInPlaceOutputStart ? .armed(date) : nil
     }
 
     mutating func markProgressStarted(currentState: TerminalExecutionState) -> TerminalExecutionState {
         pendingOutputStart = nil
         blankSubmissionAt = nil
+        // A program reporting progress is positive evidence that work is
+        // running, so the shell is no longer idling at a prompt.
+        shellIsAtPrompt = false
         guard hasUserInteraction else { return currentState }
         runningSource = .progress
         return .running
@@ -196,6 +223,11 @@ struct TerminalExecutionTracker {
         // next emitted heartbeat carries its growth AFTER this edge and must
         // not restart the finished command as an activity run.
         lastOutputRows = nil
+        // D means the shell is back at a prompt, whatever the run state was.
+        // Set unconditionally, ahead of the `.running` guard below: the prompt
+        // hooks that follow a FAST command arrive on this path while the pane
+        // still reads idle, and those are exactly the ones to suppress.
+        shellIsAtPrompt = true
         // OSC 133;D for an empty Return may arrive before its redraw/output.
         // Keep blank suppression while idle so that later callback cannot flash
         // the spinner; a genuine running completion no longer needs it.
@@ -404,6 +436,10 @@ struct TerminalExecutionTracker {
         // A canonical non-shell command is foreground-owned until its process
         // changes. Re-polls of the same pid must not restart settled state.
         guard changed else { return currentState }
+        // A process appearing while the shell sits at a prompt is a prompt hook,
+        // not the user's command (see `shellIsAtPrompt`). Suppress the START
+        // only — a run already owned by anything keeps its own rules.
+        guard !shellIsAtPrompt else { return currentState }
         runningSource = .foreground
         return .running
     }

--- a/Macterm/System/ProcessInspector.swift
+++ b/Macterm/System/ProcessInspector.swift
@@ -219,8 +219,22 @@ enum ProcessInspector {
         return false
     }
 
+    /// Options that take a separate value argument, so the scan above must skip
+    /// that value instead of mistaking it for a command word.
+    ///
+    /// `--execute` is nushell's "run this, THEN drop into the interactive REPL"
+    /// flag — unlike `-c`, the shell stays at a prompt afterwards, so an
+    /// invocation carrying it is still an idle shell. This matters for every
+    /// nushell pane: ghostty's command-wrapper injects
+    /// `nu --execute 'use ghostty *'` to load shell integration, and without
+    /// this entry the scan reads `use ghostty *` as a command word and reports
+    /// the pane's idle prompt as foreground work. `TerminalExecutionTracker`
+    /// then never sees the shell (`newKey == nil`), so it loses its
+    /// authoritative return-to-prompt completion edge and instead demotes the
+    /// run to activity ownership on the prompt's raw-mode switch — leaving a
+    /// spinner up for the full quiet-settle window after a fast command.
     private static func shellOptionConsumesNextArgument(_ option: String) -> Bool {
-        option == "--rcfile" || option == "--init-file"
+        option == "--rcfile" || option == "--init-file" || option == "--execute"
     }
 
     /// Whether the pane's tty is in raw/cbreak-style input mode. Full-screen and

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -296,6 +296,17 @@ private struct TerminalSurface: NSViewRepresentable {
         }
         view.onCommandFinished = { [weak pane, weak view] exitCode, durationNs in
             guard let pane else { return }
+            // A command boundary is exactly when the pane's identity changes —
+            // the program that just exited (claude, hx) is gone and the shell
+            // owns the foreground again. Refresh from the process table HERE
+            // rather than waiting for the next poll tick: the adaptive poll
+            // slows to 2s when the app is inactive and stops entirely once no
+            // window is visible, which is why a finished agent's icon and name
+            // used to linger until the user clicked or typed. Unconditional —
+            // names and agent icons are shown whether or not the status
+            // indicator is on, and `notePromptReturned` feeds the naming gate.
+            pane.notePromptReturned()
+            pane.refreshForegroundProcess()
             if Preferences.shared.showTabStatusIndicator {
                 pane.markCommandFinished()
                 onCommandFinished()

--- a/MactermTests/Model/PaneTitleTests.swift
+++ b/MactermTests/Model/PaneTitleTests.swift
@@ -105,7 +105,8 @@ struct PaneTitleTests {
         let pane = makePane()
         pane.receiveReportedTitle("session", programPID: 42)
         // claude exits and btop starts between two polls: the pid changed,
-        // so claude's title must not be attributed to btop.
+        // so claude's title must not be attributed to btop. Expiry is
+        // immediate — it is keyed on the pid, NOT on the debounced name.
         pane.applyForegroundRefresh(name: "btop", foregroundPID: 43)
         #expect(pane.programTitle == nil)
         #expect(pane.displayTitle == "btop")
@@ -117,6 +118,67 @@ struct PaneTitleTests {
         pane.receiveReportedTitle("session", programPID: 42)
         pane.applyForegroundRefresh(name: nil, foregroundPID: nil)
         #expect(pane.programTitle == nil)
+    }
+
+    // MARK: - Prompt-hook debounce (transient foreground processes)
+
+    private func loginShellName() throws -> String {
+        try (String(cString: #require(getpwuid(getuid())?.pointee.pw_shell)) as NSString).lastPathComponent
+    }
+
+    /// A hook-heavy shell forks `starship`/`mise`/`zoxide` on every prompt.
+    /// Publishing one renamed the tab to `starship`, and because the poll stops
+    /// while the window is occluded and the app is inactive, that wrong name
+    /// stuck until a click or keystroke re-sampled.
+    @Test
+    func promptHookNeverBecomesTheTabName() throws {
+        let pane = makePane()
+        let shell = try loginShellName()
+
+        pane.applyForegroundRefresh(name: shell, foregroundPID: 10)
+        #expect(pane.foregroundProcessName == shell)
+
+        // The shell reports its command finished, so it is now at a prompt.
+        pane.notePromptReturned()
+
+        // A poll lands inside a prompt hook's ~64ms lifetime.
+        pane.applyForegroundRefresh(name: "starship", foregroundPID: 11)
+        #expect(pane.foregroundProcessName == shell)
+        #expect(pane.displayTitle == shell)
+
+        // Another hook, next prompt — still never adopted.
+        pane.applyForegroundRefresh(name: "mise", foregroundPID: 12)
+        #expect(pane.foregroundProcessName == shell)
+
+        // The shell itself is always allowed through, so no lag returning.
+        pane.applyForegroundRefresh(name: shell, foregroundPID: 10)
+        #expect(pane.foregroundProcessName == shell)
+    }
+
+    /// The gate must not swallow the user's actual command: submitting one
+    /// means the shell is no longer at a prompt, so the name lands on the very
+    /// first poll — no added latency.
+    @Test
+    func submittedCommandIsNamedImmediately() throws {
+        let pane = makePane()
+        let shell = try loginShellName()
+        pane.applyForegroundRefresh(name: shell, foregroundPID: 10)
+        pane.notePromptReturned()
+
+        pane.recordCommandSubmission(hasContent: true)
+        pane.applyForegroundRefresh(name: "hx", foregroundPID: 20)
+        #expect(pane.foregroundProcessName == "hx")
+    }
+
+    /// A shell with no OSC 133 integration never reports a prompt, so the gate
+    /// never arms and naming is exactly as it was before it existed.
+    @Test
+    func withoutShellIntegration_namingIsUnchanged() {
+        let pane = makePane()
+        pane.applyForegroundRefresh(name: "npm", foregroundPID: 30)
+        #expect(pane.foregroundProcessName == "npm")
+        pane.applyForegroundRefresh(name: "node", foregroundPID: 31)
+        #expect(pane.foregroundProcessName == "node")
     }
 
     // MARK: - Remote panes (#104): execution-gated titles, probe-fed names

--- a/MactermTests/Model/TerminalExecutionTrackerTests.swift
+++ b/MactermTests/Model/TerminalExecutionTrackerTests.swift
@@ -156,6 +156,80 @@ struct TerminalExecutionTrackerTests {
         #expect(state == .done)
     }
 
+    /// The reported case, end to end: `ls` completes, then a prompt hook forks.
+    /// The hook must not start a run at all — once started it can strand
+    /// indefinitely, because a foreground-owned run has no self-settling wake
+    /// and `PollCadence` stops the timer entirely for an occluded, inactive app
+    /// ("it refreshes state when I click on the app").
+    @Test
+    func promptHookAfterCompletion_cannotStartForegroundRun() {
+        var tracker = TerminalExecutionTracker()
+        let submittedAt = Date(timeIntervalSince1970: 100)
+        tracker.recordUserInteraction()
+        tracker.recordCommandSubmission(at: submittedAt, allowInPlaceOutputStart: false, hasContent: true)
+
+        // `ls` is a nushell builtin: no process ever holds the foreground, and
+        // OSC 133;D lands while the pane still reads idle.
+        var state = tracker.markCommandFinished(currentState: .idle)
+        #expect(state == .idle)
+
+        // Now the prompt hooks fork, exactly as `starship`/`mise`/`zoxide` do.
+        state = tracker.refreshForeground(
+            name: "starship", pid: 2, foregroundIsShell: false, terminalInputIsRaw: false,
+            at: submittedAt.addingTimeInterval(0.25), currentState: state
+        )
+        #expect(state == .idle)
+        state = tracker.refreshForeground(
+            name: "mise", pid: 3, foregroundIsShell: false, terminalInputIsRaw: false,
+            at: submittedAt.addingTimeInterval(0.5), currentState: state
+        )
+        #expect(state == .idle)
+
+        // A blank Return launches nothing, so it must not re-open the gate.
+        tracker.recordCommandSubmission(
+            at: submittedAt.addingTimeInterval(1), allowInPlaceOutputStart: false, hasContent: false
+        )
+        state = tracker.refreshForeground(
+            name: "starship", pid: 4, foregroundIsShell: false, terminalInputIsRaw: false,
+            at: submittedAt.addingTimeInterval(1.25), currentState: state
+        )
+        #expect(state == .idle)
+
+        // The next real submission does, and a genuine command still runs.
+        tracker.recordCommandSubmission(
+            at: submittedAt.addingTimeInterval(2), allowInPlaceOutputStart: false, hasContent: true
+        )
+        state = tracker.refreshForeground(
+            name: "sleep", pid: 5, foregroundIsShell: false, terminalInputIsRaw: false,
+            at: submittedAt.addingTimeInterval(2.25), currentState: state
+        )
+        #expect(state == .running)
+        state = tracker.markCommandFinished(currentState: state)
+        #expect(state == .done)
+    }
+
+    /// A shell with no OSC 133 integration (CI's bash 3.2) never reports a
+    /// completion, so the prompt gate must never arm and foreground detection
+    /// has to behave exactly as it did before it existed.
+    @Test
+    func withoutShellIntegration_foregroundDetectionIsUnchanged() {
+        var tracker = TerminalExecutionTracker()
+        tracker.recordUserInteraction()
+        var state = tracker.refreshForeground(
+            name: "sleep", pid: 42, foregroundIsShell: false, terminalInputIsRaw: false, currentState: .idle
+        )
+        #expect(state == .running)
+        state = tracker.refreshForeground(
+            name: "bash", pid: 7, foregroundIsShell: true, terminalInputIsRaw: false, currentState: state
+        )
+        #expect(state == .done)
+        // Still no D anywhere in this timeline: the next command runs normally.
+        state = tracker.refreshForeground(
+            name: "find", pid: 43, foregroundIsShell: false, terminalInputIsRaw: false, currentState: .idle
+        )
+        #expect(state == .running)
+    }
+
     /// The reported "spinner lingers ~3s after `ls`" sequence, replayed exactly.
     ///
     /// In a hook-heavy shell (starship / mise / zoxide), returning to the prompt

--- a/MactermTests/Model/TerminalExecutionTrackerTests.swift
+++ b/MactermTests/Model/TerminalExecutionTrackerTests.swift
@@ -156,6 +156,73 @@ struct TerminalExecutionTrackerTests {
         #expect(state == .done)
     }
 
+    /// The reported "spinner lingers ~3s after `ls`" sequence, replayed exactly.
+    ///
+    /// In a hook-heavy shell (starship / mise / zoxide), returning to the prompt
+    /// briefly runs a real external process, which the poll can catch as a
+    /// foreground command. What happens next depends entirely on whether the
+    /// pane's own shell is recognized as a shell on the following poll — the
+    /// single value `ProcessInspector.foregroundProcessIsShell` returns, which
+    /// the `--execute` classification bug had stuck at `false` for every
+    /// nushell pane (see `ProcessInspectorTests`).
+    ///
+    /// Misclassified, the return-to-prompt looks like "a non-shell program went
+    /// raw", which demotes the run to activity ownership — exiting only through
+    /// the 3-second quiet-settle. Classified correctly it is the authoritative
+    /// completion edge and the run ends on the very next poll.
+    @Test
+    func promptHookRun_endsAtOncePerShellClassification_insteadOfQuietSettling() {
+        let submittedAt = Date(timeIntervalSince1970: 100)
+
+        func replay(shellIsRecognized: Bool) -> (
+            afterPrompt: TerminalExecutionState,
+            atTwoSeconds: TerminalExecutionState,
+            atFourSeconds: TerminalExecutionState
+        ) {
+            var tracker = TerminalExecutionTracker()
+            // Idle at the prompt: nushell holds the tty in raw mode for line editing.
+            var state = tracker.refreshForeground(
+                name: "nu", pid: 1, foregroundIsShell: shellIsRecognized, terminalInputIsRaw: true,
+                at: submittedAt.addingTimeInterval(-1), currentState: .idle
+            )
+            tracker.recordUserInteraction()
+            tracker.recordCommandSubmission(at: submittedAt, allowInPlaceOutputStart: false, hasContent: true)
+
+            // `ls` is a nushell builtin — it never appears as a process. The
+            // poll instead catches the pre-prompt hook, canonical and non-shell.
+            state = tracker.refreshForeground(
+                name: "starship", pid: 2, foregroundIsShell: false, terminalInputIsRaw: false,
+                at: submittedAt.addingTimeInterval(0.25), currentState: state
+            )
+            #expect(state == .running)
+
+            // Next poll: the prompt is back, raw mode again.
+            let promptAt = submittedAt.addingTimeInterval(0.5)
+            state = tracker.refreshForeground(
+                name: "nu", pid: 1, foregroundIsShell: shellIsRecognized, terminalInputIsRaw: true,
+                at: promptAt, currentState: state
+            )
+            let afterPrompt = state
+            let atTwo = tracker.settleIfQuiet(
+                now: promptAt.addingTimeInterval(2), quietInterval: 3, currentState: state
+            )
+            let atFour = tracker.settleIfQuiet(
+                now: promptAt.addingTimeInterval(4), quietInterval: 3, currentState: atTwo
+            )
+            return (afterPrompt, atTwo, atFour)
+        }
+
+        // The bug: the run survives the prompt and only clears on quiet-settle.
+        let buggy = replay(shellIsRecognized: false)
+        #expect(buggy.afterPrompt == .running)
+        #expect(buggy.atTwoSeconds == .running)
+        #expect(buggy.atFourSeconds == .done)
+
+        // Fixed: returning to the prompt IS the completion edge.
+        let fixed = replay(shellIsRecognized: true)
+        #expect(fixed.afterPrompt == .done)
+    }
+
     @Test
     func samePIDReturningToCanonicalRestoresForegroundAuthority() {
         var tracker = TerminalExecutionTracker()

--- a/MactermTests/System/ProcessInspectorTests.swift
+++ b/MactermTests/System/ProcessInspectorTests.swift
@@ -89,6 +89,29 @@ struct ProcessInspectorTests {
         #expect(!ProcessInspector.isIdleShellInvocation(["/bin/bash", "-lc", "sleep 10"]))
     }
 
+    /// Every nushell pane runs the exact argv below — ghostty's command-wrapper
+    /// injects `--execute 'use ghostty *'` to load shell integration. Unlike
+    /// `-c`, nushell's `--execute` runs its code and THEN enters the
+    /// interactive REPL, so the invocation is an idle shell. Reading it as
+    /// foreground work costs the execution tracker its return-to-prompt
+    /// completion edge, which stranded the tab spinner for the whole
+    /// quiet-settle window after fast commands.
+    @Test
+    func shellIntegrationExecuteInvocation_isIdleShell() throws {
+        // Resolved from the host's own login shell, not a hardcoded `nu` path:
+        // shell names come from `/etc/shells`, so a literal nushell argv would
+        // not even parse as a shell on a runner without nushell installed.
+        let loginShellPtr = try #require(getpwuid(getuid())?.pointee.pw_shell)
+        let shell = String(cString: loginShellPtr)
+        let loginName = (shell as NSString).lastPathComponent
+
+        #expect(ProcessInspector.isIdleShellInvocation([shell, "--execute", "use ghostty *"]))
+        #expect(ProcessInspector.isIdleShellInvocation(["-\(loginName)", "--execute", "use ghostty *"]))
+        // The value is skipped, not scanned — a real command after it still counts.
+        #expect(!ProcessInspector.isIdleShellInvocation([shell, "--execute", "use ghostty *", "-c", "sleep 10"]))
+        #expect(!ProcessInspector.isIdleShellInvocation([shell, "--execute", "use ghostty *", "script.sh"]))
+    }
+
     @Test
     func terminalInputIsRaw_reads_tty_input_mode() throws {
         // openpty's two fds: the primary (controlling) end and the secondary


### PR DESCRIPTION
## What

Two fixes for one reported bug: "run a simple `ls`, the spinner appears for a while — but it refreshes state when I click on the app."

1. **Recognize a shell-integration `--execute` invocation as an idle shell.** ghostty's command-wrapper launches every nushell pane as `nu --execute 'use ghostty *'`. `shellInvocationRunsCommand` didn't know `--execute` takes a value, so it read `use ghostty *` as a command word — `foregroundProcessIsShell` returned **false for every nushell pane, permanently**.
2. **Don't let a prompt hook start a run the poll can never end.** Gate foreground-owned *starts* on whether the shell is sitting at a prompt, which OSC 133;D already tells us.
3. **Refresh a pane's identity when its command ends.** Nothing re-read the process table on OSC 133;D, so a finished agent's name and icon lingered until the next poll tick.
4. **Keep prompt hooks out of the pane's name.** A poll landing inside a hook renamed the tab to `starship`, and the paused poll then froze that wrong name in place.


## Why

A hook-heavy shell forks a **real external process on every prompt** — `starship prompt`, `mise hook-env`, `zoxide` — and the foreground poll cannot distinguish one from a user command: same canonical tty, same non-shell foreground. A pty probe of a real nushell (sampling `tcgetpgrp` + `ICANON` every 20ms, exactly what `ProcessInspector` reads) caught `starship` holding the foreground for ~64ms immediately after Return. And `ls` in nushell is a **builtin** — it never appears as a process at all, so the hook is the only thing the poll can see.

Starting a run from that evidence is worse than a brief wrong glyph, for two compounding reasons:

- **The hook is already dead when the poll spots it**, so no transition remains to observe.
- **A foreground-owned run has no self-settling wake.** Activity-owned runs got `activityQuietPollWork` precisely so an occluded pane can still settle; foreground-owned runs rely entirely on the poll. But `PollCadence.mode` returns `.paused` — *no timer at all* — when no window is visible and the app is inactive, and `isAnyPaneBusy` only holds fast cadence while the app is frontmost.

So the phantom sits there until something wakes the poll — which is exactly why clicking the app appeared to fix it (`didBecomeActive` → `pollNow`). Fix 1 independently mattered because without it the tracker never sees `newKey == nil` and so loses its authoritative return-to-prompt completion edge, leaving the 3s quiet-settle as the only exit; that's the 3-second variant of the same symptom.

General rule this earns: **never start a foreground-owned run from evidence you cannot later observe ending.**

## How

Fix 1 is one entry in `shellOptionConsumesNextArgument`. Unlike `-c`, nushell's `--execute` runs its code and *then* enters the REPL, so the invocation genuinely is an idle shell. It completes the flag set rather than special-casing nu: `--rcfile`/`--init-file` were already listed for bash, and `--execute` (`shell_integration.zig:810`) is the only other flag ghostty injects. Blast radius is one consumer — `foregroundProcessIsShell`, feeding only the status indicator; tab naming, OSC-title provenance and layout capture use name-only checks.

Fix 2 adds `shellIsAtPrompt` to `TerminalExecutionTracker`: armed by OSC 133;D in `markCommandFinished` (**unconditionally**, ahead of the `.running` guard — a fast command's D lands while the pane still reads idle, and the hooks that follow are exactly the ones to suppress), cleared by a nonempty submission and by `markProgressStarted`. A blank Return deliberately does not clear it. Only foreground *starts* are gated; output and progress evidence are untouched.

The gate is armed **only** by OSC 133;D, never by the poll's own return-to-shell observation — arming it from the poll would break integration-less shells entirely, since their next real command would be suppressed as prompt noise.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

**End-to-end A/B — measured as a RATE, and one correction.** An earlier version of this description claimed the harness seeded a deliberately slow prompt hook to make the race deterministic. That hook silently never loaded (nushell auto-sources `vendor/autoload`, not a plain `autoload/`; and `nu -c` does not load `config.nu`, which invalidated my check of it). The observed phantoms therefore came from the real starship/mise/zoxide hooks, so the numbers below are reported as a catch rate over many trials rather than as a deterministic result.

Unit tests pin each layer, since no single test spans both:

- `ProcessInspectorTests.shellIntegrationExecuteInvocation_isIdleShell` — the real argv flips `false → true`. Fails without fix 1. Derives the shell from the host's login shell rather than hardcoding a nushell path, since shell names come from `/etc/shells` and a literal `nu` argv wouldn't parse as a shell on a runner without nushell.
- `TerminalExecutionTrackerTests.promptHookAfterCompletion_cannotStartForegroundRun` — `starship`, `mise`, and a blank Return all fail to start a run; the next real submission still does. Fails without fix 2 (3 assertions).
- `TerminalExecutionTrackerTests.withoutShellIntegration_foregroundDetectionIsUnchanged` — a shell that never emits D never arms the gate, so CI's bash 3.2 keeps today's behavior.
- `TerminalExecutionTrackerTests.promptHookRun_endsAtOncePerShellClassification_insteadOfQuietSettling` — replays the observed sequence under both classifications: misclassified it's still `running` at 2s and clears at 3s; classified correctly it's `done` on the next poll.

## Notes for reviewers

Reattached zmx sessions never fire D before their first completion, so a session that comes back with a command already running still registers — the gate can only be armed by an observed completion.

Known remaining gap, deliberately not addressed here: if a *real* command finishes while the window is occluded and the app is inactive, the poll is paused, so the tab keeps showing `running` until the user returns (then resolves to `done` correctly). That's the same `.paused` cadence behavior, but for a genuine command the eventual `done` is the intended signal, so it needs a design decision rather than a patch.



## Naming (commits 3–4)

Reported separately by the same user, same root cause, different code path: *"the tab name becomes stale sometimes — it refreshes when I click the app"*, and *"when I quit claude code, the agent icon only disappears when I make an interaction."*

The pane's name and agent icon were refreshed **only** by the adaptive poll, which slows to 2s when the app is inactive and stops outright once no window is visible. Two consequences:

- **Nothing refreshed on command end.** A command boundary is exactly when a pane's identity changes, and OSC 133;D already reports it — but `onCommandFinished` only touched run state. So quitting claude left its name and logo up until some unrelated event re-sampled. Now that closure refreshes the foreground, unconditionally (names and icons are shown whether or not the status indicator is on).
- **A hook could become the name.** While the shell is at a prompt nothing the user launched is running, so a non-shell foreground there can only be a prompt hook — ignored for naming. Shell names and `nil` always pass, so returning to the prompt has no lag, and a submitted command is named on the first poll because submitting clears the prompt state. `programTitle` expiry stays keyed on the pid so a title is never misattributed, and a shell without OSC 133 never arms the gate.

Tests: `promptHookNeverBecomesTheTabName` (fails without the gate — publishes `starship` where `nu` is required), `submittedCommandIsNamedImmediately` (no added latency for real commands), `withoutShellIntegration_namingIsUnchanged`.

**Design note for review.** This PR makes two state refreshes event-driven that previously depended on the poll, but the underlying asymmetry remains: `PollCadence` is the only thing keeping names fresh, and it deliberately pauses to save idle CPU (#110). Anything derived from the process table can therefore still go stale while the app is inactive. The durable direction is to drive identity from terminal events (command start/end, output) and treat the poll as a backstop — worth a follow-up rather than widening this change.