### PR TITLE
chore(deps): bump GhosttyKit to build-2026-08-09

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,7 @@ XCFRAMEWORK_DIR="GhosttyKit.xcframework"
 #
 # Set GHOSTTYKIT_TAG to another tag (or `latest`) to try one without committing:
 #   GHOSTTYKIT_TAG=latest mise run setup
-GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-03}"
+GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-09}"
 # Which tag the on-disk fork artifacts actually came from. Without this the
 # presence checks below would keep a stale copy forever after a pin bump — the
 # same silent-staleness trap that makes symlinking these artifacts a bad idea.


### PR DESCRIPTION
Moves the pinned `thdxg/ghostty` release (`GHOSTTYKIT_TAG` in `scripts/setup.sh`) from `build-2026-08-03` to `build-2026-08-09`.

**CI on this PR is the gate.** Editing `scripts/setup.sh` changes the GhosttyKit cache key, so this run downloads the new pin from scratch and exercises it through Unit, End-to-end, and the benchmark — rather than a release being the first thing to try it.

Compare upstream: [`build-2026-08-03...build-2026-08-09`](https://github.com/thdxg/ghostty/compare/build-2026-08-03...build-2026-08-09)

---

### GhosttyKit API review — `build-2026-08-03` → `build-2026-08-09`

Filtered to the **154** `ghostty_*`/`GHOSTTY_*` symbols Macterm's own sources reference and the header defines.

#### ✅ No symbol we use was removed

#### ⚠️ 1 enum constant(s) we use changed numeric value

`ghostty_action_tag_e`:
- added `GHOSTTY_ACTION_MOVE_TAB_TO_NEW_WINDOW`

<details><summary>Affected constants (1)</summary>

| symbol | build-2026-08-03 | build-2026-08-09 |
|---|---|---|
| `GHOSTTY_ACTION_OUTPUT_ACTIVITY` | 67 | 68 |

</details>

Harmless as long as the header and the archive stay paired — the xcframework ships them together, and `setup.sh` only ever installs both from one release. Never pair one with the other's, and treat any hardcoded raw value as suspect. A **removed** member is the one to look at closely.

#### Changed hunks touching a symbol we use

```diff
@@ -818,12 +818,13 @@
 
 // apprt.action.OpenUrlKind
 typedef enum {
   GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
   GHOSTTY_ACTION_OPEN_URL_KIND_TEXT,
   GHOSTTY_ACTION_OPEN_URL_KIND_HTML,
+  GHOSTTY_ACTION_OPEN_URL_KIND_OSC8,
 } ghostty_action_open_url_kind_e;
 
 // apprt.action.OpenUrl.C
 typedef struct {
   ghostty_action_open_url_kind_e kind;
   const char* url;
@@ -956,12 +957,13 @@
   GHOSTTY_ACTION_START_SEARCH,
   GHOSTTY_ACTION_END_SEARCH,
   GHOSTTY_ACTION_SEARCH_TOTAL,
   GHOSTTY_ACTION_SEARCH_SELECTED,
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
+  GHOSTTY_ACTION_MOVE_TAB_TO_NEW_WINDOW,
   GHOSTTY_ACTION_OUTPUT_ACTIVITY,
 } ghostty_action_tag_e;
 
 typedef union {
   ghostty_action_split_direction_e new_split;
   ghostty_action_fullscreen_e toggle_fullscreen;
```

<sub>4 changed header lines total; 2 hunk(s) touch symbols we use. A green CI run means it builds and the suites pass — not that no behaviour moved.</sub>
