### PR TITLE
Point the docs at the Cookbook and invite people to post recipes

### DIFF
--- a/website/docs/pages/00-introduction.md
+++ b/website/docs/pages/00-introduction.md
@@ -14,4 +14,4 @@ A native macOS terminal with a vertical project sidebar and persistent multiplex
 
 Macterm requires macOS 14 or later and is MIT licensed.
 
-New here? Start with [Installation](/docs/install), then point Macterm at your [Ghostty config](/docs/configuration). Automating something? There's a [CLI](/docs/cli).
+New here? Start with [Installation](/docs/install), then point Macterm at your [Ghostty config](/docs/configuration). Automating something? There's a [CLI](/docs/cli). For workflows other people run, browse the [Cookbook](/docs/cookbook).

--- a/website/docs/pages/90-cookbook.md
+++ b/website/docs/pages/90-cookbook.md
@@ -1,0 +1,27 @@
+<!-- page:
+slug: cookbook
+title: Cookbook
+nav: Cookbook
+group: Community
+description: Community-shared Macterm workflows and recipes — read what others run, and post your own.
+-->
+
+# Cookbook
+
+The [**Cookbook**](https://github.com/thdxg/macterm/discussions/categories/cookbook) is a discussion category for workflows and recipes — the layouts, keybinds, and scripts people actually run to get more out of Macterm. Anyone can post, and anyone can borrow.
+
+Three to start with:
+
+- [**Navigating `nvim` and Macterm with the same keybinds**](https://github.com/thdxg/macterm/discussions/217) — one <kbd>ctrl</kbd>+<kbd>h/j/k/l</kbd> chord moves between nvim's own splits while you're inside it and between Macterm's panes when you reach the edge. The vim-tmux-navigator experience, without tmux.
+- [**Driving an interactive program from a script**](https://github.com/thdxg/macterm/discussions/218) — a pipe can't help you with a REPL or a paged diff, but `pane run`, `pane key`, and `pane dump` can type into one and read what's on screen.
+- [**Giving a coding agent control of Macterm**](https://github.com/thdxg/macterm/discussions/219) — a drop-in skill file that lets an agent run commands in panes and *see* what a full-screen program is displaying.
+
+## Post your own
+
+Got a layout, keybind, shell integration, or script that earns its keep? [Start a Cookbook topic](https://github.com/thdxg/macterm/discussions/new?category=cookbook). What makes a recipe easy for the next person to adopt:
+
+- **Lead with what it gets you** — the annoyance it removes, before the config.
+- **Include the whole thing** — the full [layout YAML](/docs/declarative-layouts), keybind, or script, not a fragment to reassemble.
+- **Name the minimum version** if it leans on something recent, and say which other tools need to be installed.
+
+> The Cookbook is for recipes. Bugs belong in [Issues](https://github.com/thdxg/macterm/issues), questions in [Q&A](https://github.com/thdxg/macterm/discussions/categories/q-a), and feature requests in [Ideas](https://github.com/thdxg/macterm/discussions/categories/ideas).


### PR DESCRIPTION
The [Cookbook](https://github.com/thdxg/macterm/discussions/categories/cookbook) discussion category already holds three recipes, and nothing on the docs site points there. Adds `/docs/cookbook`.

## Why

The recipes only exist for people who happen to browse Discussions — the docs never mention the category, so a reader following the sidebar has no way to learn it's there. That also cuts the other way: nowhere in the docs invites anyone to *post* a workflow, which is what a cookbook needs to grow past whatever the maintainer wrote.

## What

**New page** — [`website/docs/pages/90-cookbook.md`](https://github.com/thdxg/macterm/blob/claude/cookbook-docs-page-172bd9/website/docs/pages/90-cookbook.md), served at `/docs/cookbook`:

- Links the category, then previews the three topics in it (#217, #218, #219) with a one-line hook each rather than a bare title.
- A **Post your own** section linking `discussions/new?category=cookbook`, plus three guidelines aimed at recipes someone else can actually adopt — lead with what it gets you, include the whole config rather than a fragment, name the minimum version.
- A closing aside routing bugs to Issues, questions to Q&A, and feature requests to Ideas, so the category stays recipes.

**One clause in the introduction** so the page is reachable from `/docs/` and not just the sidebar.

## The sidebar group is a judgment call

The page opens a new **Community** group rather than filing under **Automation**. Two of the three current recipes are automation and one is keybinds, so the axis that generalizes is who writes them, not what they cover — and it leaves somewhere obvious for future community-facing pages. Easy to move if you'd rather not add a group for one page.

## Verified

`bun run build:docs` renders 10 pages; sidebar shows Community → Cookbook active; page is in `sitemap.xml`. Rendered at desktop and mobile — no console errors, no horizontal overflow, lists match existing pages (Tailwind preflight suppresses bullet markers site-wide; **Command palette** computes identically, so that's not new here). All ten external links return 200, and the extensionless `/docs/cookbook` resolves under `wrangler dev` — worth checking separately, since a plain static server can't serve those URLs.

## Follow-up, not in this PR

The "Three to start with" list is curated by hand, so it goes stale as outside recipes land. If that turns into a chore, the alternative is dropping the enumeration and letting the category page speak for itself.