### PR TITLE
Re-measure the tab switcher when its segments change

### DIFF
--- a/Macterm/Views/TabSwitcherToolbarItem.swift
+++ b/Macterm/Views/TabSwitcherToolbarItem.swift
@@ -43,6 +43,9 @@ struct TabSwitcherToolbarItem: View {
             let activeIndex = tabs.firstIndex(where: { $0.id == workspace.activeTabID }) ?? 0
             let window = slidingWindow(activeIndex: activeIndex, tabCount: tabs.count)
             let windowTabs = Array(tabs[window])
+            let labels = windowTabs.indices.map {
+                label(offset: $0, window: window, tabCount: tabs.count)
+            }
 
             Picker("Tab", selection: Binding(
                 get: { workspace.activeTabID },
@@ -51,18 +54,32 @@ struct TabSwitcherToolbarItem: View {
                     appState.selectTab(id, projectID: projectID)
                 }
             )) {
-                ForEach(Array(windowTabs.enumerated()), id: \.element.id) { offset, tab in
-                    Text(label(
-                        offset: offset,
-                        window: window,
-                        tabCount: tabs.count
-                    ))
-                    .tag(Optional(tab.id))
+                ForEach(Array(zip(windowTabs, labels)), id: \.0.id) { tab, label in
+                    Text(label)
+                        .tag(Optional(tab.id))
                 }
             }
             .pickerStyle(.segmented)
             .labelsHidden()
             .fixedSize()
+            // Rebuild the control whenever the rendered segments change, so
+            // its width can never lag its contents by one change.
+            //
+            // A segmented picker hosted in an `NSToolbarItem` is measured once
+            // per view identity, and `fixedSize` is what promotes that
+            // measurement to the control's width. Mutating the tab set from
+            // `KeyRouter`'s `NSEvent` monitor — Cmd+T, Cmd+W — updates the
+            // labels without prompting AppKit to re-measure the item, so the
+            // track keeps the *previous* segment count's width: growing clips
+            // the last segment, shrinking leaves the track too wide for the
+            // segments stretched across it. Paths that happen to end in an
+            // independent AppKit layout pass mask it, which is why the same
+            // edit through the menu bar or the control socket looks correct
+            // and only the keybinds show the bug.
+            //
+            // Keyed on the labels rather than `windowTabs.count`: a digit
+            // flipping to `⋯` changes the ideal width at a constant count.
+            .id(labels.joined(separator: "\u{1F}"))
             .help("Cmd+1…\(min(9, tabs.count)) to switch tabs")
         }
     }


### PR DESCRIPTION
Fixes the titlebar tab switcher rendering at the **previous** segment count's width: `Cmd+T` clipped the newly added last segment, `Cmd+W` left the track too wide with the remaining segments stretched across it.

## Cause

A segmented picker hosted in an `NSToolbarItem` is measured once per view identity, and `.fixedSize()` is what promotes that measurement to the control's width. Mutating the tab set from `KeyRouter`'s `NSEvent` monitor updates the labels without prompting AppKit to re-measure the item, so the track keeps the width it was last measured at.

## Fix

Key the `Picker`'s identity on its rendered labels, forcing a fresh measurement. Keyed on the labels rather than the segment count because a digit flipping to `⋯` changes the ideal width at a constant count.

## Reviewer notes

**This only reproduces through real keybinds.** Any path that ends in an independent AppKit layout pass masks it completely, so it looks like there is no bug when driven any other way:

- `macterm tab new` — the control socket hops to `@MainActor` from a socket thread, landing in a fresh run-loop turn after layout.
- Menu-bar **File → New Tab** — menu tracking forces a re-layout.

Both render correctly at every count on unpatched code. Only `Cmd+T` / `Cmd+W` show it.

## Verification

Region video of the switcher at 8fps while sending real `Cmd+T` / `Cmd+W`:

| state | before | after |
| --- | --- | --- |
| 4 tabs (3× `Cmd+T`) | digits run to x=582, 28px past the control's right edge — last segment clipped | enclosed, right edge 554, even 20px margin |
| 3 tabs (`Cmd+W`) | digits stretched across 193px (64px/segment) | 147px (49px/segment), track snug |

Keybind-driven regression sweep: grow 1→7 tabs, shrink 7→4, and `ctrl+[` cycling at a constant count (flips digits to `⋯`, changing the ideal width without changing the segment count) — correct at every step. `mise run test` passes; format and lint clean.
