### PR TITLE
chore(deps): bump GhosttyKit to build-2026-08-03

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,7 @@ XCFRAMEWORK_DIR="GhosttyKit.xcframework"
 #
 # Set GHOSTTYKIT_TAG to another tag (or `latest`) to try one without committing:
 #   GHOSTTYKIT_TAG=latest mise run setup
-GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-02}"
+GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-03}"
 # Which tag the on-disk artifacts actually came from. Without this the presence
 # checks below would keep a stale copy forever after a pin bump — the same
 # silent-staleness trap that makes symlinking these artifacts a bad idea. Absent


### PR DESCRIPTION
Moves the pinned `thdxg/ghostty` release (`GHOSTTYKIT_TAG` in `scripts/setup.sh`) from `build-2026-08-02` to `build-2026-08-03`.

**CI on this PR is the gate.** Editing `scripts/setup.sh` changes the GhosttyKit cache key, so this run downloads the new pin from scratch and exercises it through Unit, End-to-end, and the benchmark — rather than a release being the first thing to try it.

Compare upstream: [`build-2026-08-02...build-2026-08-03`](https://github.com/thdxg/ghostty/compare/build-2026-08-02...build-2026-08-03)

> [!NOTE]
> The commit on this branch was built and pushed by `bump-ghosttykit.yml` ([run 30830232925](https://github.com/thdxg/macterm/actions/runs/30830232925)), but the workflow could not open the PR — `GH_PAT` lacks *Pull requests: write*, so `gh pr create` returned `Resource not accessible by personal access token`. The branch is exactly what the workflow produced; only this PR was opened by hand. See #220.

---

### GhosttyKit API review — `build-2026-08-02` → `build-2026-08-03`

Filtered to the **154** `ghostty_*`/`GHOSTTY_*` symbols Macterm's own sources reference and the header defines.

#### ✅ No symbol we use was removed

#### No changed hunk touches a symbol we use

<sub>0 changed header lines total; 0 hunk(s) touch symbols we use. A green CI run means it builds and the suites pass — not that no behaviour moved.</sub>
