### PR TITLE
Add a native Show Toolbar option that hides the whole title bar

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -278,6 +278,19 @@ final class Preferences {
         }
     }
 
+    /// Hide the window's title bar entirely: the toolbar (sidebar toggle, tab
+    /// switcher, update button), the title text, and — a side effect of
+    /// SwiftUI removing the window toolbar — the traffic lights. The sidebar
+    /// and terminal surface extend to the window's top edge. Tab switching
+    /// stays available via the sidebar and Cmd+1…9; close/minimize/zoom stay
+    /// available from the Window menu. No AppKit private API involved: the
+    /// window keeps its normal style mask, so edge-resizing still works.
+    var hideTitleBar: Bool {
+        didSet {
+            defaults.set(hideTitleBar, forKey: Keys.hideTitleBar)
+        }
+    }
+
     // MARK: - Ghostty config
 
     /// Path to the user's Ghostty config. Empty string = don't load any user
@@ -397,6 +410,7 @@ final class Preferences {
         windowGlassEnabled = defaults.object(forKey: Keys.windowGlassEnabled) as? Bool ?? false
         windowGlassStyle = (defaults.string(forKey: Keys.windowGlassStyle))
             .flatMap(WindowGlassStyle.init(rawValue:)) ?? .regular
+        hideTitleBar = defaults.object(forKey: Keys.hideTitleBar) as? Bool ?? false
         userGhosttyConfigPath = defaults.string(forKey: Keys.userGhosttyConfigPath) ?? "~/.config/ghostty/config"
         passthroughPrograms = defaults.string(forKey: Keys.passthroughPrograms) ?? ""
         quickTerminalEnabled = defaults.object(forKey: Keys.quickTerminalEnabled) as? Bool ?? true
@@ -465,6 +479,7 @@ final class Preferences {
         static let windowBlurRadius = "macterm.window.blurRadius"
         static let windowGlassEnabled = "macterm.window.glassEnabled"
         static let windowGlassStyle = "macterm.window.glassStyle"
+        static let hideTitleBar = "macterm.window.hideTitleBar"
         static let userGhosttyConfigPath = "macterm.ghostty.userConfigPath"
         static let passthroughPrograms = "macterm.hotkey.passthroughPrograms"
         static let quickTerminalEnabled = "macterm.quickTerminal.enabled"

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -580,10 +580,19 @@ private struct AppearanceSettings: View {
     private var liquidGlassStyle: WindowGlassStyle = Preferences.shared.windowGlassStyle
     @State
     private var paneDimOpacity: Double = Preferences.shared.paneDimOpacity
+    @State
+    private var hideTitleBar: Bool = Preferences.shared.hideTitleBar
 
     var body: some View {
         Form {
             Section("Window") {
+                Toggle("Hide title bar", isOn: $hideTitleBar)
+                    .onChange(of: hideTitleBar) { _, v in
+                        Preferences.shared.hideTitleBar = v
+                    }
+                Text("Removes the toolbar and window buttons so the terminal reaches the top edge; switch tabs via the sidebar or ⌘1–9.")
+                    .settingsCaption()
+
                 HStack {
                     Text("Background opacity")
                         .frame(width: sliderLabelWidth, alignment: .leading)

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -590,7 +590,7 @@ private struct AppearanceSettings: View {
                     .onChange(of: hideTitleBar) { _, v in
                         Preferences.shared.hideTitleBar = v
                     }
-                Text("Removes the toolbar and window buttons so the terminal reaches the top edge; switch tabs via the sidebar or ⌘1–9.")
+                Text("Removes the toolbar, window buttons, and drag area; switch tabs via the sidebar or ⌘1–9.")
                     .settingsCaption()
 
                 HStack {

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -580,19 +580,14 @@ private struct AppearanceSettings: View {
     private var liquidGlassStyle: WindowGlassStyle = Preferences.shared.windowGlassStyle
     @State
     private var paneDimOpacity: Double = Preferences.shared.paneDimOpacity
+    /// Inverted view of `Preferences.hideTitleBar`: the control reads as
+    /// "Show toolbar" (on by default), the preference stores the hide.
     @State
-    private var hideTitleBar: Bool = Preferences.shared.hideTitleBar
+    private var showToolbar: Bool = !Preferences.shared.hideTitleBar
 
     var body: some View {
         Form {
             Section("Window") {
-                Toggle("Hide title bar", isOn: $hideTitleBar)
-                    .onChange(of: hideTitleBar) { _, v in
-                        Preferences.shared.hideTitleBar = v
-                    }
-                Text("Removes the toolbar, window buttons, and drag area; switch tabs via the sidebar or ⌘1–9.")
-                    .settingsCaption()
-
                 HStack {
                     Text("Background opacity")
                         .frame(width: sliderLabelWidth, alignment: .leading)
@@ -688,27 +683,37 @@ private struct AppearanceSettings: View {
             }
 
             Section("Toolbar") {
-                Picker("Tab switcher", selection: $tabSwitcherVisibility) {
-                    ForEach(TabSwitcherVisibility.allCases) { option in
-                        Text(option.displayName).tag(option.rawValue)
+                Toggle("Show toolbar", isOn: $showToolbar)
+                    .onChange(of: showToolbar) { _, v in
+                        Preferences.shared.hideTitleBar = !v
                     }
-                }
-                .onChange(of: tabSwitcherVisibility) { _, v in
-                    Preferences.shared.tabSwitcherVisibility = TabSwitcherVisibility(rawValue: v) ?? .whenMultiple
-                }
-                Text("Numbered control in the title bar for switching tabs by index.")
+                Text("Hiding it removes the title bar, window buttons, and drag area; switch tabs via the sidebar or ⌘1–9.")
                     .settingsCaption()
 
-                Picker("Tab switcher position", selection: $tabSwitcherPosition) {
-                    ForEach(TabSwitcherPosition.allCases) { option in
-                        Text(option.displayName).tag(option.rawValue)
+                Group {
+                    Picker("Tab switcher", selection: $tabSwitcherVisibility) {
+                        ForEach(TabSwitcherVisibility.allCases) { option in
+                            Text(option.displayName).tag(option.rawValue)
+                        }
                     }
+                    .onChange(of: tabSwitcherVisibility) { _, v in
+                        Preferences.shared.tabSwitcherVisibility = TabSwitcherVisibility(rawValue: v) ?? .whenMultiple
+                    }
+                    Text("Numbered control in the title bar for switching tabs by index.")
+                        .settingsCaption()
+
+                    Picker("Tab switcher position", selection: $tabSwitcherPosition) {
+                        ForEach(TabSwitcherPosition.allCases) { option in
+                            Text(option.displayName).tag(option.rawValue)
+                        }
+                    }
+                    .onChange(of: tabSwitcherPosition) { _, v in
+                        Preferences.shared.tabSwitcherPosition = TabSwitcherPosition(rawValue: v) ?? .trailing
+                    }
+                    Text("Left places the switcher before the window title, next to the sidebar.")
+                        .settingsCaption()
                 }
-                .onChange(of: tabSwitcherPosition) { _, v in
-                    Preferences.shared.tabSwitcherPosition = TabSwitcherPosition(rawValue: v) ?? .trailing
-                }
-                Text("Left places the switcher before the window title, next to the sidebar.")
-                    .settingsCaption()
+                .disabled(!showToolbar)
             }
         }
         .formStyle(.grouped)

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -23,9 +23,18 @@ struct MainWindow: View {
         // Read in body, not inside the toolbar builder, so the Observation
         // dependency is registered and a Settings change re-places the item.
         let switcherPosition = preferences.tabSwitcherPosition
+        // Hiding the window toolbar (#226) also drops the titlebar itself,
+        // traffic lights included — that's AppKit's behavior for a toolbar-less
+        // fullSizeContentView window, not something we do separately. Read in
+        // body so flipping the setting re-applies live.
+        let chromeHidden = preferences.hideTitleBar
         return NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarContent()
                 .navigationSplitViewColumnWidth(min: 140, ideal: 180, max: 280)
+                // Hiding the toolbar removes the chrome but SwiftUI keeps its
+                // titlebar safe-area inset reserved; ignoring it is what lets
+                // rows actually start at the window's top edge.
+                .ignoresSafeArea(chromeHidden ? .container : [], edges: .top)
         } detail: {
             ZStack {
                 // The window's NSWindow.backgroundColor (set by WindowAppearance)
@@ -45,6 +54,9 @@ struct MainWindow: View {
                     WelcomeView()
                 }
             }
+            // Same safe-area reclaim as the sidebar: without it the terminal
+            // keeps a blank strip where the hidden titlebar used to be.
+            .ignoresSafeArea(chromeHidden ? .container : [], edges: .top)
             .navigationTitle(activeProject?.name ?? appDisplayName)
             .navigationSubtitle(activeTabTitle)
             .onGeometryChange(for: CGFloat.self) { proxy in
@@ -73,7 +85,8 @@ struct MainWindow: View {
                 }
             }
         }
-        .background(WindowStyler())
+        .toolbar(chromeHidden ? .hidden : .visible, for: .windowToolbar)
+        .background(WindowStyler(hideTitle: chromeHidden))
         .overlay {
             if appState.isCommandPaletteVisible {
                 CommandPaletteOverlay()
@@ -319,6 +332,11 @@ struct ZoomIndicator: View {
 }
 
 private struct WindowStyler: NSViewRepresentable {
+    /// Mirrors `Preferences.hideTitleBar`. The toolbar hide is SwiftUI-side
+    /// (`.toolbar(.hidden, for: .windowToolbar)` in `MainWindow`); the title
+    /// text is an `NSWindow` property, so it's applied here.
+    var hideTitle: Bool = false
+
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
@@ -352,6 +370,7 @@ private struct WindowStyler: NSViewRepresentable {
             // Without this the titlebar floats above the sidebar with a
             // visible boundary, which is jarring when both are translucent.
             window.styleMask.insert(.fullSizeContentView)
+            window.titleVisibility = hideTitle ? .hidden : .visible
             WindowAppearance.sync(window: window)
             coordinator.observe(window: window)
             // Intercept the close button to hide instead of close,
@@ -360,7 +379,14 @@ private struct WindowStyler: NSViewRepresentable {
         }
     }
 
-    func updateNSView(_: NSView, context _: Context) {}
+    func updateNSView(_ view: NSView, context _: Context) {
+        // Follow live setting flips. Async because SwiftUI forbids window
+        // mutation from inside the update pass.
+        let hide = hideTitle
+        DispatchQueue.main.async {
+            view.window?.titleVisibility = hide ? .hidden : .visible
+        }
+    }
 
     final class Coordinator: NSObject, NSWindowDelegate {
         nonisolated(unsafe) private var observer: Any?

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -384,7 +384,9 @@ private struct WindowStyler: NSViewRepresentable {
         // mutation from inside the update pass.
         let hide = hideTitle
         DispatchQueue.main.async {
-            view.window?.titleVisibility = hide ? .hidden : .visible
+            guard let window = view.window else { return }
+            window.titleVisibility = hide ? .hidden : .visible
+            WindowAppearance.syncTitleBarHidden(window: window)
         }
     }
 

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -30,6 +30,10 @@ struct MainWindow: View {
         let chromeHidden = preferences.hideTitleBar
         return NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarContent()
+                // Breathing room for the first row once the chrome is gone.
+                // Innermost, before `ignoresSafeArea`, so the padding insets
+                // the rows while the sidebar surface still reaches the edge.
+                .safeAreaPadding(.top, chromeHidden ? 8 : 0)
                 .navigationSplitViewColumnWidth(min: 140, ideal: 180, max: 280)
                 // Hiding the toolbar removes the chrome but SwiftUI keeps its
                 // titlebar safe-area inset reserved; ignoring it is what lets

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -3,6 +3,18 @@ import GhosttyKit
 import QuartzCore
 
 final class GhosttyTerminalNSView: NSView {
+    /// In a `.fullSizeContentView` window AppKit keeps a titlebar-height drag
+    /// band at the top (the area above `contentLayoutRect`), and a click there
+    /// moves the window whenever the hit-tested view answers true — NSView's
+    /// default for non-opaque views. With Hide Title Bar on (#226) the
+    /// terminal's top rows sit inside that band, so the default turned clicks
+    /// there into window drags and the surface never saw them. Ghostty solves
+    /// this by overriding `contentLayoutRect` on its NSWindow subclass; we
+    /// don't own SwiftUI's window class, so we answer per-view instead — same
+    /// idea as Ghostty's `NonDraggableHostingView`. Unconditional: a click on
+    /// the terminal should always be terminal input, never a window drag.
+    override var mouseDownCanMoveWindow: Bool { false }
+
     /// Weak registry of every live instance so global operations (e.g. config
     /// reload) can iterate without a central cache.
     @MainActor private static let liveViews = NSHashTable<GhosttyTerminalNSView>.weakObjects()

--- a/Macterm/Views/Terminal/SurfaceScrollView.swift
+++ b/Macterm/Views/Terminal/SurfaceScrollView.swift
@@ -76,6 +76,14 @@ final class SurfaceScrollView: NSScrollView {
         autohidesScrollers = false
         usesPredominantAxisScrolling = true
         verticalScrollElasticity = .none
+        // Never inset content or the scroller by the window's titlebar
+        // overlap. With Hide Title Bar on (#226) the pane extends into the old
+        // titlebar band, and the automatic adjustment pushed the scroller's
+        // track down so it started below the window top. With the chrome
+        // visible the pane sits below the titlebar and the automatic insets
+        // are zero anyway, so this is a no-op there.
+        automaticallyAdjustsContentInsets = false
+        contentInsets = NSEdgeInsets()
         // The window composites its own translucency (see WindowAppearance);
         // drawing a background here would double-tint.
         drawsBackground = false

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -418,32 +418,21 @@ enum WindowAppearance {
 
         syncTitleBarHidden(window: window)
 
-        let isFullScreen = window.styleMask.contains(.fullScreen)
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
-            // Windowed, on Tahoe: the NavigationSplitView's sidebar is a
-            // liquid-glass surface that extends behind the titlebar by design.
-            // Painting any flat color on the titlebar layer draws a band over
-            // that glass and creates a visible seam, so keep the layer clear
+            // On Tahoe, the NavigationSplitView's sidebar is a liquid-glass
+            // surface that extends behind the titlebar by design. Painting
+            // any flat color on the titlebar layer draws a band over that
+            // glass and creates a visible seam. Keep the layer transparent
             // and let AppKit's default titlebar materials (or the content
-            // view, with `.fullSizeContentView`) show through.
-            //
-            // Fullscreen is the opposite (#24): the titlebar lives in the
-            // NSToolbarFullScreenWindow overlay, a separate window nothing of
-            // ours shows through — clear just exposes its native gray
-            // material, which ignores `titlebarAppearsTransparent`. Painting
-            // the window background here is what makes the pinned fullscreen
-            // toolbar read as part of the app.
-            titlebarView.layer?.backgroundColor = isFullScreen
-                ? window.backgroundColor.cgColor
-                : NSColor.clear.cgColor
+            // view, with `.fullSizeContentView`) show through in both modes.
+            titlebarView.layer?.backgroundColor = NSColor.clear.cgColor
         }
 
         // NSTitlebarBackgroundView has subviews that force their own background
-        // colors; hide it when transparent — and in fullscreen, where it would
-        // paint the native gray between our painted layer and the toolbar
-        // items. Windowed-opaque keeps the default chrome intact.
-        container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = isTransparent || isFullScreen
+        // colors; hide it only when transparent, so the default opaque-mode
+        // chrome stays intact.
+        container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = isTransparent
     }
 
     private static func titlebarContainer(in window: NSWindow) -> NSView? {

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -418,21 +418,32 @@ enum WindowAppearance {
 
         syncTitleBarHidden(window: window)
 
+        let isFullScreen = window.styleMask.contains(.fullScreen)
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
-            // On Tahoe, the NavigationSplitView's sidebar is a liquid-glass
-            // surface that extends behind the titlebar by design. Painting
-            // any flat color on the titlebar layer draws a band over that
-            // glass and creates a visible seam. Keep the layer transparent
+            // Windowed, on Tahoe: the NavigationSplitView's sidebar is a
+            // liquid-glass surface that extends behind the titlebar by design.
+            // Painting any flat color on the titlebar layer draws a band over
+            // that glass and creates a visible seam, so keep the layer clear
             // and let AppKit's default titlebar materials (or the content
-            // view, with `.fullSizeContentView`) show through in both modes.
-            titlebarView.layer?.backgroundColor = NSColor.clear.cgColor
+            // view, with `.fullSizeContentView`) show through.
+            //
+            // Fullscreen is the opposite (#24): the titlebar lives in the
+            // NSToolbarFullScreenWindow overlay, a separate window nothing of
+            // ours shows through — clear just exposes its native gray
+            // material, which ignores `titlebarAppearsTransparent`. Painting
+            // the window background here is what makes the pinned fullscreen
+            // toolbar read as part of the app.
+            titlebarView.layer?.backgroundColor = isFullScreen
+                ? window.backgroundColor.cgColor
+                : NSColor.clear.cgColor
         }
 
         // NSTitlebarBackgroundView has subviews that force their own background
-        // colors; hide it only when transparent, so the default opaque-mode
-        // chrome stays intact.
-        container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = isTransparent
+        // colors; hide it when transparent — and in fullscreen, where it would
+        // paint the native gray between our painted layer and the toolbar
+        // items. Windowed-opaque keeps the default chrome intact.
+        container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = isTransparent || isFullScreen
     }
 
     private static func titlebarContainer(in window: NSWindow) -> NSView? {

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -387,13 +387,21 @@ enum WindowAppearance {
         // flipping the setting mid-fullscreen) restores it.
         window.toolbar?.isVisible = !hidden
         // Even toolbar-less, the overlay hosts a bare titlebar that the system
-        // slides down when the pointer hits the top of the fullscreen space,
-        // and its gray background is system-painted — it ignores
-        // `titlebarAppearsTransparent`, and AppKit rebuilds its subviews on
-        // reveal, undoing any view-level hide. The window's own alpha survives
-        // both, so the reveal animates an invisible window; the menu bar is a
+        // slides down alongside the menu bar when the pointer pushes past the
+        // top of the fullscreen space, and its gray background is
+        // system-painted — it ignores `titlebarAppearsTransparent`. A plain
+        // `alphaValue = 0` did not survive either: the reveal animates the
+        // overlay's alpha back in (observed live — the bar returned
+        // translucent, mid-animation). So blank the window's whole view tree
+        // from the root: the slide can animate whatever alpha it likes over a
+        // window that renders nothing. The root survives the reveal's subview
+        // rebuilds, and every sync re-asserts anyway. The menu bar is a
         // separate system window and still slides in for menu access.
-        fullscreenToolbarOverlay(for: window)?.alphaValue = hidden ? 0 : 1
+        if let overlay = fullscreenToolbarOverlay(for: window) {
+            overlay.alphaValue = hidden ? 0 : 1
+            let root = overlay.contentView?.superview ?? overlay.contentView
+            root?.isHidden = hidden
+        }
         // The macOS 26+ scroll-edge-effect pocket: AppKit hosts it in the
         // titlebar area (moved there on macOS 27, ghostty#13390) where it sits
         // over the terminal's top rows and blocks clicks/selection once the

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -378,6 +378,22 @@ enum WindowAppearance {
         let hidden = Preferences.shared.hideTitleBar
         titlebarContainer(in: window)?.isHidden = hidden
         window.isMovable = !hidden
+        // SwiftUI's `.toolbar(.hidden, for: .windowToolbar)` collapses the
+        // windowed titlebar but keeps the NSToolbar object on the window, and
+        // in native fullscreen AppKit creates a 52pt NSToolbarFullScreenWindow
+        // overlay for any window that owns a toolbar — an empty bar pinned to
+        // the top of the fullscreen space. Toggling the toolbar's own
+        // visibility removes the overlay; symmetric so leaving the mode (or
+        // flipping the setting mid-fullscreen) restores it.
+        window.toolbar?.isVisible = !hidden
+        // Even toolbar-less, the overlay hosts a bare titlebar that the system
+        // slides down when the pointer hits the top of the fullscreen space,
+        // and its gray background is system-painted — it ignores
+        // `titlebarAppearsTransparent`, and AppKit rebuilds its subviews on
+        // reveal, undoing any view-level hide. The window's own alpha survives
+        // both, so the reveal animates an invisible window; the menu bar is a
+        // separate system window and still slides in for menu access.
+        fullscreenToolbarOverlay(for: window)?.alphaValue = hidden ? 0 : 1
         // The macOS 26+ scroll-edge-effect pocket: AppKit hosts it in the
         // titlebar area (moved there on macOS 27, ghostty#13390) where it sits
         // over the terminal's top rows and blocks clicks/selection once the
@@ -422,12 +438,16 @@ enum WindowAppearance {
         guard window.styleMask.contains(.fullScreen) else {
             return findTitlebarContainer(from: window.contentView)
         }
-        for other in NSApp.windows
-            where other.className == "NSToolbarFullScreenWindow" && other.parent == window
-        {
-            return findTitlebarContainer(from: other.contentView)
+        return findTitlebarContainer(from: fullscreenToolbarOverlay(for: window)?.contentView)
+    }
+
+    /// The NSToolbarFullScreenWindow AppKit parents to `window` in native
+    /// fullscreen; nil outside fullscreen or before the overlay exists.
+    private static func fullscreenToolbarOverlay(for window: NSWindow) -> NSWindow? {
+        guard window.styleMask.contains(.fullScreen) else { return nil }
+        return NSApp.windows.first {
+            $0.className == "NSToolbarFullScreenWindow" && $0.parent == window
         }
-        return nil
     }
 
     /// Root-walk then search: the container is an ancestor sibling of the

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -345,8 +345,22 @@ enum WindowAppearance {
         return window.value(forKey: "_cornerRadius") as? CGFloat
     }
 
+    /// Hide or restore the titlebar container for the Hide Title Bar option
+    /// (#226). Hiding the window toolbar collapses the visible chrome, but the
+    /// collapsed titlebar still tracks its old rect and drags the window from
+    /// an invisible strip over the terminal's top rows. Hiding the container
+    /// itself — as Ghostty's hidden titlebar style does — lets those events
+    /// reach the content. Runs on every `sync` so AppKit rebuilding the
+    /// titlebar subviews (becomeMain, fullscreen transitions) re-asserts it;
+    /// `WindowStyler.updateNSView` calls it directly for live setting flips.
+    static func syncTitleBarHidden(window: NSWindow) {
+        titlebarContainer(in: window)?.isHidden = Preferences.shared.hideTitleBar
+    }
+
     private static func syncTitlebar(window: NSWindow, isTransparent: Bool) {
         guard let container = titlebarContainer(in: window) else { return }
+
+        syncTitleBarHidden(window: window)
 
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -345,16 +345,27 @@ enum WindowAppearance {
         return window.value(forKey: "_cornerRadius") as? CGFloat
     }
 
-    /// Hide or restore the titlebar container for the Hide Title Bar option
-    /// (#226). Hiding the window toolbar collapses the visible chrome, but the
-    /// collapsed titlebar still tracks its old rect and drags the window from
-    /// an invisible strip over the terminal's top rows. Hiding the container
-    /// itself — as Ghostty's hidden titlebar style does — lets those events
-    /// reach the content. Runs on every `sync` so AppKit rebuilding the
-    /// titlebar subviews (becomeMain, fullscreen transitions) re-asserts it;
-    /// `WindowStyler.updateNSView` calls it directly for live setting flips.
+    /// Apply the Hide Title Bar option (#226) to the window: hide the titlebar
+    /// container, and disable click-dragging while the option is on.
+    ///
+    /// Hiding the window toolbar collapses the visible chrome, but two drag
+    /// paths survive it. The collapsed titlebar container still tracks its old
+    /// rect and swallows events over an invisible strip — hiding the container
+    /// (as Ghostty's hidden titlebar style does) lets those reach the content.
+    /// Even then, a `.fullSizeContentView` window keeps a titlebar-height drag
+    /// band (the area above `contentLayoutRect`) that moves the window from any
+    /// hit view answering `mouseDownCanMoveWindow` — Ghostty removes it by
+    /// overriding `contentLayoutRect` on its NSWindow subclass, but SwiftUI
+    /// owns our window class, so the public equivalent is `isMovable = false`:
+    /// no user drags anywhere while hidden (programmatic moves, including
+    /// window managers driving Accessibility, still work). Runs on every
+    /// `sync` so AppKit rebuilding the titlebar subviews (becomeMain,
+    /// fullscreen transitions) re-asserts it; `WindowStyler.updateNSView`
+    /// calls it directly for live setting flips.
     static func syncTitleBarHidden(window: NSWindow) {
-        titlebarContainer(in: window)?.isHidden = Preferences.shared.hideTitleBar
+        let hidden = Preferences.shared.hideTitleBar
+        titlebarContainer(in: window)?.isHidden = hidden
+        window.isMovable = !hidden
     }
 
     private static func syncTitlebar(window: NSWindow, isTransparent: Bool) {

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -17,6 +17,18 @@ extension NSView {
         }
         return nil
     }
+
+    /// Every descendant whose class name matches `name` — for private views
+    /// that can exist once per scroll view (e.g. `NSScrollPocket`), where
+    /// hiding only the first would leave the rest in place.
+    func forEachDescendant(withClassName name: String, _ body: (NSView) -> Void) {
+        for subview in subviews {
+            if String(describing: type(of: subview)) == name {
+                body(subview)
+            }
+            subview.forEachDescendant(withClassName: name, body)
+        }
+    }
 }
 
 // MARK: - Color helpers (for the inactive-glass tint)
@@ -366,6 +378,15 @@ enum WindowAppearance {
         let hidden = Preferences.shared.hideTitleBar
         titlebarContainer(in: window)?.isHidden = hidden
         window.isMovable = !hidden
+        // The macOS 26+ scroll-edge-effect pocket: AppKit hosts it in the
+        // titlebar area (moved there on macOS 27, ghostty#13390) where it sits
+        // over the terminal's top rows and blocks clicks/selection once the
+        // chrome is gone. Hiding NSTitlebarBackgroundView doesn't cover it, so
+        // hide every pocket directly — one can exist per scroll view. On
+        // systems without the class the walk finds nothing.
+        window.contentView?.superview?.forEachDescendant(withClassName: "NSScrollPocket") {
+            $0.isHidden = hidden
+        }
     }
 
     private static func syncTitlebar(window: NSWindow, isTransparent: Bool) {

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -413,10 +413,27 @@ enum WindowAppearance {
 
     private static func titlebarContainer(in window: NSWindow) -> NSView? {
         // The titlebar container lives on the window's content view's root in
-        // normal mode, and on a separate NSToolbarFullScreenWindow in native
-        // fullscreen. We don't support native fullscreen tab bars, so the
-        // first path suffices for Macterm.
-        guard let contentView = window.contentView else { return nil }
+        // normal mode. In native fullscreen AppKit hosts it in a separate
+        // NSToolbarFullScreenWindow parented to ours — without following that
+        // hop, a hidden toolbar left an empty bar pinned to the top of the
+        // fullscreen space (#226). Ghostty's TerminalWindow resolves it the
+        // same way; matching on `parent` picks the right overlay when several
+        // fullscreen windows exist.
+        guard window.styleMask.contains(.fullScreen) else {
+            return findTitlebarContainer(from: window.contentView)
+        }
+        for other in NSApp.windows
+            where other.className == "NSToolbarFullScreenWindow" && other.parent == window
+        {
+            return findTitlebarContainer(from: other.contentView)
+        }
+        return nil
+    }
+
+    /// Root-walk then search: the container is an ancestor sibling of the
+    /// content view, so the lookup climbs to the theme frame first.
+    private static func findTitlebarContainer(from contentView: NSView?) -> NSView? {
+        guard let contentView else { return nil }
         var root: NSView = contentView
         while let s = root.superview {
             root = s


### PR DESCRIPTION
## What

A Settings → Appearance → Toolbar → **Show toolbar** toggle (on by default). Turning it off removes the window's entire top chrome — toolbar (sidebar toggle, tab switcher, update button), title text, traffic lights, and the drag band — so the sidebar and terminal surface extend to the window's top edge. The tab-switcher settings gray out while hidden.

## Why

Requested in #226 (an unobtrusive, kitty/Terminal.app-minimal look). Feasibility was the question; it turned out to be achievable with entirely native API, no private-view *mutation* beyond the hide/show of two titlebar subviews this codebase already reaches (and Ghostty's hidden style performs the same hides).

Closes #226

## How

Six levers, each one earned against a real symptom — the first three make the chrome disappear, the last three un-break the strip it leaves behind:

- `.toolbar(hidden ? .hidden : .visible, for: .windowToolbar)` on the `NavigationSplitView`. Hiding the window toolbar makes AppKit collapse the whole titlebar of a `.fullSizeContentView` window, traffic lights included. The visibility parameter (rather than an `if`-wrapped modifier) keeps the split view's identity across toggles, so terminal surfaces are never rebuilt.
- `.ignoresSafeArea(.container, edges: .top)` on both columns — hiding the toolbar does not release its reserved safe-area inset. The sidebar keeps an 8pt `safeAreaPadding` (innermost, so its surface still reaches the edge) for breathing room.
- `window.titleVisibility = .hidden` (public AppKit): the title text belongs to the titlebar, not the toolbar.
- **Drag band** (`WindowAppearance.syncTitleBarHidden`): even fully collapsed, the titlebar container tracks its old rect and AppKit keeps a titlebar-height drag band (the area above `contentLayoutRect`) that moves the window from any hit view answering `mouseDownCanMoveWindow`. Ghostty's hidden style fixes this by overriding `contentLayoutRect` on its NSWindow subclass; SwiftUI owns our window class, so the public equivalents are: hide the `NSTitlebarContainerView` (as Ghostty also does), answer `mouseDownCanMoveWindow = false` from `GhosttyTerminalNSView` (mirrors Ghostty's `NonDraggableHostingView`), and set `isMovable = false` while hidden. Programmatic moves — including AX-driven tiling window managers — are unaffected.
- **Click-blocking pocket**: the macOS 26+ scroll-edge-effect `NSScrollPocket` is hosted in the titlebar area (moved there outright on macOS 27, ghostty#13390) and sat over the terminal's top rows, blocking text selection. Hidden while the option is on — every pocket, since one can exist per scroll view.
- **Scroller inset**: `NSScrollView`'s automatic content insets pushed the overlay scroller's track down by the titlebar overlap, so it started below the window top. `SurfaceScrollView` opts out (`automaticallyAdjustsContentInsets = false`) — a no-op while the chrome is visible, since the pane then sits below the titlebar and the insets are zero.

All of it re-asserts from every `WindowAppearance.sync` (AppKit rebuilds titlebar subviews on becomeMain/fullscreen transitions) and applies live in both directions — no restart, window frame unchanged, surfaces untouched.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [ ] Added or updated tests for new model / persistence / palette / hotkey logic — plain `Preferences` bool with no logic; matches existing toggles, which carry no per-setting tests

Verified in a hermetic instance and by hand on a real setup (macOS 27, AeroSpace): chrome gone with content at the top edge, no drag from the top strip, text selection works in the top rows, scroller starts at the window top, stock chrome returns losslessly when toggled back, and the Settings pane disables the tab-switcher pickers while hidden.

## Notes for reviewers

- The original issue asked for Terminal.app-style auto-minimize (expand when tabs > 1). That variant was spiked and works, but the shipped behavior is an unconditional hide by explicit choice — the sidebar is already the tab UI, and chrome popping in on tab spawn read as a bug in practice.
- With the toolbar hidden the window cannot be moved by dragging at all (same end state as Ghostty's `macos-titlebar-style = hidden`); close/minimize stay available via the Window menu and hotkeys.
- Native fullscreen (toolbar hidden) is handled: AppKit hosts the fullscreen titlebar in a separate `NSToolbarFullScreenWindow` parented to the main window, and `titlebarContainer` follows that hop (Ghostty's `TerminalWindow` pattern). `toolbar.isVisible = false` removes the overlay's 52pt slot, and hiding the overlay's root view blanks the top-edge hover reveal (its slide animates the overlay's alpha back, so a plain `alphaValue = 0` didn't survive).
- A #24-style fix for the toolbar-VISIBLE fullscreen bar (paint the overlay's titlebar with the window background) was tried on this branch and reverted: it makes the detail column seamless but trades the gray seam for a color seam at the sidebar column, whose surface shade the flat paint can't match — the same reason the 2026-05 attempt on #24 wasn't landed. The stock gray fullscreen toolbar stays for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
