### PR TITLE
Let tab cycling stay inside the current project

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -13,6 +13,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
     case renameTab
     case nextTab
     case previousTab
+    case nextTabInProject
+    case previousTabInProject
     case recentTab
     case separateAllPanes
     // Panes
@@ -60,6 +62,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .renameTab: "Rename Current Tab"
         case .nextTab: "Next Tab"
         case .previousTab: "Previous Tab"
+        case .nextTabInProject: "Next Tab in Project"
+        case .previousTabInProject: "Previous Tab in Project"
         case .recentTab: "Recent Tab"
         case .separateAllPanes: "Separate All Panes"
         case .separateCurrentPane: "Separate Current Pane"
@@ -104,6 +108,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
              .renameTab,
              .nextTab,
              .previousTab,
+             .nextTabInProject,
+             .previousTabInProject,
              .recentTab,
              .separateAllPanes: .tabs
         case .splitRight,
@@ -149,6 +155,8 @@ enum AppCommand: String, CaseIterable, Identifiable {
         case .closePane: .closePane
         case .nextTab: .nextGlobalTab
         case .previousTab: .previousGlobalTab
+        case .nextTabInProject: .nextTabInProject
+        case .previousTabInProject: .previousTabInProject
         case .recentTab: .recentTab
         case .separateAllPanes: .separateAllPanes
         case .splitRight: .splitRight

--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -34,9 +34,10 @@ extension AppCommand {
             return { ctx.appState.selectGlobalTab(.next, projects: ctx.projectStore.projects) }
         case .previousTab:
             return { ctx.appState.selectGlobalTab(.previous, projects: ctx.projectStore.projects) }
-        // The project-scoped pair: cycling wraps within the active project's
-        // own tabs, so a keystroke can never carry focus into another project
-        // the way `.nextTab`/`.previousTab` do.
+        // The project-scoped pair (what ctrl+]/ctrl+[ bind to by default):
+        // cycling wraps within the active project's own tabs, so a keystroke
+        // can never carry focus into another project the way the
+        // `.nextTab`/`.previousTab` pair above does.
         case .nextTabInProject:
             guard let projectID else { return nil }
             return { ctx.appState.selectNextTab(projectID: projectID) }

--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -34,6 +34,15 @@ extension AppCommand {
             return { ctx.appState.selectGlobalTab(.next, projects: ctx.projectStore.projects) }
         case .previousTab:
             return { ctx.appState.selectGlobalTab(.previous, projects: ctx.projectStore.projects) }
+        // The project-scoped pair: cycling wraps within the active project's
+        // own tabs, so a keystroke can never carry focus into another project
+        // the way `.nextTab`/`.previousTab` do.
+        case .nextTabInProject:
+            guard let projectID else { return nil }
+            return { ctx.appState.selectNextTab(projectID: projectID) }
+        case .previousTabInProject:
+            guard let projectID else { return nil }
+            return { ctx.appState.selectPreviousTab(projectID: projectID) }
         case .recentTab:
             guard let projectID else { return nil }
             return { ctx.appState.cycleRecentTab(projectID: projectID) }

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -71,13 +71,16 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .recentTab: "ctrl+tab"
         case .nextProject: "cmd+]"
         case .previousProject: "cmd+["
-        case .nextGlobalTab: "ctrl+]"
-        case .previousGlobalTab: "ctrl+["
-        // Unbound by default: the ctrl+]/ctrl+[ pair above already covers tab
-        // cycling out of the box, and these are the opt-in variant for users
-        // who don't want a keystroke to carry them into another project.
-        case .nextTabInProject: "none"
-        case .previousTabInProject: "none"
+        // ctrl+]/ctrl+[ drive the project-scoped pair: cycling stops at the
+        // project's own tabs, which is what a workspace boundary implies. The
+        // cross-project pair keeps the chord's old job but ships unbound —
+        // both pairs on one chord would register as a conflict in Settings,
+        // and the responder's global branch runs first, so it would simply
+        // shadow the scoped one. Users who want the old reach rebind it.
+        case .nextGlobalTab: "none"
+        case .previousGlobalTab: "none"
+        case .nextTabInProject: "ctrl+]"
+        case .previousTabInProject: "ctrl+["
         case .focusPaneLeft: "cmd+ctrl+h"
         case .focusPaneDown: "cmd+ctrl+j"
         case .focusPaneUp: "cmd+ctrl+k"

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -20,6 +20,8 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
     case previousProject = "previous_project"
     case nextGlobalTab = "next_global_tab"
     case previousGlobalTab = "previous_global_tab"
+    case nextTabInProject = "next_tab_in_project"
+    case previousTabInProject = "previous_tab_in_project"
     case focusPaneLeft = "focus_pane_left"
     case focusPaneDown = "focus_pane_down"
     case focusPaneUp = "focus_pane_up"
@@ -71,6 +73,11 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .previousProject: "cmd+["
         case .nextGlobalTab: "ctrl+]"
         case .previousGlobalTab: "ctrl+["
+        // Unbound by default: the ctrl+]/ctrl+[ pair above already covers tab
+        // cycling out of the box, and these are the opt-in variant for users
+        // who don't want a keystroke to carry them into another project.
+        case .nextTabInProject: "none"
+        case .previousTabInProject: "none"
         case .focusPaneLeft: "cmd+ctrl+h"
         case .focusPaneDown: "cmd+ctrl+j"
         case .focusPaneUp: "cmd+ctrl+k"

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -207,6 +207,18 @@ struct MactermApp: App {
                 Divider()
                 AppCommandMenuItem(command: .nextTab, appState: appState, projectStore: projectStore, titleOverride: "Next Tab")
                 AppCommandMenuItem(command: .previousTab, appState: appState, projectStore: projectStore, titleOverride: "Previous Tab")
+                AppCommandMenuItem(
+                    command: .nextTabInProject,
+                    appState: appState,
+                    projectStore: projectStore,
+                    titleOverride: "Next Tab in Project"
+                )
+                AppCommandMenuItem(
+                    command: .previousTabInProject,
+                    appState: appState,
+                    projectStore: projectStore,
+                    titleOverride: "Previous Tab in Project"
+                )
                 AppCommandMenuItem(command: .recentTab, appState: appState, projectStore: projectStore, titleOverride: "Recent Tab")
             }
             CommandMenu("Project") {

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -268,9 +268,11 @@ final class MainAppResponder: KeyResponder {
             appState.selectGlobalTab(.previous, projects: projectStore.projects)
             return .handled
         }
-        // Project-scoped counterparts: cycle within the active project's tabs
-        // only, wrapping at either end instead of crossing into the next
-        // project the way the global pair above does.
+        // Project-scoped counterparts, and what ctrl+]/ctrl+[ bind to by
+        // default: cycle within the active project's tabs only, wrapping at
+        // either end instead of crossing into the next project the way the
+        // global pair above does. Order matters only if a user binds both
+        // pairs to one chord — the global branch above would win.
         if HotkeyRegistry.matches(event, action: .nextTabInProject) {
             guard let projectID = appState.activeProjectID else { return .passThrough }
             appState.selectNextTab(projectID: projectID)

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -268,6 +268,19 @@ final class MainAppResponder: KeyResponder {
             appState.selectGlobalTab(.previous, projects: projectStore.projects)
             return .handled
         }
+        // Project-scoped counterparts: cycle within the active project's tabs
+        // only, wrapping at either end instead of crossing into the next
+        // project the way the global pair above does.
+        if HotkeyRegistry.matches(event, action: .nextTabInProject) {
+            guard let projectID = appState.activeProjectID else { return .passThrough }
+            appState.selectNextTab(projectID: projectID)
+            return .handled
+        }
+        if HotkeyRegistry.matches(event, action: .previousTabInProject) {
+            guard let projectID = appState.activeProjectID else { return .passThrough }
+            appState.selectPreviousTab(projectID: projectID)
+            return .handled
+        }
 
         if let (_, dir) = Self.focusActions.first(where: { HotkeyRegistry.matches(event, action: $0.0) }) {
             guard let projectID = appState.activeProjectID else { return .passThrough }

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -403,6 +403,59 @@ struct AppStateTests {
         #expect(ws.tabs.count == 1)
     }
 
+    // MARK: - Project-scoped tab navigation
+
+    @Test
+    func selectNextTab_wraps_within_the_project() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let other = seedProject(state, name: "other", path: "/tmp/other")
+        let ws = try #require(state.workspaces[p.id])
+        let first = try #require(ws.activeTabID)
+        let second = ws.createTab(projectPath: p.path).id
+        // Seed a tab in the sibling project so a leak across projects would show.
+        _ = try #require(state.workspaces[other.id]?.activeTabID)
+        state.activeProjectID = p.id
+        ws.selectTab(first)
+
+        state.selectNextTab(projectID: p.id)
+        #expect(ws.activeTabID == second)
+        // At the last tab it wraps to the first rather than crossing over.
+        state.selectNextTab(projectID: p.id)
+        #expect(ws.activeTabID == first)
+        #expect(state.activeProjectID == p.id)
+    }
+
+    @Test
+    func selectPreviousTab_wraps_within_the_project() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        _ = seedProject(state, name: "other", path: "/tmp/other")
+        let ws = try #require(state.workspaces[p.id])
+        let first = try #require(ws.activeTabID)
+        let second = ws.createTab(projectPath: p.path).id
+        state.activeProjectID = p.id
+        ws.selectTab(first)
+
+        // At the first tab it wraps to the last rather than crossing over.
+        state.selectPreviousTab(projectID: p.id)
+        #expect(ws.activeTabID == second)
+        state.selectPreviousTab(projectID: p.id)
+        #expect(ws.activeTabID == first)
+        #expect(state.activeProjectID == p.id)
+    }
+
+    @Test
+    func selectNextTab_single_tab_is_noop() throws {
+        let state = makeAppState()
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        let only = try #require(ws.activeTabID)
+        state.selectNextTab(projectID: p.id)
+        state.selectPreviousTab(projectID: p.id)
+        #expect(ws.activeTabID == only)
+    }
+
     // MARK: - Focus navigation
 
     @Test

--- a/MactermTests/App/HotkeysTests.swift
+++ b/MactermTests/App/HotkeysTests.swift
@@ -334,6 +334,21 @@ struct HotkeysTests {
     }
 
     @Test
+    func project_scoped_tab_actions_are_unbound_by_default_and_titled_from_command() {
+        // The global ctrl+]/ctrl+[ pair already ships bound; these clamp the
+        // same navigation to the active project and are opt-in via Keymaps.
+        #expect(HotkeyAction.nextTabInProject.defaultShortcut == "none")
+        #expect(HotkeyAction.previousTabInProject.defaultShortcut == "none")
+        #expect(HotkeyAction.nextTabInProject.title == "Next Tab in Project")
+        #expect(HotkeyAction.previousTabInProject.title == "Previous Tab in Project")
+        #expect(AppCommand.nextTabInProject.hotkeyAction == .nextTabInProject)
+        #expect(AppCommand.previousTabInProject.hotkeyAction == .previousTabInProject)
+        // Distinct from the cross-project pair they sit beside.
+        #expect(AppCommand.nextTab.hotkeyAction == .nextGlobalTab)
+        #expect(AppCommand.previousTab.hotkeyAction == .previousGlobalTab)
+    }
+
+    @Test
     func all_action_ids_are_unique() {
         let ids = HotkeyAction.allCases.map(\.rawValue)
         #expect(ids.count == Set(ids).count)

--- a/MactermTests/App/HotkeysTests.swift
+++ b/MactermTests/App/HotkeysTests.swift
@@ -334,11 +334,15 @@ struct HotkeysTests {
     }
 
     @Test
-    func project_scoped_tab_actions_are_unbound_by_default_and_titled_from_command() {
-        // The global ctrl+]/ctrl+[ pair already ships bound; these clamp the
-        // same navigation to the active project and are opt-in via Keymaps.
-        #expect(HotkeyAction.nextTabInProject.defaultShortcut == "none")
-        #expect(HotkeyAction.previousTabInProject.defaultShortcut == "none")
+    func ctrl_bracket_defaults_to_the_project_scoped_tab_pair() {
+        // ctrl+]/ctrl+[ cycle within the active project. The cross-project
+        // pair ships unbound: both on one chord would conflict, and the
+        // responder's global branch runs first, so it would shadow the
+        // scoped one outright rather than merely tie with it.
+        #expect(HotkeyAction.nextTabInProject.defaultShortcut == "ctrl+]")
+        #expect(HotkeyAction.previousTabInProject.defaultShortcut == "ctrl+[")
+        #expect(HotkeyAction.nextGlobalTab.defaultShortcut == "none")
+        #expect(HotkeyAction.previousGlobalTab.defaultShortcut == "none")
         #expect(HotkeyAction.nextTabInProject.title == "Next Tab in Project")
         #expect(HotkeyAction.previousTabInProject.title == "Previous Tab in Project")
         #expect(AppCommand.nextTabInProject.hotkeyAction == .nextTabInProject)
@@ -346,6 +350,17 @@ struct HotkeysTests {
         // Distinct from the cross-project pair they sit beside.
         #expect(AppCommand.nextTab.hotkeyAction == .nextGlobalTab)
         #expect(AppCommand.previousTab.hotkeyAction == .previousGlobalTab)
+    }
+
+    @Test
+    func no_two_actions_ship_the_same_default_shortcut() {
+        // Guards the swap above (and any future default): two actions on one
+        // chord surface as a conflict in Settings → Keymaps, and whichever
+        // responder branch runs first silently wins.
+        let bound = HotkeyAction.allCases.compactMap {
+            HotkeyRegistry.conflictKey(for: $0.defaultShortcut)
+        }
+        #expect(bound.count == Set(bound).count)
     }
 
     @Test


### PR DESCRIPTION
## What

Adds two keybindable actions — **Next Tab in Project** and **Previous Tab in Project** — that cycle tabs within the active project only, wrapping at either end instead of crossing into another project. `ctrl+]` / `ctrl+[` now bind to these by default.

## Why

`ctrl+]` / `ctrl+[` walked a single flat list of every tab across every project, so cycling past a project's last tab silently switched projects. A project is a workspace boundary, so the stock tab-cycling chord should respect it.

## How

Straight application of the "Adding a New Action" recipe in `CLAUDE.md`:

- `Hotkeys.swift` — `nextTabInProject` / `previousTabInProject` (`next_tab_in_project`, `previous_tab_in_project`), taking over the `ctrl+]` / `ctrl+[` defaults.
- `AppCommand.swift` — matching commands in the Tabs category, linked to those hotkey actions, so the palette and Settings → Keymaps pick them up from `allCases` with no extra wiring.
- `AppCommandActions.swift` — the shared implementation both the palette and menu bar run.
- `Responders.swift` — key handling in `MainAppResponder`, beside the global pair.
- `MactermApp.swift` — Window menu items next to Next/Previous Tab.

Three things worth a reviewer's attention:

**The behavior is inherited, not reimplemented.** `AppState.selectNextTab(projectID:)` / `selectPreviousTab(projectID:)` already cycled within one workspace (via `Workspace.selectNextTab()`, a modulo walk over that workspace's tabs that no-ops on a single tab) — they simply had no callers. This PR gives them one.

**The cross-project pair had to give up the chord, not share it.** Next/Previous Tab keep their behavior and their place in the menu and palette, but now ship unbound (`"none"`). Two actions on one chord surface as a conflict in Settings → Keymaps, and `MainAppResponder` checks the global branch first — so sharing wouldn't tie, it would shadow the scoped action outright and this PR would appear to do nothing. Anyone who wants the old cross-project reach rebinds it.

**This changes behavior for existing users who never rebound.** A stored override always wins over a default, so users who already set their own tab-cycling chord are untouched; everyone else gets scoped cycling on `ctrl+]` / `ctrl+[` after updating. That's the intent, but it is a default change rather than a purely additive one.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [ ] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

New tests: three in `AppStateTests` (next wraps within the project, previous wraps within the project, single-tab is a no-op — each seeding a sibling project so a leak across projects would fail the assertion) and two in `HotkeysTests` (the `ctrl+]` / `ctrl+[` defaults now land on the scoped pair with the global pair unbound; and a guard that **no** two actions ship the same default shortcut, since that collision fails silently). Confirmed via the xcresult that each actually executed rather than merely compiling.

## Notes for reviewers

Not exercised by hand in a running app. The logic under these actions is the already-tested `Workspace` cycling, and the palette/menu/hotkey paths all route through the one `AppCommand.action(in:)` closure, but flagging it since the checklist item is unticked.

Two commits, worth reading in order: the first adds the actions unbound, the second swaps the defaults.

This worktree had never been set up, so I ran `mise trust` + `mise run setup` (pin `build-2026-08-09`) before it could build. No committed change from that — the artifacts are gitignored.
