### PR TITLE
Sit the New Project button an equal distance off both sidebar edges

### DIFF
--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -124,7 +124,12 @@ struct SidebarContent: View {
             }
             .padding(.horizontal, 16)
             .padding(.top, 36)
-            .padding(.bottom, 10)
+            // Not 16: the two edges are padding the label's *layout* box, whose
+            // slack differs per edge — the leading side bearing of the `plus`
+            // symbol pushes its ink ~4.5pt in, while the line box ends ~0.5pt
+            // below the text's descender. Measured on a build, 16/20 is what
+            // puts the ink an equal ~20.5pt off both the left and bottom edges.
+            .padding(.bottom, 20)
         }
         .onChange(of: selection) { _, items in
             // Navigation follows a single selection only. A multi-selection is


### PR DESCRIPTION
The sidebar footer button read as misaligned in the bottom-left corner — its ink sat noticeably further from the left edge than from the bottom.

## What was actually wrong

The existing padding (`16` horizontal, `10` bottom) looked like a deliberate pair, but the two edges are padding the label's *layout* box, and its slack differs per edge:

- **Left** — the `plus` SF Symbol's leading side bearing pushes its ink ~4.5pt past the horizontal pad → **20.5pt** of visible gap.
- **Bottom** — the `.body` line box ends only ~0.5pt below the text's descender → **10.5pt** of visible gap.

So simply matching the numbers (`16`/`16`) would *not* have matched the gaps. The bottom pad is `20` because that is what measurement says lands the ink at the same ~20.5pt.

## How it was verified

Built the Debug app, launched it hermetically (throwaway `$HOME` + `MACTERM_BENCHMARK_DATA_DIR` + `ZMX_DIR`), captured the window with `screencapture -o -l <windowid>`, and scanned the bottom-left region for the ink bounding box against the sidebar background:

| | left gap | bottom gap |
|---|---|---|
| before | 20.5pt | 10.5pt |
| after | 20.5pt | 20.5pt |

## Reviewer notes

- The asymmetric `16`/`20` is the point, not a typo — the comment records the measurement so it doesn't get "corrected" to `16`/`16` later.
- Only the bottom pad moved; the horizontal pad is untouched, so the button stays aligned with the list rows above it. The footer grows 10pt taller.
- No tests: this is a view-layout constant, and UI isn't unit-tested per the project conventions. `format` and `lint` are clean.