### PR TITLE
Make the quick terminal honor the liquid glass setting

### DIFF
--- a/Macterm/Ghostty/Theme.swift
+++ b/Macterm/Ghostty/Theme.swift
@@ -7,15 +7,6 @@ enum MactermTheme {
     static var bg: Color { Color(nsColor: nsBg) }
     @MainActor
     static var nsBg: NSColor { GhosttyApp.shared.effectiveBackgroundColor }
-    /// Background tinted by `Preferences.shared.windowOpacity`. Use for
-    /// SwiftUI chrome that should follow window transparency (sidebar,
-    /// palette, search bar). `bg`/`nsBg` stay opaque for callers that need
-    /// a known-solid base color.
-    @MainActor
-    static var bgWithOpacity: Color {
-        Color(nsColor: nsBg.withAlphaComponent(Preferences.shared.windowOpacity))
-    }
-
     @MainActor
     static var fg: Color { Color(nsColor: nsFg) }
     @MainActor

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -78,11 +78,12 @@ final class QuickTerminalService: NSObject {
             name: UserDefaults.didChangeNotification,
             object: nil
         )
-        // Re-apply the blur radius when Ghostty config changes so the visible
-        // panel picks up Settings adjustments without needing to be re-shown.
+        // Re-apply the window appearance (opacity/blur/glass) when a Ghostty
+        // config or appearance pref changes so the visible panel picks up
+        // Settings adjustments without needing to be re-shown.
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(reapplyBlur),
+            selector: #selector(reapplyAppearance),
             name: .mactermConfigDidChange,
             object: nil
         )
@@ -90,9 +91,9 @@ final class QuickTerminalService: NSObject {
     }
 
     @objc
-    private func reapplyBlur() {
+    private func reapplyAppearance() {
         guard let panel, isVisible else { return }
-        setWindowBackgroundBlur(panel, radius: Preferences.shared.windowBlurRadius)
+        WindowAppearance.syncPanel(panel)
     }
 
     @objc
@@ -306,8 +307,10 @@ final class QuickTerminalService: NSObject {
             previousFrontmostApp = nil
             return
         }
-        // Apply the current blur radius (0 = no blur) for this panel session.
-        setWindowBackgroundBlur(panel, radius: Preferences.shared.windowBlurRadius)
+        // Apply the current appearance (opacity/blur/glass) for this panel
+        // session. After the order-front: the glass view sizes itself against
+        // the panel's frame view, which wants the panel fully set up.
+        WindowAppearance.syncPanel(panel)
         if let focusedID = splitState.focusedPaneID {
             FocusRestoration.restoreFocus(to: focusedID, in: splitState.splitRoot, window: panel)
         }
@@ -648,7 +651,10 @@ private struct QuickTerminalView: View {
             }
             splitTree(renderedNode)
         }
-        .background(MactermTheme.bgWithOpacity)
+        // No SwiftUI background: the panel window paints the tint itself
+        // (`WindowAppearance.syncPanel` — window backgroundColor, or the glass
+        // view's tint when liquid glass is on). Painting the tinted background
+        // here too would double-tint the glass.
         .onPreferenceChange(DraggingPaneKey.self) { value in
             MainActor.assumeIsolated {
                 draggedPaneID = value

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -414,6 +414,42 @@ enum WindowAppearance {
         logger.info("sidebar edge-hover reveal disabled")
     }
 
+    /// Apply the current opacity/blur/glass settings to the quick-terminal
+    /// panel. The window-background slice of `sync(window:)` only: a borderless
+    /// panel has no titlebar, sidebar, or toolbar to style, but it must make
+    /// the same glass-vs-blur-vs-solid decision as the main window or the
+    /// liquid glass setting silently degrades to the legacy blur there.
+    ///
+    /// The panel's tint deliberately lives here (window `backgroundColor` /
+    /// glass tint), not in its SwiftUI content — a tinted SwiftUI background
+    /// over an installed glass view would double-tint it, the same
+    /// double-paint problem `macterm-overrides.conf` pins
+    /// `background-opacity = 0` to avoid.
+    static func syncPanel(_ panel: NSPanel) {
+        let opacity = Preferences.shared.windowOpacity
+        let bg = MactermTheme.nsBg
+        let isTransparent = opacity < 1.0
+        let useGlass = glassSupported && Preferences.shared.windowGlassEnabled && isTransparent
+
+        if isTransparent {
+            panel.isOpaque = false
+            if useGlass {
+                panel.backgroundColor = .clear
+                setWindowBackgroundBlur(panel, radius: 0)
+                syncGlass(window: panel, backgroundColor: bg, opacity: opacity)
+            } else {
+                panel.backgroundColor = bg.withAlphaComponent(opacity)
+                setWindowBackgroundBlur(panel, radius: Preferences.shared.windowBlurRadius)
+                removeGlass(window: panel)
+            }
+        } else {
+            panel.isOpaque = true
+            panel.backgroundColor = bg
+            setWindowBackgroundBlur(panel, radius: 0)
+            removeGlass(window: panel)
+        }
+    }
+
     /// Update the inactive-glass tint when the window gains/loses key status.
     /// Cheap no-op unless the glass view is currently installed.
     static func syncKeyStatus(window: NSWindow) {


### PR DESCRIPTION
## What

The quick terminal panel now runs the same appearance pipeline as the main window, so enabling liquid glass (Settings → Appearance) applies to it instead of silently leaving it on the legacy CGS blur.

## Why

The panel never consulted `windowGlassEnabled`: it applied the blur radius directly and painted its tint as a SwiftUI `.background(bgWithOpacity)`, an ad-hoc copy of the pre-glass appearance path. Turning on liquid glass changed the main window but not the quick terminal.

## How

- `WindowAppearance.syncPanel(_:)` is the window-background slice of `sync(window:)` — the same glass-vs-blur-vs-solid decision, installing the same `MactermGlassView`, minus the titlebar/sidebar/toolbar work a borderless panel has no surface for.
- The panel tint moves from the SwiftUI content to the window itself (window `backgroundColor`, or the glass tint when glass is on). A tinted SwiftUI background painted over an installed glass view would double-tint it — the same double-paint problem `macterm-overrides.conf` pins `background-opacity = 0` to avoid.
- The service's existing `.mactermConfigDidChange` observer (previously `reapplyBlur`) now re-syncs the whole appearance, so every appearance pref — opacity, blur, glass on/off, glass style, theme reloads — applies live to a visible panel instead of blur only.
- `MactermTheme.bgWithOpacity` had no remaining users after the move (its doc already claimed sidebar/palette callers it had lost), so it is removed.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [ ] Built and ran the change in the app (`mise run run`) and confirmed the behavior

## Notes for reviewers

- The panel is rebuilt on every show and hides on `resignKey`, so it is effectively always the key window while visible — the glass view's inactive tint overlay stays at alpha 0, which is the correct focused appearance.
- Live verification stopped short of the glass visual itself: there is no headless way to toggle the panel (no bench/CLI verb, and a synthetic ``ctrl+` `` would trigger the real Macterm's global hotkey on the desktop). A hermetic debug instance did launch cleanly with the change. Worth one manual ``ctrl+` `` with glass on before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
