### PR TITLE
chore(deps): bump GhosttyKit to build-2026-08-16

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,7 @@ XCFRAMEWORK_DIR="GhosttyKit.xcframework"
 #
 # Set GHOSTTYKIT_TAG to another tag (or `latest`) to try one without committing:
 #   GHOSTTYKIT_TAG=latest mise run setup
-GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-09}"
+GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-16}"
 # Which tag the on-disk fork artifacts actually came from. Without this the
 # presence checks below would keep a stale copy forever after a pin bump — the
 # same silent-staleness trap that makes symlinking these artifacts a bad idea.


### PR DESCRIPTION
Moves the pinned `thdxg/ghostty` release (`GHOSTTYKIT_TAG` in `scripts/setup.sh`) from `build-2026-08-09` to `build-2026-08-16`.

**CI on this PR is the gate.** Editing `scripts/setup.sh` changes the GhosttyKit cache key, so this run downloads the new pin from scratch and exercises it through Unit, End-to-end, and the benchmark — rather than a release being the first thing to try it.

Compare upstream: [`build-2026-08-09...build-2026-08-16`](https://github.com/thdxg/ghostty/compare/build-2026-08-09...build-2026-08-16)

---

### GhosttyKit API review — `build-2026-08-09` → `build-2026-08-16`

Filtered to the **157** `ghostty_*`/`GHOSTTY_*` symbols Macterm's own sources reference and the header defines.

#### ✅ No symbol we use was removed

#### ⚠️ 22 enum constant(s) we use changed numeric value

`ghostty_action_tag_e`:
- added `GHOSTTY_ACTION_SET_WINDOW_TITLE`

<details><summary>Affected constants (22)</summary>

| symbol | build-2026-08-09 | build-2026-08-16 |
|---|---|---|
| `GHOSTTY_ACTION_CHECK_FOR_UPDATES` | 55 | 56 |
| `GHOSTTY_ACTION_COLOR_CHANGE` | 47 | 48 |
| `GHOSTTY_ACTION_COMMAND_FINISHED` | 60 | 61 |
| `GHOSTTY_ACTION_CONFIG_CHANGE` | 49 | 50 |
| `GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD` | 66 | 67 |
| `GHOSTTY_ACTION_END_SEARCH` | 62 | 63 |
| `GHOSTTY_ACTION_MOUSE_OVER_LINK` | 39 | 40 |
| `GHOSTTY_ACTION_MOUSE_SHAPE` | 37 | 38 |
| `GHOSTTY_ACTION_MOUSE_VISIBILITY` | 38 | 39 |
| `GHOSTTY_ACTION_OPEN_CONFIG` | 41 | 42 |
| `GHOSTTY_ACTION_OPEN_URL` | 56 | 57 |
| `GHOSTTY_ACTION_OUTPUT_ACTIVITY` | 68 | 69 |
| `GHOSTTY_ACTION_PROGRESS_REPORT` | 58 | 59 |
| `GHOSTTY_ACTION_PROMPT_TITLE` | 35 | 36 |
| `GHOSTTY_ACTION_PWD` | 36 | 37 |
| `GHOSTTY_ACTION_RELOAD_CONFIG` | 48 | 49 |
| `GHOSTTY_ACTION_RENDERER_HEALTH` | 40 | 41 |
| `GHOSTTY_ACTION_RING_BELL` | 51 | 52 |
| `GHOSTTY_ACTION_SEARCH_SELECTED` | 64 | 65 |
| `GHOSTTY_ACTION_SEARCH_TOTAL` | 63 | 64 |
| `GHOSTTY_ACTION_SECURE_INPUT` | 44 | 45 |
| `GHOSTTY_ACTION_START_SEARCH` | 61 | 62 |

</details>

Harmless as long as the header and the archive stay paired — the xcframework ships them together, and `setup.sh` only ever installs both from one release. Never pair one with the other's, and treat any hardcoded raw value as suspect. A **removed** member is the one to look at closely.

#### Changed hunks touching a symbol we use

```diff
@@ -678,19 +682,28 @@
 } ghostty_action_set_title_s;
 
 // apprt.action.PromptTitle
 typedef enum {
   GHOSTTY_PROMPT_TITLE_SURFACE,
   GHOSTTY_PROMPT_TITLE_TAB,
+  GHOSTTY_PROMPT_TITLE_WINDOW,
 } ghostty_action_prompt_title_e;
 
 // apprt.action.Pwd.C
 typedef struct {
   const char* pwd;
 } ghostty_action_pwd_s;
 
+// apprt.action.OpenConfig
+typedef enum {
+  // Open the config in the OS default editor.
+  GHOSTTY_ACTION_OPEN_CONFIG_OS_OPEN,
+  // Open the config in a new window using $EDITOR or $VISUAL
+  GHOSTTY_ACTION_OPEN_CONFIG_NEW_WINDOW,
+} ghostty_action_open_config_e;
+
 // terminal.MouseShape
 typedef enum {
   GHOSTTY_MOUSE_SHAPE_DEFAULT,
   GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU,
   GHOSTTY_MOUSE_SHAPE_HELP,
   GHOSTTY_MOUSE_SHAPE_POINTER,
@@ -925,12 +938,13 @@
   GHOSTTY_ACTION_SHOW_GTK_INSPECTOR,
   GHOSTTY_ACTION_RENDER_INSPECTOR,
   GHOSTTY_ACTION_EXPORT_TERMINAL_IO,
   GHOSTTY_ACTION_DESKTOP_NOTIFICATION,
   GHOSTTY_ACTION_SET_TITLE,
   GHOSTTY_ACTION_SET_TAB_TITLE,
+  GHOSTTY_ACTION_SET_WINDOW_TITLE,
   GHOSTTY_ACTION_PROMPT_TITLE,
   GHOSTTY_ACTION_PWD,
   GHOSTTY_ACTION_MOUSE_SHAPE,
   GHOSTTY_ACTION_MOUSE_VISIBILITY,
   GHOSTTY_ACTION_MOUSE_OVER_LINK,
   GHOSTTY_ACTION_RENDERER_HEALTH,
@@ -1002,12 +1016,13 @@
   ghostty_action_progress_report_s progress_report;
   ghostty_action_command_finished_s command_finished;
   ghostty_action_start_search_s start_search;
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
+  ghostty_action_open_config_e open_config;
 } ghostty_action_u;
 
 typedef struct {
   ghostty_action_tag_e tag;
   ghostty_action_u action;
 } ghostty_action_s;
```

<sub>30 changed header lines total; 3 hunk(s) touch symbols we use. A green CI run means it builds and the suites pass — not that no behaviour moved.</sub>
