### PR TITLE
Let a program hand pane focus back out at its own split edge

### DIFF
--- a/CLI/MactermCommand.swift
+++ b/CLI/MactermCommand.swift
@@ -316,14 +316,19 @@ struct PaneCommand: ParsableCommand {
 
     struct Focus: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Focus a pane (selects its tab and fronts the window)."
+            abstract: "Focus a pane, or its neighbour in a direction (selects its tab and fronts the window)."
         )
+
+        @Option(help: "Move to the nearest pane this way from the target instead: left, down, up, or right.")
+        var direction: String?
 
         @OptionGroup var target: PaneTarget
         @OptionGroup var options: ConnectionOptions
 
         func run() throws {
-            try runControlCommand(command: "pane.focus", args: target.controlArgs(), options: options)
+            var args = target.controlArgs()
+            args.direction = direction
+            try runControlCommand(command: "pane.focus", args: args, options: options)
         }
     }
 

--- a/Macterm/Control/ControlHandler.swift
+++ b/Macterm/Control/ControlHandler.swift
@@ -372,10 +372,37 @@ final class ControlHandler {
     private func paneFocus(_ args: ControlArgs) throws -> ControlData {
         let (project, workspace) = try resolveWorkspace(args)
         let target = try resolvePane(args, in: workspace)
+        // With a direction the resolved pane is the ORIGIN, not the
+        // destination: move to its nearest neighbour that way. Same
+        // `nearestPane` primitive the focus keybinds use, so a CLI move and a
+        // keybind move can't pick different panes.
+        var pane = target.pane
+        if let raw = args.direction {
+            let direction: PaneFocusDirection
+            switch raw {
+            case "left": direction = .left
+            case "down": direction = .down
+            case "up": direction = .up
+            case "right": direction = .right
+            default:
+                throw ControlError(code: .badRequest, message: "direction must be left, down, up, or right")
+            }
+            // No neighbour that way is a successful no-op, NOT an error. The
+            // caller is typically a program that already failed to move within
+            // its own splits (a vim-tmux-navigator-style keymap) and is asking
+            // whether Macterm can go further; at the outermost edge the answer
+            // is simply "no". Returning the unchanged pane lets the caller see
+            // that by comparing the reported session against its own.
+            if let neighbour = target.tab.splitRoot.nearestPane(from: pane.id, direction: direction),
+               let resolved = target.tab.splitRoot.findPane(id: neighbour)
+            {
+                pane = resolved
+            }
+        }
         // navigateToPane selects the containing tab, fronts the window, and
         // restores first responder — everything "focus" means for a human.
-        appState.navigateToPane(target.pane.id, projectID: project.id)
-        return ControlData(panes: [paneInfo(target.pane, in: target.tab, workspace: workspace)])
+        appState.navigateToPane(pane.id, projectID: project.id)
+        return ControlData(panes: [paneInfo(pane, in: target.tab, workspace: workspace)])
     }
 
     private func paneClose(_ args: ControlArgs) throws -> ControlData {

--- a/Macterm/Control/ControlProtocol.swift
+++ b/Macterm/Control/ControlProtocol.swift
@@ -75,7 +75,9 @@ struct ControlArgs: Codable, Equatable {
     /// (`tab.new`, `pane.split`, `grid`), typed into the live shell for
     /// `pane.run`.
     var run: String?
-    /// Split direction: `right`, `down`, or `auto`.
+    /// Direction, with a per-command vocabulary: `right`/`down`/`auto` for
+    /// `pane.split`, `left`/`down`/`up`/`right` for `pane.focus` (where it
+    /// makes the resolved pane the origin and focuses its neighbour).
     var direction: String?
     /// Skip the busy-confirmation and destructive-plan guards
     /// (`tab.close`, `pane.close`, `layout.apply`).

--- a/MactermTests/Control/ControlHandlerTests.swift
+++ b/MactermTests/Control/ControlHandlerTests.swift
@@ -481,6 +481,47 @@ struct ControlHandlerTests {
         #expect(firstTab.focusedPaneID == firstPane.id)
     }
 
+    /// The direction makes the resolved pane the ORIGIN. The edge case is the
+    /// contract a vim-tmux-navigator-style keymap depends on: no neighbour that
+    /// way reports the origin unchanged and stays `ok`, so the caller can tell
+    /// "didn't move" from "failed" without parsing an error.
+    @Test
+    func pane_focus_direction_moves_from_the_target_and_no_ops_at_the_edge() async throws {
+        let (handler, appState, projectStore) = makeHandler()
+        let project = seedProject(appState, projectStore)
+        let tab = try #require(appState.workspaces[project.id]?.activeTab)
+        let left = try #require(tab.splitRoot.allPanes().first)
+        appState.splitPane(direction: .horizontal, projectID: project.id)
+        let panes = tab.splitRoot.allPanes()
+        #expect(panes.count == 2)
+        let right = try #require(panes.last)
+        #expect(tab.focusedPaneID == right.id)
+
+        // From the right pane (the focused one, so no selector needed) leftward.
+        let moved = await handler.handle(request("pane.focus", args: ControlArgs(direction: "left")))
+        #expect(moved.ok)
+        #expect(tab.focusedPaneID == left.id)
+        #expect(moved.data?.panes?.first?.id == left.id.uuidString)
+
+        // Already leftmost: ok, focus unchanged, and the reported pane is the
+        // origin — that identity is how a caller detects the edge.
+        let edge = await handler.handle(request("pane.focus", args: ControlArgs(direction: "left")))
+        #expect(edge.ok)
+        #expect(tab.focusedPaneID == left.id)
+        #expect(edge.data?.panes?.first?.id == left.id.uuidString)
+
+        // An explicit origin overrides the focused-pane default.
+        let fromLeft = await handler.handle(request(
+            "pane.focus", args: ControlArgs(pane: left.id.uuidString, direction: "right")
+        ))
+        #expect(fromLeft.ok)
+        #expect(tab.focusedPaneID == right.id)
+
+        // `auto` is split's vocabulary, not focus's.
+        let bogus = await handler.handle(request("pane.focus", args: ControlArgs(direction: "auto")))
+        #expect(bogus.error?.code == .badRequest)
+    }
+
     @Test
     func pane_close_requires_explicit_target() async throws {
         let (handler, appState, projectStore) = makeHandler()

--- a/e2e/test_panes.py
+++ b/e2e/test_panes.py
@@ -47,6 +47,35 @@ def test_focus_moves_between_panes(app, fresh_tab, live_pane):
         assert focused == [target["session"]]
 
 
+def test_focus_direction_moves_from_the_origin_and_no_ops_at_the_edge(app, fresh_tab, live_pane):
+    """`pane focus --direction` is the half of a vim-tmux-navigator-style keymap
+    that lives outside the editor: the plugin calls it only after failing to
+    move within its own splits, so the edge case is API surface. No neighbour
+    that way must exit 0 and report the origin unchanged — a plugin tells
+    "didn't move" from "failed" by comparing the reported session, not by
+    parsing an error."""
+    app.cli("pane", "split", "--direction", "down", "--session", live_pane["session"])
+    panes = app.panes(tab=fresh_tab["id"])
+    assert len(panes) == 2
+    top, bottom = panes[0], panes[1]
+
+    # Up from the bottom pane lands on the top one, and says so.
+    moved = app.cli_json("pane", "focus", "--direction", "up", "--session", bottom["session"])
+    assert moved["panes"][0]["session"] == top["session"]
+    focused = [pane["session"] for pane in app.panes(tab=fresh_tab["id"]) if pane["focused"]]
+    assert focused == [top["session"]]
+
+    # Already topmost: still ok, focus unchanged, origin reported back.
+    edge = app.cli_json("pane", "focus", "--direction", "up", "--session", top["session"])
+    assert edge["panes"][0]["session"] == top["session"]
+    focused = [pane["session"] for pane in app.panes(tab=fresh_tab["id"]) if pane["focused"]]
+    assert focused == [top["session"]]
+
+    # Down from the top pane goes back — the direction isn't one-way.
+    back = app.cli_json("pane", "focus", "--direction", "down", "--session", top["session"])
+    assert back["panes"][0]["session"] == bottom["session"]
+
+
 def test_tab_close_follows_the_running_program_signal(app):
     """`tab close` without --force succeeds iff libghostty reports no running
     program (needsConfirmQuit) — the exact signal the close guard reads.

--- a/website/docs/pages/80-cli.md
+++ b/website/docs/pages/80-cli.md
@@ -51,6 +51,7 @@ The grammar is `macterm <noun> <verb> [options]`. A bare noun defaults to its `l
 | `pane dump [--scrollback] [target]` | Print a pane's terminal text — the viewport, or the full scrollback with `--scrollback`. Pipeline-friendly (text only). |
 | `pane split [--direction right\|down\|auto] [--run CMD] [target]` | Split a pane; the new pane inherits the source's cwd. `auto` picks the longer on-screen axis. |
 | `pane focus <target>` | Focus a pane: selects its tab, fronts the window, restores keyboard focus. |
+| `pane focus --direction left\|down\|up\|right [target]` | Focus the nearest pane that way *from* the target — the same geometry the focus keybinds use. At the outermost edge it's a no-op, not an error. |
 | `pane close (--pane P \| --session S) [--force]` | Close a pane, killing its session. Always explicit — never defaults to "the pane you're in". |
 | `pane run <command…> [target]` | Type a command (plus newline) into an **existing** live pane's shell. |
 | `pane key <chord> [target]` | Send one key chord (`ctrl+c`, `escape`, `up`, `ctrl+\`) to a live pane through the terminal's key-encoding path — control/named keys that `pane run` can't type. |
@@ -76,6 +77,8 @@ Pane verbs (`split`, `focus`, `close`, `run`, `grid`) resolve their target in th
 4. Otherwise, the focused pane of the active tab.
 
 `pane close` never uses the `MACTERM_SESSION` fallback — destroying "whatever pane I'm in" because no target was given is a footgun, so it always demands an explicit `--pane` or `--session`.
+
+`pane focus --direction` treats the resolved target as the **origin**, not the destination — so a bare `macterm pane focus --direction left` run inside a pane moves left from *that* pane. It reports the pane that ended up focused, and at the outermost edge it reports the origin unchanged rather than failing, so a caller can tell whether it moved by comparing the reported session to its own `$MACTERM_SESSION`.
 
 ## Introspecting a pane
 


### PR DESCRIPTION
Part of #209 — the half that lives outside the editor.

## Why

An editor with its own splits can't participate in pane navigation today. Even once Macterm stops swallowing a chord like `ctrl+h`, nvim can move within its own windows but has no way to move focus **out** at its leftmost one: `pane focus` takes a target, and `ControlPaneInfo` exposes no split geometry, so a plugin can't compute the neighbour itself. That leaves a keymap able to enter an editor and never leave it — which is exactly the gap vim-tmux-navigator closes by having the *editor* call `tmux select-pane -L`.

## What

`pane focus` grows `--direction left|down|up|right`. With a direction the resolved target is the **origin**, not the destination, so a bare `macterm pane focus --direction left` run inside a pane moves left from *that* pane (via the usual `MACTERM_SESSION` fallback). It routes through the same `nearestPane` primitive the focus keybinds use, so a CLI move and a keybind move can never pick different panes.

## The contract

**No neighbour that way is a successful no-op, not an error**, and the response reports whichever pane ended up focused — at the outermost edge, the origin unchanged.

That pairing is deliberate, and it's the part worth reviewing. A caller invokes this only *after* failing to move within its own splits, so reaching the outer edge is an expected outcome rather than a failure; returning `not_found` would make every edge press look like a broken command. Comparing the reported session against `$MACTERM_SESSION` is how a plugin tells "didn't move" from "didn't work", with no error parsing and no extra wire field.

## Verification

- **Unit** (`ControlHandlerTests`): directional move, the edge no-op, an explicit origin overriding the focused-pane default, and `auto` rejected as `bad_request` — it's `pane split`'s vocabulary, not focus's, and the two now share the `direction` field.
- **E2e** against the real app: all 12 pass, so the ArgumentParser → wire → handler path is proven end to end, not just the handler.
- `format` / `lint` clean; `--help` rendering checked.

## Docs

The verb table plus a note in "Targeting a pane" spelling out the origin semantics and the edge behaviour.

I deliberately left the worked vim-tmux-navigator example **out**: until the keybind-side toggle lands, nvim can't receive `ctrl+h`, so documenting the full workflow would describe something half-built. It goes in with that change.
