### PR TITLE
Make the split divider possible to grab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,7 @@ One `XxxTests.swift` per production type, mirroring the source path. `@testable 
 - `createSurface()` needs a non-zero frame and a window; `TerminalSurface` defers creation until attached. A `Pane`'s `command`/`shell`/`env` (from a declarative layout) map to libghostty's `initial_input`/`command`/`env_vars`.
 - The `closeSurface` callback fires asynchronously — guard against double-close.
 - First-responder handoff after reshapes/tab switches must go through `FocusRestoration.restoreFocus(...)` — a bare `makeFirstResponder` races the NSView's window attachment.
+- **Anything that must take mouse input over a pane needs an AppKit view of its own.** `GhosttyTerminalNSView` handles `mouseDown` itself and wins AppKit hit testing, so a SwiftUI gesture layered over a pane never sees the press — which is why the pane grab handle (`PaneDragSource`) and the split divider's grab band (`SplitResizeBand`, #260) are both `NSViewRepresentable`s. Before that band, the divider's SwiftUI `DragGesture` was reachable only in the 1pt gap *between* the two panes, which is exactly how "you have to be very precise to resize" got reported. A SwiftUI overlay is fine only where it takes no clicks (the unfocused-pane dim, which is `allowsHitTesting(false)`). Such a view sits ON a pane, so it must hand back what it doesn't own: the band claims the left button and forwards scroll/right/middle events to `viewBeneath`, because the responder chain runs up through its ancestors and never across to the sibling it covers.
 
 ### Persistence
 

--- a/Macterm/Views/SplitTreeView.swift
+++ b/Macterm/Views/SplitTreeView.swift
@@ -177,12 +177,6 @@ struct SplitDividerView<First: View, Second: View>: View {
     let first: First
     @ViewBuilder
     let second: Second
-    /// Tracks whether the resize cursor is currently pushed, so it can be
-    /// popped on disappear. SwiftUI does not deliver `onHover(false)` when the
-    /// divider leaves the hierarchy mid-hover (pane close, zoom toggle, tab
-    /// switch), which would otherwise leave the resize cursor stuck on the
-    /// global cursor stack.
-    @State private var isHovering = false
 
     var body: some View {
         GeometryReader { geo in
@@ -198,38 +192,218 @@ struct SplitDividerView<First: View, Second: View>: View {
                 Color.clear
                     .frame(width: h ? 1 : nil, height: h ? nil : 1)
                     .overlay(Rectangle().fill(MactermTheme.border))
-                    .overlay {
-                        Color.clear
-                            .frame(width: h ? 5 : nil, height: h ? nil : 5)
-                            .contentShape(Rectangle())
-                            .gesture(DragGesture(minimumDistance: 1).onChanged { v in
-                                let pos = h ? v.location.x : v.location.y
-                                let origin = h ? v.startLocation.x : v.startLocation.y
-                                let newPos = total * branch.ratio + (pos - origin)
-                                branch.ratio = min(max(newPos / total, 0.15), 0.85)
-                            })
-                            .onHover { on in
-                                if on {
-                                    (h ? NSCursor.resizeLeftRight : NSCursor.resizeUpDown).push()
-                                    isHovering = true
-                                } else {
-                                    NSCursor.pop()
-                                    isHovering = false
-                                }
-                            }
-                            // Balance a push that never got its hover-exit pop
-                            // (divider removed mid-hover). Gated on `isHovering`
-                            // so a non-hovered divider doesn't over-pop.
-                            .onDisappear {
-                                if isHovering {
-                                    NSCursor.pop()
-                                    isHovering = false
-                                }
-                            }
-                    }
 
                 second.frame(width: h ? secondSize : nil, height: h ? nil : secondSize)
             }
+            // The grab band is layered OVER both panes rather than attached to
+            // the hairline, because a target that sits under a pane is no
+            // target at all: each pane is a real NSView that consumes mouseDown
+            // itself, so the old overlay-on-the-divider gesture was reachable
+            // only in the 1pt gap between them — the "you have to be very
+            // precise" of #260. Being a sibling in the layout wouldn't help
+            // either; the second pane is drawn after the divider and would
+            // cover the half of the band that overlaps it.
+            .overlay {
+                let offset = SplitDividerMetrics.bandOffset(total: total, ratio: branch.ratio)
+
+                layout {
+                    Color.clear
+                        .frame(width: h ? offset : nil, height: h ? nil : offset)
+                        .allowsHitTesting(false)
+
+                    SplitResizeBand(
+                        horizontal: h,
+                        axisLength: total,
+                        ratioAtDragStart: { branch.ratio },
+                        onResize: { branch.ratio = $0 }
+                    )
+                    .frame(
+                        width: h ? SplitDividerMetrics.bandThickness : nil,
+                        height: h ? nil : SplitDividerMetrics.bandThickness
+                    )
+
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+}
+
+/// Pure geometry for the divider's drag band (#260).
+enum SplitDividerMetrics {
+    /// Thickness of the invisible grab band, centered on the 1pt divider. It
+    /// deliberately reaches a few points into both panes — the hairline alone
+    /// is far too fine a thing to aim a pointer at. Matches the size ghostty
+    /// gives its own split dividers.
+    static let bandThickness: CGFloat = 10
+    /// How far the divider can be dragged, same bounds as `SplitNode`'s own
+    /// clamp and the `pane.resize-split` contract.
+    static let minRatio: CGFloat = 0.15
+    static let maxRatio: CGFloat = 0.85
+
+    /// Distance from the container's leading (or top) edge to the start of the
+    /// grab band: centered on the divider, kept inside the container so the
+    /// band never hangs off an edge.
+    static func bandOffset(total: CGFloat, ratio: CGFloat) -> CGFloat {
+        min(max(total * ratio - bandThickness / 2, 0), max(total - bandThickness, 0))
+    }
+
+    /// The ratio a drag lands on, measured from the ratio captured at
+    /// mouse-down plus the total distance travelled since.
+    static func draggedRatio(start: CGFloat, delta: CGFloat, total: CGFloat) -> CGFloat {
+        guard total > 0 else { return start }
+        return min(max(start + delta / total, minRatio), maxRatio)
+    }
+}
+
+/// The divider's drag target: a transparent AppKit view sized to a comfortable
+/// grab band and layered above the panes.
+///
+/// AppKit rather than a SwiftUI `DragGesture` because the panes it covers are
+/// `GhosttyTerminalNSView`s, which handle `mouseDown` themselves and win AppKit
+/// hit testing against any SwiftUI gesture underneath them.
+private struct SplitResizeBand: NSViewRepresentable {
+    let horizontal: Bool
+    /// The container's size along the split axis, which is what turns the
+    /// drag's distance in points into a ratio.
+    let axisLength: CGFloat
+    /// Read once at mouse-down, so the whole drag is measured from a single
+    /// origin instead of accumulating against a divider that moves with it.
+    let ratioAtDragStart: () -> CGFloat
+    /// The ratio the drag has reached, already clamped.
+    let onResize: (CGFloat) -> Void
+
+    func makeNSView(context _: Context) -> BandView {
+        let view = BandView()
+        configure(view)
+        return view
+    }
+
+    func updateNSView(_ view: BandView, context _: Context) {
+        configure(view)
+    }
+
+    private func configure(_ view: BandView) {
+        view.horizontal = horizontal
+        view.axisLength = axisLength
+        view.ratioAtDragStart = ratioAtDragStart
+        view.onResize = onResize
+    }
+
+    final class BandView: NSView {
+        var horizontal = true
+        var axisLength: CGFloat = 0
+        var ratioAtDragStart: () -> CGFloat = { 0.5 }
+        var onResize: (CGFloat) -> Void = { _ in }
+
+        /// Where the press that started the current drag landed, in WINDOW
+        /// coordinates: the band itself travels with the divider mid-drag, so a
+        /// view-local origin would move out from under the measurement.
+        private var dragOrigin: NSPoint?
+        /// The ratio that drag started from — kept here rather than in SwiftUI
+        /// state, which wouldn't be guaranteed to have flowed back through
+        /// `updateNSView` before the first `mouseDragged` arrives.
+        private var startRatio: CGFloat = 0.5
+
+        /// Set while resolving what the band is covering, so its own `hitTest`
+        /// steps aside and the view underneath answers instead.
+        private var isTransparentToHitTest = false
+
+        private var cursor: NSCursor {
+            horizontal ? .resizeLeftRight : .resizeUpDown
+        }
+
+        override var mouseDownCanMoveWindow: Bool { false }
+
+        override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+            true
+        }
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            trackingAreas.forEach { removeTrackingArea($0) }
+            addTrackingArea(NSTrackingArea(
+                rect: .zero,
+                options: [.cursorUpdate, .activeInActiveApp, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            ))
+        }
+
+        /// The tracking area owns the resize cursor for the whole hover and
+        /// AppKit restores the previous one on exit — no push/pop pair left
+        /// stranded when the divider leaves the hierarchy mid-hover (pane
+        /// close, zoom toggle, tab switch), which the SwiftUI `onHover` path
+        /// this replaced had to unwind by hand.
+        override func cursorUpdate(with _: NSEvent) {
+            cursor.set()
+        }
+
+        override func mouseDown(with event: NSEvent) {
+            dragOrigin = event.locationInWindow
+            startRatio = ratioAtDragStart()
+        }
+
+        override func mouseDragged(with event: NSEvent) {
+            guard let dragOrigin else { return }
+            let now = event.locationInWindow
+            // Window space is Y-up; the layout (and so the ratio) grows
+            // downward, so a vertical split reads the delta inverted.
+            let delta = horizontal ? now.x - dragOrigin.x : dragOrigin.y - now.y
+            // Hold the resize cursor for the duration: dragging routinely
+            // wanders off the band, and `cursorUpdate` only fires for
+            // mouse-moved events, which a drag doesn't produce.
+            cursor.set()
+            onResize(SplitDividerMetrics.draggedRatio(start: startRatio, delta: delta, total: axisLength))
+        }
+
+        override func mouseUp(with _: NSEvent) {
+            dragOrigin = nil
+        }
+
+        // MARK: - Pass-through
+
+        // The band claims the left button — the resize drag — and nothing
+        // else. Scrolling or right-clicking a few points from a divider still
+        // belongs to the pane the band is sitting on, and AppKit would
+        // otherwise drop those events: the responder chain runs up through the
+        // band's ancestors, never across to the sibling underneath it.
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            isTransparentToHitTest ? nil : super.hitTest(point)
+        }
+
+        /// The view an event would have reached had the band not been there.
+        private func viewBeneath(_ event: NSEvent) -> NSView? {
+            isTransparentToHitTest = true
+            defer { isTransparentToHitTest = false }
+            let target = window?.contentView?.hitTest(event.locationInWindow)
+            return target === self ? nil : target
+        }
+
+        override func scrollWheel(with event: NSEvent) {
+            guard let target = viewBeneath(event) else { return super.scrollWheel(with: event) }
+            target.scrollWheel(with: event)
+        }
+
+        override func rightMouseDown(with event: NSEvent) {
+            guard let target = viewBeneath(event) else { return super.rightMouseDown(with: event) }
+            target.rightMouseDown(with: event)
+        }
+
+        override func rightMouseUp(with event: NSEvent) {
+            guard let target = viewBeneath(event) else { return super.rightMouseUp(with: event) }
+            target.rightMouseUp(with: event)
+        }
+
+        override func otherMouseDown(with event: NSEvent) {
+            guard let target = viewBeneath(event) else { return super.otherMouseDown(with: event) }
+            target.otherMouseDown(with: event)
+        }
+
+        override func otherMouseUp(with event: NSEvent) {
+            guard let target = viewBeneath(event) else { return super.otherMouseUp(with: event) }
+            target.otherMouseUp(with: event)
         }
     }
 }

--- a/MactermTests/Views/SplitDividerMetricsTests.swift
+++ b/MactermTests/Views/SplitDividerMetricsTests.swift
@@ -1,0 +1,83 @@
+import CoreGraphics
+@testable import Macterm
+import Testing
+
+/// Pure geometry behind the split divider's drag band (#260). UI behavior isn't
+/// unit-tested per the project's conventions, but where the band sits and where
+/// a drag lands are plain arithmetic worth pinning — the clamping in particular,
+/// which is what keeps the band inside the container and the ratio inside the
+/// bounds `pane.resize-split` promises.
+struct SplitDividerMetricsTests {
+    private let thickness = SplitDividerMetrics.bandThickness
+
+    // MARK: - bandOffset
+
+    @Test
+    func band_is_centered_on_the_divider() {
+        // Divider at 500 in a 1000pt container: a 10pt band starts 5pt before it.
+        #expect(SplitDividerMetrics.bandOffset(total: 1000, ratio: 0.5) == 500 - thickness / 2)
+    }
+
+    @Test
+    func band_follows_an_off_center_divider() {
+        #expect(SplitDividerMetrics.bandOffset(total: 1000, ratio: 0.15) == 150 - thickness / 2)
+    }
+
+    @Test
+    func band_never_starts_before_the_leading_edge() {
+        // Divider at 3pt: centering would put the band at -2.
+        #expect(SplitDividerMetrics.bandOffset(total: 20, ratio: 0.15) == 0)
+    }
+
+    @Test
+    func band_never_runs_past_the_trailing_edge() {
+        // Divider at 17 of 20pt: centering would put the band at 12, hanging
+        // 2pt off the end. It stops where it still fits.
+        #expect(SplitDividerMetrics.bandOffset(total: 20, ratio: 0.85) == 20 - thickness)
+    }
+
+    @Test
+    func band_collapses_to_the_leading_edge_when_the_container_is_thinner_than_the_band() {
+        // Degenerate geometry (a container narrower than the band itself):
+        // clamp to 0 rather than to a negative upper bound.
+        #expect(SplitDividerMetrics.bandOffset(total: 6, ratio: 0.5) == 0)
+        #expect(SplitDividerMetrics.bandOffset(total: 0, ratio: 0.5) == 0)
+    }
+
+    // MARK: - draggedRatio
+
+    @Test
+    func drag_moves_the_ratio_by_the_distance_travelled() {
+        // A quarter of the container to the right of where the drag began.
+        #expect(SplitDividerMetrics.draggedRatio(start: 0.5, delta: 250, total: 1000) == 0.75)
+    }
+
+    @Test
+    func drag_back_moves_the_ratio_the_other_way() {
+        #expect(SplitDividerMetrics.draggedRatio(start: 0.5, delta: -125, total: 1000) == 0.375)
+    }
+
+    @Test
+    func drag_is_measured_from_the_start_ratio_not_the_current_one() {
+        // Same travel from a different origin lands somewhere else — this is
+        // what keeps a drag from accumulating against a divider that moves
+        // with the pointer.
+        #expect(SplitDividerMetrics.draggedRatio(start: 0.25, delta: 250, total: 1000) == 0.5)
+    }
+
+    @Test
+    func drag_clamps_to_the_upper_bound() {
+        #expect(SplitDividerMetrics.draggedRatio(start: 0.8, delta: 400, total: 1000) == SplitDividerMetrics.maxRatio)
+    }
+
+    @Test
+    func drag_clamps_to_the_lower_bound() {
+        #expect(SplitDividerMetrics.draggedRatio(start: 0.2, delta: -400, total: 1000) == SplitDividerMetrics.minRatio)
+    }
+
+    @Test
+    func drag_in_a_zero_sized_container_holds_the_start_ratio() {
+        // No axis to measure against: hold still instead of dividing by zero.
+        #expect(SplitDividerMetrics.draggedRatio(start: 0.4, delta: 250, total: 0) == 0.4)
+    }
+}


### PR DESCRIPTION
## What

Replaces the split divider's resize target with a 10pt AppKit grab band layered over both panes, centered on the 1pt hairline.

## Why

The resize target was a SwiftUI `DragGesture` on an overlay of the divider itself, and it was reachable only in the hairline gap between the two panes — you had to land the pointer on ~1pt to resize.

Two things conspired: each pane is a `GhosttyTerminalNSView` that handles `mouseDown` itself and so wins AppKit hit testing against any SwiftUI gesture underneath it, and the second pane is drawn *after* the divider in the stack, so the half of the 5pt target that reached into it was covered as well.

Closes #260

## How

- `SplitResizeBand` is an `NSViewRepresentable` layered as an `.overlay` above both panes (a sibling in the layout wouldn't help — the second pane would still cover half of it), positioned by `SplitDividerMetrics.bandOffset` and clamped so the band never hangs off a container edge. 10pt matches the size ghostty gives its own split dividers.
- The band **claims the left button only**. Scroll, right-click and middle-click are forwarded to `viewBeneath` — the view AppKit would have hit had the band not been there — because the responder chain runs up through the band's ancestors and never across to the sibling it covers. Without that, a 10pt strip of terminal beside every divider would silently stop scrolling and lose its context menu.
- The drag measures from the ratio captured at mouse-down plus the total distance travelled, instead of accumulating deltas against a divider that moves with the pointer. The origin is a *window*-space point for the same reason: the band travels with the divider mid-drag. That start ratio lives in the `NSView`, not in `@State`, so it can't fail to have flowed back through `updateNSView` before the first `mouseDragged`.
- The cursor now comes from a `.cursorUpdate` tracking area, which retires the `NSCursor.push()`/`pop()` pair the old `onHover` path had to unwind by hand (with an `onDisappear` guard) when the divider left the hierarchy mid-hover. `mouseDragged` re-`set`s it because a drag routinely wanders off the band and produces no mouse-moved events.
- Ratio bounds (0.15…0.85) are unchanged, and now named next to the geometry that uses them.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass — **via CI, not locally** (see below): Format, Lint, Unit and End-to-end are all green on this branch
- [ ] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

`SplitDividerMetricsTests` covers the pure geometry: band centering, both edge clamps, a container thinner than the band, drag→ratio conversion in both directions, measuring from the start ratio rather than the current one, both clamps, and a zero-length axis.

This was authored in a session with no macOS toolchain — no `xcodebuild`, `swiftformat` or `swiftlint` — so CI was the first thing to compile it. It builds clean and the suites pass, but **nobody has put a pointer on the divider yet**. A reviewer should confirm on a Mac that the band drags, that the resize cursor appears and reverts, and that scrolling still works right beside a divider.

## Notes for reviewers

- The band covers the top 5pt of a lower pane in a vertical split, which is where that pane's `PaneGrabHandle` pill sits (80×12, flush with the pane's top edge). The pill keeps 7 of its 12 points, and its hover reveal is a tracking area so it is unaffected — but it is the one interaction this makes slightly smaller.
- Pane and tab drop targets are unaffected: the band registers no dragged types, and SwiftUI's `.onDrop` regions already resolve at the hosting-view level over the terminal `NSView`s.
- The benchmark flagged one cell (idle `focused` wakeups/s, +62%) without labelling the PR. It reads as runner noise: that state is sampled before the workload spawns, so it has a single pane and therefore no divider and no band — this diff instantiates nothing there. The two states that *do* have dividers (the `grid 2x2` workload) moved +24% and −3%.