### PR TITLE
Show a grabbing hand while the quick terminal is dragged by its strip

### DIFF
--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -738,6 +738,10 @@ private struct WindowDragArea: NSViewRepresentable {
     func updateNSView(_: DragAreaView, context _: Context) {}
 
     final class DragAreaView: NSView {
+        /// Polls for the release that ends a window-server drag — the drag
+        /// runs out-of-process, so no mouseUp ever reaches this view.
+        private var cursorRestoreTimer: Timer?
+
         /// Let the first click both key the panel and start the drag,
         /// matching how a real titlebar behaves on an inactive window.
         override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
@@ -745,11 +749,42 @@ private struct WindowDragArea: NSViewRepresentable {
         }
 
         override func mouseDown(with event: NSEvent) {
+            // Grabbing hand for the duration of the drag. Cursor rects are
+            // suspended first — they re-evaluate as the window moves under
+            // the pointer, which is what snapped the cursor back to the
+            // arrow — and restored when the poll below sees the release.
+            window?.disableCursorRects()
+            NSCursor.closedHand.set()
             window?.performDrag(with: event)
+            watchForDragRelease()
         }
 
         override func resetCursorRects() {
             addCursorRect(bounds, cursor: .openHand)
+        }
+
+        private func watchForDragRelease() {
+            cursorRestoreTimer?.invalidate()
+            let timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] timer in
+                guard NSEvent.pressedMouseButtons & 0x1 == 0 else {
+                    // Mid-drag, the arrow keeps getting stamped back (tracking
+                    // updates as the window moves under the pointer); a single
+                    // set() at mouseDown doesn't survive, so re-assert each
+                    // tick until release.
+                    MainActor.assumeIsolated { NSCursor.closedHand.set() }
+                    return
+                }
+                timer.invalidate()
+                MainActor.assumeIsolated {
+                    guard let self, let window = self.window else { return }
+                    window.enableCursorRects()
+                    window.invalidateCursorRects(for: self)
+                    let point = self.convert(window.mouseLocationOutsideOfEventStream, from: nil)
+                    (self.bounds.contains(point) ? NSCursor.openHand : NSCursor.arrow).set()
+                }
+            }
+            cursorRestoreTimer = timer
+            RunLoop.main.add(timer, forMode: .common)
         }
     }
 }


### PR DESCRIPTION
## Why

Grabbing the quick terminal's drag strip (dynamic position mode, #267) showed the open-hand hover cursor, but the moment the drag began the cursor snapped back to the plain arrow. It should read as a grab: closed hand for the duration of the drag.

## What

The root cause is that `performDrag(with:)` hands the drag to the window server — the view receives no further mouse events (not even the `mouseUp`), and AppKit's tracking updates keep stamping the arrow back as the window moves under the stationary pointer. A one-shot `NSCursor.closedHand.set()` at `mouseDown` doesn't survive that. So `DragAreaView` now:

- suspends the window's cursor rects at `mouseDown` (their re-evaluation is what flips the cursor back) and sets `.closedHand`;
- polls `NSEvent.pressedMouseButtons` every 50ms — the only release signal available, since the window-server drag swallows all events — re-asserting `.closedHand` on each tick while the button is down, so whatever resets the cursor can win for at most one tick;
- on release, re-enables the cursor rects and restores open-hand or arrow depending on whether the pointer ended up back over the strip.

The drag itself is untouched — still the window server's own (`performDrag`), keeping live movement, screen-edge handling, and multi-display behavior native.

## Testing

- `mise run format`, `mise run lint`, `mise run test` all pass.
- Manual: toggle the quick terminal in dynamic position mode and drag by the strip — closed hand throughout the drag, open hand on hover after release.
