### PR TITLE
feat: drop a pane on the sidebar to separate it into a tab

### DIFF
--- a/Macterm/Views/PaneDragDrop.swift
+++ b/Macterm/Views/PaneDragDrop.swift
@@ -21,26 +21,45 @@ extension NSPasteboard.PasteboardType {
 
 /// The grab-handle drag as seen by its drop targets: the pane UUID
 /// `PaneDragSource` writes as 16 raw bytes under `.mactermPaneID`.
-/// Deliberately NOT `Transferable`: the drag is an AppKit `NSDraggingSession`
-/// whose custom-type pasteboard data never reaches SwiftUI's `dropDestination`
-/// import path, so the workspace leaves read the drag pasteboard directly
-/// through a raw `DropDelegate`. (This drag also cannot target the sidebar
-/// at all — no public drop mechanism in that column ever receives the
-/// session, which is why "separate a pane into its own tab" ships as the
-/// Separate Current Pane command rather than a sidebar drop.)
+///
+/// Deliberately NOT `Transferable` itself: the drag lifts as an AppKit
+/// `NSDraggingSession` (see `PaneDragSource`), never through `.draggable`, so
+/// there is no export side to declare, and the two importers that do exist —
+/// the sidebar's `SidebarDropItem` and `TabSlotDropItem` unions — decode these
+/// bytes as one case among several. The workspace leaves read the pasteboard
+/// directly instead (`fromDragPasteboard`), so every path decodes the same 16
+/// bytes through `init?(payload:)`.
 struct MovablePane {
     let paneID: UUID
 
-    /// Decode the drag's payload synchronously off the drag pasteboard. The
-    /// pane drag never leaves the app and its bytes are written eagerly at
-    /// mouseDragged, so unlike `MovableTab` there is no async fallback to
-    /// need — nil simply means "not a pane drag".
+    /// Decode the wire form: the pane UUID as 16 raw bytes. The one decoder
+    /// every drop path shares, so the leaves' pasteboard read and the
+    /// sidebar's `Transferable` import can't drift.
+    init?(payload: Data) {
+        guard payload.count == 16 else { return nil }
+        self.init(paneID: payload.withUnsafeBytes { UUID(uuid: $0.loadUnaligned(as: uuid_t.self)) })
+    }
+
+    init(paneID: UUID) {
+        self.paneID = paneID
+    }
+
+    /// The wire form of a pane's identity — what `PaneDragSource` puts on the
+    /// drag pasteboard.
+    static func payload(for paneID: UUID) -> Data {
+        withUnsafeBytes(of: paneID.uuid) { Data($0) }
+    }
+
+    /// Decode the drag's payload synchronously off the drag pasteboard — the
+    /// path the workspace leaves take, since a raw `DropDelegate` gets the
+    /// session but not a decoded payload. The bytes are written eagerly at
+    /// mouseDragged, so nil simply means "not a pane drag".
     static func fromDragPasteboard() -> MovablePane? {
         guard let data = NSPasteboard(name: .drag).pasteboardItems?
             .compactMap({ $0.data(forType: .mactermPaneID) })
-            .first, data.count == 16
+            .first
         else { return nil }
-        return MovablePane(paneID: data.withUnsafeBytes { UUID(uuid: $0.loadUnaligned(as: uuid_t.self)) })
+        return MovablePane(payload: data)
     }
 }
 
@@ -222,10 +241,7 @@ private struct PaneDragSource: NSViewRepresentable {
             guard !isTracking, let pane else { return }
 
             let pasteboardItem = NSPasteboardItem()
-            pasteboardItem.setData(
-                withUnsafeBytes(of: pane.id.uuid) { Data($0) },
-                forType: .mactermPaneID
-            )
+            pasteboardItem.setData(MovablePane.payload(for: pane.id), forType: .mactermPaneID)
             let item = NSDraggingItem(pasteboardWriter: pasteboardItem)
 
             let image = dragPreviewImage(for: pane)
@@ -404,7 +420,7 @@ struct LeafDropDelegate: DropDelegate {
         }
         context.resolution.wrappedValue = nil
 
-        // A pane drag first: its payload is an eagerly-written UUID, readable
+        // A pane drag first: its payload is a UUID, usually readable
         // synchronously off the drag pasteboard (this drag never leaves the
         // app — sourceOperationMask is .move only within the application).
         if let movable = MovablePane.fromDragPasteboard() {
@@ -412,7 +428,6 @@ struct LeafDropDelegate: DropDelegate {
             MainActor.assumeIsolated { move(movable.paneID, target) }
             return true
         }
-
         guard let onMergeTab = context.onMergeTab else { return false }
         if let movable = MovableTab.fromDragPasteboard() {
             MainActor.assumeIsolated { onMergeTab(movable, target) }

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -70,18 +70,20 @@ extension UTType {
     static let mactermProject = UTType(exportedAs: "com.thdxg.macterm.project-move")
 }
 
-/// Import-side union of the two sidebar drag payloads, so a single view can
-/// accept BOTH drags through ONE `.dropDestination`. This exists because
-/// stacking two `.dropDestination`s (one per payload type) on the same view
-/// is non-deterministic: only one of the two registrations wins, and which
-/// one flips with unrelated view changes — measured live, the project header
-/// accepted project drops in one build and silently rejected them in the
-/// next. Never stack drop destinations; widen the payload instead.
+/// Import-side union of the drag payloads a project HEADER accepts, so a
+/// single view can accept all of them through ONE `.dropDestination`. This
+/// exists because stacking two `.dropDestination`s (one per payload type) on
+/// the same view is non-deterministic: only one of the two registrations
+/// wins, and which one flips with unrelated view changes — measured live, the
+/// project header accepted project drops in one build and silently rejected
+/// them in the next. Never stack drop destinations; widen the payload instead.
 /// Import-only: drags still lift as `MovableTab`/`MovableProject` (their
-/// `CodableRepresentation` is JSON, which is what the decoders here parse).
+/// `CodableRepresentation` is JSON, which is what the decoders here parse) or,
+/// for a pane, as the raw UUID bytes an `NSDraggingSession` writes.
 enum SidebarDropItem: Transferable {
     case tab(MovableTab)
     case project(MovableProject)
+    case pane(MovablePane)
 
     static var transferRepresentation: some TransferRepresentation {
         DataRepresentation(importedContentType: .mactermTab) { data in
@@ -89,6 +91,36 @@ enum SidebarDropItem: Transferable {
         }
         DataRepresentation(importedContentType: .mactermProject) { data in
             try .project(JSONDecoder().decode(MovableProject.self, from: data))
+        }
+        DataRepresentation(importedContentType: .mactermPaneID) { data in
+            guard let pane = MovablePane(payload: data) else {
+                throw CocoaError(.coderInvalidValue)
+            }
+            return .pane(pane)
+        }
+    }
+}
+
+/// The narrower union the tab-list ForEach accepts: a tab (reorder/move) or a
+/// pane (separate into a new tab), both of which want the insertion offset the
+/// ForEach reports. Deliberately NOT `SidebarDropItem` — including the project
+/// payload here would make a project drag target the tab rows, which is the
+/// state the header comment calls out as broken at this outline level: the
+/// insertion line would appear inside a section a project can't land in. The
+/// two unions are separate views' payloads, not stacked destinations.
+enum TabSlotDropItem: Transferable {
+    case tab(MovableTab)
+    case pane(MovablePane)
+
+    static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(importedContentType: .mactermTab) { data in
+            try .tab(JSONDecoder().decode(MovableTab.self, from: data))
+        }
+        DataRepresentation(importedContentType: .mactermPaneID) { data in
+            guard let pane = MovablePane(payload: data) else {
+                throw CocoaError(.coderInvalidValue)
+            }
+            return .pane(pane)
         }
     }
 }
@@ -214,13 +246,22 @@ struct SidebarContent: View {
             ForEach(Array(tabs.enumerated()), id: \.element.id) { tabIndex, tab in
                 tabRow(tab: tab, index: tabIndex, project: project)
             }
-            // Single drop mechanism for both cases: SwiftUI reports the
-            // insertion `offset` within THIS project's tab list. A drop from
-            // the same project reorders to that slot; a drop from another
-            // project moves the tab in at that slot. Replaces the old `.onMove`
-            // (which is per-section and can't express a cross-project move).
-            .dropDestination(for: MovableTab.self) { items, offset in
-                receiveTabDrop(items, into: project, at: offset)
+            // Single drop mechanism for every case: SwiftUI reports the
+            // insertion `offset` within THIS project's tab list. A tab drop
+            // from the same project reorders to that slot; one from another
+            // project moves the tab in at that slot; a PANE drop (the grab
+            // handle drag from the workspace) separates that pane into a new
+            // tab landing at the same slot. Replaces the old `.onMove` (which
+            // is per-section and can't express a cross-project move).
+            .dropDestination(for: TabSlotDropItem.self) { items, offset in
+                for item in items {
+                    switch item {
+                    case let .tab(tab):
+                        receiveTabDrop([tab], into: project, at: offset)
+                    case let .pane(pane):
+                        receivePaneDrop([pane], into: project, at: offset)
+                    }
+                }
             }
         } label: {
             projectHeader(index: projectIndex, project: project)
@@ -269,10 +310,11 @@ struct SidebarContent: View {
         .tag(SidebarItem.project(project.id))
         // Drag the header to reorder projects (replaces the removed `.onMove`).
         .draggable(MovableProject(projectID: project.id))
-        // ONE drop destination for both payloads (see `SidebarDropItem` for
+        // ONE drop destination for every payload (see `SidebarDropItem` for
         // why stacking two is a landmine). A TAB dropped here appends to this
         // project — the only drop path for a collapsed or empty project,
-        // whose tab ForEach renders no rows to target. A PROJECT dropped
+        // whose tab ForEach renders no rows to target — and a PANE dropped
+        // here appends its new tab the same way. A PROJECT dropped
         // squarely on the header reorders it to this project's slot; the
         // seams BETWEEN rows deliberately stay uncovered (label-height
         // target, no taller band) so the ForEach-level insertion line can
@@ -284,6 +326,8 @@ struct SidebarContent: View {
                     receiveTabDrop([tab], into: project, at: nil)
                 case let .project(dragged):
                     receiveProjectDrop([dragged], before: project)
+                case let .pane(pane):
+                    receivePaneDrop([pane], into: project, at: nil)
                 }
             }
             return true
@@ -322,6 +366,25 @@ struct SidebarContent: View {
                     toIndex: index
                 )
             }
+        }
+        expandedProjects.insert(project.id)
+    }
+
+    /// Apply a pane drag-and-drop: the pane leaves its split tree and becomes
+    /// its own tab in this project, at `index` (nil = append, used by header
+    /// drops). The `Pane` object — and its live surface and shell — is reused,
+    /// the same as the Separate Current Pane command, which calls the same
+    /// `AppState.separatePane`. Dragging a tab's ONLY pane here is a no-op:
+    /// it already is its own tab, and moving it to another project is what
+    /// dragging its sidebar row does.
+    private func receivePaneDrop(_ items: [MovablePane], into project: Project, at index: Int?) {
+        for item in items {
+            appState.separatePane(
+                item.paneID,
+                toProject: project.id,
+                destPath: project.path,
+                at: index
+            )
         }
         expandedProjects.insert(project.id)
     }

--- a/MactermTests/Views/PaneDragDropTests.swift
+++ b/MactermTests/Views/PaneDragDropTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+/// The pane drag's wire form. Two drop paths decode it — the workspace
+/// leaves read the drag pasteboard directly, the sidebar imports it as a
+/// `Transferable` — and both go through `MovablePane(payload:)`, so this
+/// pins the codec they share.
+@MainActor
+struct PaneDragDropTests {
+    @Test
+    func payload_round_trips_the_pane_id() throws {
+        let id = UUID()
+        let decoded = try #require(MovablePane(payload: MovablePane.payload(for: id)))
+        #expect(decoded.paneID == id)
+    }
+
+    @Test
+    func payload_is_the_uuid_as_sixteen_raw_bytes() {
+        #expect(MovablePane.payload(for: UUID()).count == 16)
+    }
+
+    /// A short, long, or empty payload is "not a pane drag", never a
+    /// half-decoded UUID: the raw bytes are loaded unaligned straight out of
+    /// the buffer, so the length check is what keeps that read in bounds.
+    @Test
+    func payload_of_the_wrong_length_is_rejected() {
+        #expect(MovablePane(payload: Data()) == nil)
+        #expect(MovablePane(payload: Data(repeating: 0, count: 15)) == nil)
+        #expect(MovablePane(payload: Data(repeating: 0, count: 17)) == nil)
+    }
+}


### PR DESCRIPTION
Dragging a pane's grab handle onto the sidebar now separates it into its own tab — dropped between two tab rows it lands at that slot, dropped on a project header it appends (the only path for a collapsed or empty project, whose tab ForEach renders no rows to target). Cross-project drops work the same way tab-row drags already do.

## Why the sidebar could not be targeted before

`PaneDragDrop.swift` recorded the column as structurally unreachable, which is why "separate a pane into its own tab" shipped as the Separate Current Pane command rather than a drop. The real obstacle is narrower than that: a plain `NSPasteboardItem`'s custom-type data never reaches SwiftUI's `dropDestination(for:)` **import** path, so no `Transferable` destination in the sidebar ever saw the session.

So the sidebar doesn't try to receive the `NSDraggingSession` — it imports the pane's raw UUID bytes as one case of a `Transferable` union, the same import-only shape `SidebarDropItem` already used for tab and project payloads. The drag itself is unchanged: still an AppKit session writing the UUID eagerly, so the workspace leaves keep reading it straight off the drag pasteboard.

## Notes for review

- **Two unions, not a stacked destination.** The project header widens `SidebarDropItem` with a `.pane` case. The tab-list ForEach gets its own narrower `TabSlotDropItem` (tab + pane) so it can report the insertion offset; including the project payload there would put an insertion line inside a section a project can't land in. Each view still carries exactly one destination — the rule `SidebarDropItem`'s comment already documents.
- **Tab rows still carry no drop target**, so the native insertion line and tab reordering are untouched.
- **No model changes.** `AppState.separatePane` already accepted the destination index a sidebar drop reports, and its doc comment already described this caller. The `Pane` object is reused, so the surface and running shell survive.
- Dropping a tab's only pane is a no-op — it is already its own tab, and moving it across projects is what dragging its sidebar row does.
- `MovablePane(payload:)` is now the single decoder shared by the leaves' pasteboard read and the sidebar's import, covered by `PaneDragDropTests`.

## Verification

Built and exercised in the debug app on macOS 26.5 / Xcode 26.6: pane dropped between rows lands at that slot, on a header appends, shell keeps running, and tab reorder still shows its insertion line. `mise run format` and `mise run lint` are clean; the unit suite was left to CI.
