### PR TITLE
Publish a sortable image tag so the site can be deployed by Flux

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -139,11 +139,19 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # :latest is what a deployment tracks; :sha-<short> is what it pins
-          # to, and the only way back to a specific build after a bad one.
+          # Three tags, each with a job. :latest is what a human pulls;
+          # :sha-<short> is the way back to a specific build after a bad one;
+          # and the UTC timestamp tag is what the cluster deploys, because
+          # Flux's ImagePolicy picks the newest image by sorting tag strings
+          # (`alphabetical: asc`) and neither of the other two orders. Keep the
+          # timestamp first and zero-padded — that is what makes lexical order
+          # and chronological order the same thing. Changing this format means
+          # changing the `filterTags` pattern in the homelab repo's
+          # apps/macterm/manifests/image.yaml to match.
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
+            type=raw,value={{date 'YYYYMMDD-HHmmss' tz='UTC'}}-{{sha}},enable={{is_default_branch}}
 
       - name: Create and push the manifest list
         working-directory: /tmp/digests

--- a/website/README.md
+++ b/website/README.md
@@ -100,8 +100,16 @@ and publishes one multi-arch manifest to
 `ghcr.io/thdxg/macterm/website`. Pull requests build both architectures without
 pushing, so a broken Dockerfile fails the PR rather than `:latest`.
 
-Two tags are published: `:latest` (what a deployment tracks) and
-`:sha-<short>` (what it pins to, and the only way back after a bad build).
+Three tags are published: `:latest` (what a human pulls), `:sha-<short>` (the
+way back to a specific build after a bad one), and a UTC timestamp tag,
+`:20260813-142259-62701be`. The last one exists for the deployment — the
+cluster runs the site at [macterm.thdxg.dev](https://macterm.thdxg.dev) and
+Flux's image automation selects the newest image by **sorting tag strings**, so
+it needs a tag whose lexical order is its chronological order. `:latest` is one
+string forever and `:sha-<short>` sorts arbitrarily; only the zero-padded
+timestamp does. The deployment manifest lives in the
+[`thdxg/homelab`](https://github.com/thdxg/homelab) repo under `apps/macterm/`,
+and its `filterTags` pattern hard-codes this format — the two move together.
 
 ```sh
 docker run --rm -p 3000:3000 ghcr.io/thdxg/macterm/website:latest


### PR DESCRIPTION
## What

The website workflow publishes a third tag alongside `:latest` and `:sha-<short>`: a zero-padded UTC timestamp followed by the short sha, e.g. `20260813-142259-62701be`.

## Why

The site is being deployed to the k3s cluster at [macterm.thdxg.dev](https://macterm.thdxg.dev), with Flux's image automation keeping it current. Flux's `ImagePolicy` selects the newest image by **sorting tag strings**, and neither existing tag can carry that:

- `:latest` is one string forever — it never sorts to anything new.
- `:sha-<short>` sorts by whatever the abbreviated hash happens to be, which has no relation to build order.

A zero-padded UTC timestamp is the one format whose lexical order *is* its chronological order. This is the same tag the portfolio site already publishes, and the cluster consumes both the same way.

The two existing tags keep their jobs — `:latest` for a human `docker run`, `:sha-<short>` as the way back to a specific build after a bad one.

## How

One line added to the `publish` job's `docker/metadata-action` tags, matching the portfolio's:

```
type=raw,value={{date 'YYYYMMDD-HHmmss' tz='UTC'}}-{{sha}},enable={{is_default_branch}}
```

`enable={{is_default_branch}}` keeps it off PR builds, which push nothing anyway.

The format is a **contract with the homelab repo** — `apps/macterm/manifests/image.yaml` hard-codes `^\d{8}-\d{6}-[a-f0-9]+` as its `filterTags` pattern, so changing the format here without changing it there strands the deployment on its pinned tag. Both the workflow comment and `website/README.md` say so.

## Verified

- Tag template confirmed against the portfolio site's published tags (`20260812-142259-5b2c39d` and predecessors), which use the identical `metadata-action` expression — so `{{date}}`/`{{sha}}` are known to render this way rather than assumed.
- Confirmed `ghcr.io/thdxg/macterm/website` currently publishes only `latest` and four `sha-*` tags, i.e. nothing the policy pattern can match today. The first push to `main` after this merges produces the first selectable tag.
- Not run: `mise run format` / `lint` / `test`. This branch was prepared on Linux and they need macOS — the change is a workflow and a README, and CI on this PR exercises the workflow itself.

## Notes for reviewers

The companion deployment is a separate PR against `thdxg/homelab` (`apps/macterm/`). Merge order doesn't matter, but the site only starts auto-updating once **this** one has merged and produced one timestamped build. Until then the cluster runs the tag pinned in that PR (`:sha-62701be`, the current head of `main`) and the `ImagePolicy` reports no matching tag.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CfEJ5yKpFAcVAWuCbhEhcb)_