### PR TITLE
Make Separate All Panes and Separate Current Pane keybindable commands

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -14,10 +14,12 @@ enum AppCommand: String, CaseIterable, Identifiable {
     case nextTab
     case previousTab
     case recentTab
+    case separateAllPanes
     // Panes
     case splitRight
     case splitDown
     case splitAuto
+    case separateCurrentPane
     case zoomPane
     case focusLeft
     case focusRight
@@ -59,6 +61,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .nextTab: "Next Tab"
         case .previousTab: "Previous Tab"
         case .recentTab: "Recent Tab"
+        case .separateAllPanes: "Separate All Panes"
+        case .separateCurrentPane: "Separate Current Pane"
         case .splitRight: "Split Right"
         case .splitDown: "Split Down"
         case .splitAuto: "Split Automatically"
@@ -100,10 +104,12 @@ enum AppCommand: String, CaseIterable, Identifiable {
              .renameTab,
              .nextTab,
              .previousTab,
-             .recentTab: .tabs
+             .recentTab,
+             .separateAllPanes: .tabs
         case .splitRight,
              .splitDown,
              .splitAuto,
+             .separateCurrentPane,
              .zoomPane,
              .focusLeft,
              .focusRight,
@@ -144,9 +150,11 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .nextTab: .nextGlobalTab
         case .previousTab: .previousGlobalTab
         case .recentTab: .recentTab
+        case .separateAllPanes: .separateAllPanes
         case .splitRight: .splitRight
         case .splitDown: .splitDown
         case .splitAuto: .splitAuto
+        case .separateCurrentPane: .separateCurrentPane
         case .zoomPane: .zoomPane
         case .focusLeft: .focusPaneLeft
         case .focusRight: .focusPaneRight

--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -50,6 +50,29 @@ extension AppCommand {
                 // responder. Applies to every caller (palette, menu, hotkey).
                 DispatchQueue.main.async { ctx.appState.renamingTabID = tabID }
             }
+        case .separateAllPanes:
+            // The palette/keybind form of the tab context menu's "Separate
+            // Panes": every pane of the active tab after the first opens in
+            // its own tab, shells intact. nil (hidden/fall-through) on a
+            // single-pane tab — there is nothing to separate.
+            guard let projectID,
+                  let tab = ctx.appState.workspaces[projectID]?.activeTab,
+                  tab.splitRoot.allPanes().count > 1
+            else { return nil }
+            return { ctx.appState.separateTabPanes(tab.id, projectID: projectID) }
+        case .separateCurrentPane:
+            // Split just the focused pane out of the active tab into its own
+            // tab, landing right after the source tab (mirroring where
+            // "Separate All Panes" puts them). Same single-pane guard.
+            guard let projectID, let current,
+                  let ws = ctx.appState.workspaces[projectID],
+                  let tab = ws.activeTab,
+                  tab.splitRoot.allPanes().count > 1,
+                  let paneID = tab.focusedPaneID
+            else { return nil }
+            let destPath = current.path
+            let index = ws.tabs.firstIndex(where: { $0.id == tab.id }).map { $0 + 1 }
+            return { ctx.appState.separatePane(paneID, toProject: projectID, destPath: destPath, at: index) }
         case .splitRight:
             guard let projectID else { return nil }
             return { ctx.appState.splitPane(direction: .horizontal, projectID: projectID) }

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -1014,6 +1014,60 @@ final class AppState {
         saveWorkspaces()
     }
 
+    /// Split a single pane out of its tab into its own fresh tab — the
+    /// per-pane sibling of `separateTabPanes` ("Separate Current Pane"). The
+    /// `Pane` object is reused as-is, so its surface and running shell
+    /// survive; the source tab keeps its remaining panes. `index` is the
+    /// slot in the destination project's tab list (nil appends). Crossing
+    /// projects rebinds the pane's routing identity, mirroring `moveTab`.
+    /// No-op when the pane isn't in any workspace or is its tab's only pane
+    /// (already its own tab).
+    func separatePane(_ paneID: UUID, toProject destProjectID: UUID, destPath: String, at index: Int? = nil) {
+        guard let (sourceProjectID, sourceTab) = locatePane(paneID),
+              sourceTab.splitRoot.allPanes().count > 1,
+              let pane = sourceTab.splitRoot.findPane(id: paneID)
+        else { return }
+        // Resolve the destination before detaching, so a failure can't leave
+        // the pane belonging to no tab.
+        ensureWorkspace(projectID: destProjectID, path: destPath)
+        guard let dest = workspaces[destProjectID],
+              let remaining = sourceTab.splitRoot.removing(paneID: paneID)
+        else { return }
+        logger.debug(
+            "separatePane: \(paneID, privacy: .public) to=\(destProjectID, privacy: .public) index=\(index ?? -1, privacy: .public)"
+        )
+        // Detach without destroying: the same tree/zoom/focus repair as
+        // `removePane`, minus the surface teardown — the pane lives on.
+        sourceTab.splitRoot = remaining
+        if sourceTab.zoomedPaneID == paneID { sourceTab.zoomedPaneID = nil }
+        sourceTab.paneFocusHistory.remove(paneID)
+        if sourceTab.focusedPaneID == paneID {
+            sourceTab.focusedPaneID = sourceTab.nextFocusAfterClose()
+        }
+        if Preferences.shared.autoTilingEnabled { sourceTab.splitRoot.rebalanced() }
+
+        if sourceProjectID != destProjectID {
+            pane.rebind(projectID: destProjectID)
+        }
+        let newTab = TerminalTab(id: UUID(), splitRoot: .pane(pane), focusedPaneID: pane.id)
+        dest.adoptTab(newTab, at: index)
+        activeProjectID = destProjectID
+        recordProjectVisit(destProjectID)
+        saveWorkspaces()
+    }
+
+    /// Find the workspace tab currently holding a pane. Scans every loaded
+    /// workspace — a sidebar pane drop only carries the pane's id, and the
+    /// quick terminal's ephemeral tab (not in `workspaces`) correctly misses.
+    private func locatePane(_ paneID: UUID) -> (projectID: UUID, tab: TerminalTab)? {
+        for (projectID, ws) in workspaces {
+            if let tab = ws.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil }) {
+                return (projectID, tab)
+            }
+        }
+        return nil
+    }
+
     /// Reorder a tab within its own project to an absolute drop index (the
     /// offset a sidebar drag-and-drop reports). Persists on a real move.
     func reorderTab(_ tabID: UUID, inProject projectID: UUID, toIndex destination: Int) {

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -41,6 +41,8 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
     case copySessionID = "copy_session_id"
     case applyLayout = "apply_layout"
     case saveLayout = "save_layout"
+    case separateAllPanes = "separate_all_panes"
+    case separateCurrentPane = "separate_current_pane"
 
     var id: String { rawValue }
 
@@ -92,6 +94,10 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         // stray keystroke on a stock binding would be destructive.
         case .applyLayout: "none"
         case .saveLayout: "none"
+        // Unbound by default for the same reason: both restructure the live
+        // pane tree (shells survive, but the layout doesn't).
+        case .separateAllPanes: "none"
+        case .separateCurrentPane: "none"
         }
     }
 }

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -321,6 +321,8 @@ final class MainAppResponder: KeyResponder {
             .applyLayout,
             .saveLayout,
             .reloadGhosttyConfig,
+            .separateAllPanes,
+            .separateCurrentPane,
         ] {
             guard HotkeyRegistry.matches(event, action: action),
                   let command = AppCommand.allCases.first(where: { $0.hotkeyAction == action })

--- a/Macterm/Views/PaneDragDrop.swift
+++ b/Macterm/Views/PaneDragDrop.swift
@@ -19,6 +19,31 @@ extension NSPasteboard.PasteboardType {
     static let mactermPaneID = NSPasteboard.PasteboardType(UTType.mactermPaneID.identifier)
 }
 
+/// The grab-handle drag as seen by its drop targets: the pane UUID
+/// `PaneDragSource` writes as 16 raw bytes under `.mactermPaneID`.
+/// Deliberately NOT `Transferable`: the drag is an AppKit `NSDraggingSession`
+/// whose custom-type pasteboard data never reaches SwiftUI's `dropDestination`
+/// import path, so the workspace leaves read the drag pasteboard directly
+/// through a raw `DropDelegate`. (This drag also cannot target the sidebar
+/// at all — no public drop mechanism in that column ever receives the
+/// session, which is why "separate a pane into its own tab" ships as the
+/// Separate Current Pane command rather than a sidebar drop.)
+struct MovablePane {
+    let paneID: UUID
+
+    /// Decode the drag's payload synchronously off the drag pasteboard. The
+    /// pane drag never leaves the app and its bytes are written eagerly at
+    /// mouseDragged, so unlike `MovableTab` there is no async fallback to
+    /// need — nil simply means "not a pane drag".
+    static func fromDragPasteboard() -> MovablePane? {
+        guard let data = NSPasteboard(name: .drag).pasteboardItems?
+            .compactMap({ $0.data(forType: .mactermPaneID) })
+            .first, data.count == 16
+        else { return nil }
+        return MovablePane(paneID: data.withUnsafeBytes { UUID(uuid: $0.loadUnaligned(as: uuid_t.self)) })
+    }
+}
+
 /// Propagates the ID of the pane currently being dragged (nil when idle) from
 /// the grab handle up to its own leaf, so the source pane can disable its drop
 /// target — a drop on itself is meaningless, and an invalid drop should
@@ -382,13 +407,9 @@ struct LeafDropDelegate: DropDelegate {
         // A pane drag first: its payload is an eagerly-written UUID, readable
         // synchronously off the drag pasteboard (this drag never leaves the
         // app — sourceOperationMask is .move only within the application).
-        if let data = NSPasteboard(name: .drag).pasteboardItems?
-            .compactMap({ $0.data(forType: .mactermPaneID) })
-            .first, data.count == 16
-        {
-            let sourceID = data.withUnsafeBytes { UUID(uuid: $0.loadUnaligned(as: uuid_t.self)) }
+        if let movable = MovablePane.fromDragPasteboard() {
             let move = context.onMovePane
-            MainActor.assumeIsolated { move(sourceID, target) }
+            MainActor.assumeIsolated { move(movable.paneID, target) }
             return true
         }
 

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -292,6 +292,95 @@ struct AppStateTests {
         #expect(ws.tabs.count == 1)
     }
 
+    // MARK: - Separate one pane into its own tab (Separate Current Pane)
+
+    @Test
+    func separatePane_splits_the_pane_into_its_own_tab() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        let tab = try #require(ws.activeTab)
+        let original = try #require(tab.focusedPaneID)
+        state.splitPane(direction: .horizontal, projectID: p.id)
+        let dragged = try #require(tab.focusedPaneID)
+        tab.zoomedPaneID = dragged
+
+        state.separatePane(dragged, toProject: p.id, destPath: p.path)
+
+        // The source tab keeps its remaining pane, exits the stale zoom, and
+        // repairs focus; the dragged Pane object lives on in the new tab.
+        #expect(tab.splitRoot.allPanes().map(\.id) == [original])
+        #expect(tab.zoomedPaneID == nil)
+        #expect(tab.focusedPaneID == original)
+        #expect(ws.tabs.count == 2)
+        let newTab = try #require(ws.tabs.last)
+        #expect(newTab.splitRoot.allPanes().map(\.id) == [dragged])
+        #expect(newTab.focusedPaneID == dragged)
+        #expect(ws.activeTabID == newTab.id)
+    }
+
+    @Test
+    func separatePane_at_index_lands_at_that_slot() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        let tab = try #require(ws.activeTab)
+        state.splitPane(direction: .horizontal, projectID: p.id)
+        let dragged = try #require(tab.focusedPaneID)
+
+        state.separatePane(dragged, toProject: p.id, destPath: p.path, at: 0)
+
+        #expect(ws.tabs.count == 2)
+        #expect(ws.tabs.first?.splitRoot.allPanes().map(\.id) == [dragged])
+        #expect(ws.tabs.last?.id == tab.id)
+    }
+
+    @Test
+    func separatePane_across_projects_rebinds_and_activates_destination() throws {
+        let state = makeAppState()
+        let p1 = seedProject(state, name: "p1", path: "/tmp1")
+        let p2 = seedProject(state, name: "p2", path: "/tmp2")
+        let ws1 = try #require(state.workspaces[p1.id])
+        let ws2 = try #require(state.workspaces[p2.id])
+        state.selectProject(p1)
+        state.splitPane(direction: .horizontal, projectID: p1.id)
+        let sourceTab = try #require(ws1.activeTab)
+        let dragged = try #require(sourceTab.focusedPaneID)
+        let ws2TabsBefore = ws2.tabs.count
+
+        state.separatePane(dragged, toProject: p2.id, destPath: p2.path)
+
+        #expect(sourceTab.splitRoot.allPanes().count == 1)
+        #expect(ws2.tabs.count == ws2TabsBefore + 1)
+        let newTab = try #require(ws2.tabs.last)
+        #expect(newTab.splitRoot.allPanes().map(\.id) == [dragged])
+        // Routing identity follows the pane, mirroring moveTab's rebind.
+        #expect(newTab.splitRoot.allPanes().allSatisfy { $0.projectID == p2.id })
+        #expect(state.activeProjectID == p2.id)
+        #expect(ws2.activeTabID == newTab.id)
+    }
+
+    @Test
+    func separatePane_only_pane_of_its_tab_is_noop() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        let tab = try #require(ws.activeTab)
+        let onlyPane = try #require(tab.focusedPaneID)
+        state.separatePane(onlyPane, toProject: p.id, destPath: p.path)
+        #expect(ws.tabs.count == 1)
+        #expect(tab.splitRoot.allPanes().map(\.id) == [onlyPane])
+    }
+
+    @Test
+    func separatePane_unknown_pane_is_noop() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        state.separatePane(UUID(), toProject: p.id, destPath: p.path)
+        #expect(ws.tabs.count == 1)
+    }
+
     // MARK: - Focus navigation
 
     @Test


### PR DESCRIPTION
Stacked on #230 (which stacks on #228) — retarget as the PRs beneath merge.

**Separate Panes** existed only in the tab context menu. This PR makes it and a new per-pane sibling first-class commands — palette rows plus rebindable hotkeys (unbound by default, matching the other tree-rewriting actions like Apply/Save Layout):

- **Separate All Panes** — the context-menu action, invocable on the active tab.
- **Separate Current Pane** — new: splits just the focused pane out of the active tab into its own tab, inserted right after it.

## Why commands and not a sidebar drag

Dragging a pane's grab handle onto the sidebar was tried first (twice) and is **not implementable with public SwiftUI**: the sidebar column's hierarchy never receives the grab handle's AppKit `NSDraggingSession`. Tested against the live app with synthesized drags — row-, ForEach-, and header-level `dropDestination`; row-, header-, and List-level `onDrop`; and a target outside the List — none ever got a single delegate callback, while the identical delegate fires fine in the workspace column (the same drag session reshapes splits there). The finding is recorded on `MovablePane`'s doc comment so nobody retries it blind.

## How it works

- `AppState.separatePane` does `removePane`'s tree/zoom/focus repair *minus* the surface teardown, so the `Pane` object (surface and running shell) survives the trip; crossing projects rebinds routing identity the way `moveTab` does. The destination workspace resolves before detaching, so a failure can't leave the pane belonging to no tab.
- Both commands follow the add-an-action recipe: `AppCommand` cases (palette picks them up via `allCases`), `HotkeyAction` cases, and routing through the `AppCommand.action(in:)` single source of truth in `Responders.swift`, so palette, menu, and binding can't drift. Enablement guards make them no-ops on single-pane tabs.
- `MovablePane` stays as the shared drag-pasteboard decode for the workspace's `LeafDropDelegate`, which previously unpacked the UUID bytes inline.

## Testing

- New `AppStateTests`: pane lands in its own tab with source-tab zoom/focus repair, insertion at a slot, cross-project rebind + destination activation, only-pane / unknown-pane no-ops. Full suite passes; `format`/`lint` clean.
- Live-verified through the command palette in a hermetic app instance: "Separate Current Pane" on a 2-pane tab produced the new tab right after the source with focus following; "Separate All Panes" exploded a 3-pane tab into single-pane tabs in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)