### PR TITLE
Persist directory permissions across updates and surface Full Disk Access in Settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,69 @@ jobs:
       - name: Setup GhosttyKit
         run: mise run setup --verbose
 
+      # Import the stable self-signed release certificate and hand its identity
+      # to build.sh via MACTERM_CODESIGN_IDENTITY. macOS TCC keys privacy
+      # grants (Documents, Downloads, …) to the app's code-signing designated
+      # requirement; ad-hoc signing (what releases shipped with before) bakes
+      # the per-build CDHash into that requirement, so every update looked like
+      # a new app and dropped every grant. Signing every release with ONE
+      # certificate keeps the requirement stable, so grants survive updates.
+      # Gatekeeper is unchanged (still self-signed, still needs the first-install
+      # xattr) — TCC doesn't require a trusted anchor, only the same cert.
+      #
+      # Missing secrets FAIL the release rather than falling back to ad-hoc: a
+      # silent fallback would ship an update that resets every user's grants
+      # once more, which is exactly the bug this exists to fix — and the next
+      # properly-signed release would reset them yet again. The generation
+      # recipe lives in AGENTS.md's Releasing section (a once-a-decade ceremony,
+      # so no script); never rotate the cert casually (a new cert is one more
+      # reset), and back it up like the Sparkle private key.
+      - name: Import signing certificate
+        env:
+          MACTERM_SIGNING_CERT_P12: ${{ secrets.MACTERM_SIGNING_CERT_P12 }}
+          MACTERM_SIGNING_CERT_PASSWORD: ${{ secrets.MACTERM_SIGNING_CERT_PASSWORD }}
+        run: |
+          if [[ -z "$MACTERM_SIGNING_CERT_P12" || -z "$MACTERM_SIGNING_CERT_PASSWORD" ]]; then
+            echo "error: MACTERM_SIGNING_CERT_P12 / MACTERM_SIGNING_CERT_PASSWORD repo secrets are not set." >&2
+            echo "Releases are signed with a stable certificate so users' privacy grants survive" >&2
+            echo "updates. Follow the recipe in AGENTS.md's Releasing section to create the cert" >&2
+            echo "and add the secrets." >&2
+            exit 1
+          fi
+          KEYCHAIN="$RUNNER_TEMP/macterm-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          P12="$RUNNER_TEMP/macterm-signing.p12"
+          printf '%s' "$MACTERM_SIGNING_CERT_P12" | base64 --decode > "$P12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$P12" -k "$KEYCHAIN" -f pkcs12 \
+            -P "$MACTERM_SIGNING_CERT_PASSWORD" -T /usr/bin/codesign
+          # Let codesign reach the key headlessly (no UI to answer a prompt).
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+          # Trust settings don't travel inside a .p12, and codesign refuses an
+          # identity whose chain doesn't end at a trusted anchor — so trust the
+          # self-signed cert explicitly (runners have passwordless sudo).
+          CERT_PEM="$RUNNER_TEMP/macterm-signing.pem"
+          /usr/bin/openssl pkcs12 -in "$P12" -clcerts -nokeys \
+            -passin env:MACTERM_SIGNING_CERT_PASSWORD -out "$CERT_PEM"
+          sudo security add-trusted-cert -d -r trustRoot \
+            -k /Library/Keychains/System.keychain "$CERT_PEM"
+          # Resolve the identity by hash (unambiguous even if a runner image
+          # ever ships a similarly named cert). find-identity -v requires the
+          # trust added above, so a bad import fails HERE, not mid-build.
+          IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | awk '$2 ~ /^[0-9A-F]{40}$/ {print $2; exit}')"
+          if [[ -z "$IDENTITY" ]]; then
+            echo "error: imported certificate is not a valid code-signing identity:" >&2
+            security find-identity -p codesigning "$KEYCHAIN" >&2
+            exit 1
+          fi
+          echo "MACTERM_CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+          rm -f "$P12" "$CERT_PEM"
+
       - name: Build universal release artifact
         env:
           SPARKLE_ED_PUBLIC_KEY: ${{ secrets.SPARKLE_ED_PUBLIC_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,25 @@ Requires macOS 14+, Swift 6.0+. Liquid glass and a few chrome refinements are ma
 
 Auto-updates ship via [Sparkle](https://sparkle-project.org/) — daily background check, manual via **Macterm → Check for Updates…**. Updates verify an EdDSA signature, so no `xattr` workaround after first install. No telemetry.
 
-Tag-pushed builds release via `.github/workflows/release.yml`, which needs repo secrets: `SPARKLE_ED_PUBLIC_KEY` (baked into `Info.plist`), `SPARKLE_ED_PRIVATE_KEY` (signs each DMG — **back it up; losing it means users can't auto-update to any further release**), and `HOMEBREW_TAP_PAT` (pushes the cask to the tap repo). GhosttyKit needs no secret: `thdxg/ghostty` is public, so `setup.sh`'s release downloads run under `GITHUB_TOKEN` here as in every other workflow. The workflow appends an `<item>` to `appcast.xml` on `gh-pages` (served at `https://thdxg.github.io/macterm/appcast.xml`, the feed URL in `Info.plist`) along with a per-version notes page rendered from the GitHub Release body (`publish-appcast.sh`).
+Tag-pushed builds release via `.github/workflows/release.yml`, which needs repo secrets: `SPARKLE_ED_PUBLIC_KEY` (baked into `Info.plist`), `SPARKLE_ED_PRIVATE_KEY` (signs each DMG — **back it up; losing it means users can't auto-update to any further release**), `HOMEBREW_TAP_PAT` (pushes the cask to the tap repo), and `MACTERM_SIGNING_CERT_P12` + `MACTERM_SIGNING_CERT_PASSWORD` (the stable self-signed code-signing certificate — **back it up too; rotating or losing it resets every user's TCC privacy grants one more time**, because TCC keys grants to the certificate in the app's designated requirement. Ad-hoc signing, the old scheme, keyed grants to the per-build CDHash, which is why every update used to drop Documents/Downloads access. A missing cert secret fails the release loudly rather than silently shipping an ad-hoc build that would reset grants again; local `mise run build`/`bench` stay ad-hoc, which is fine because they're never distributed).
+
+The certificate is a once-a-decade ceremony, so there's no script — the recipe lives here. It deliberately uses `/usr/bin/openssl` (macOS's LibreSSL): its PKCS#12 defaults are the legacy algorithms `security import` is guaranteed to read, where a Homebrew OpenSSL 3 defaults to AES/PBES2 containers it has a history of rejecting. The codeSigning EKU is what makes the identity acceptable to `codesign`; validity only gates *future signing*, not already-shipped apps.
+
+```bash
+mkdir -p ~/.config/macterm/signing && cd ~/.config/macterm/signing
+/usr/bin/openssl rand -hex 16 > macterm-signing.password
+/usr/bin/openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 3650 \
+  -subj "/CN=Macterm Release Signing" \
+  -addext "keyUsage=critical,digitalSignature" \
+  -addext "extendedKeyUsage=critical,codeSigning" \
+  -addext "basicConstraints=critical,CA:FALSE" \
+  -keyout macterm-signing.key -out macterm-signing.crt
+/usr/bin/openssl pkcs12 -export -inkey macterm-signing.key -in macterm-signing.crt \
+  -name "Macterm Release Signing" -passout "pass:$(cat macterm-signing.password)" \
+  -out macterm-signing.p12
+gh secret set MACTERM_SIGNING_CERT_P12 --repo thdxg/macterm --body "$(base64 -i macterm-signing.p12)"
+gh secret set MACTERM_SIGNING_CERT_PASSWORD --repo thdxg/macterm --body "$(cat macterm-signing.password)"
+``` GhosttyKit needs no secret: `thdxg/ghostty` is public, so `setup.sh`'s release downloads run under `GITHUB_TOKEN` here as in every other workflow. The workflow appends an `<item>` to `appcast.xml` on `gh-pages` (served at `https://thdxg.github.io/macterm/appcast.xml`, the feed URL in `Info.plist`) along with a per-version notes page rendered from the GitHub Release body (`publish-appcast.sh`).
 
 **Release notes come from GitHub's native generator**, configured by `.github/release.yml` (categories keyed on the `enhancement`/`bug`/`chore`/`dependencies`/`documentation` labels, `skip-changelog` excluded, a trailing `*` catch-all so nothing is silently dropped — GitHub assigns each PR to the first matching category, so that entry must stay last). `release-drafter` used to maintain a rolling draft and derive the next version from PR labels; it was removed as redundant now that the notes are native. The tradeoff is deliberate: **the version number is chosen by hand when cutting a release**, since native notes only ever describe a tag that already exists. That is also what keeps `vX.Y.Z-beta.N` prerelease tags simple — nothing tries to compute them.
 
@@ -272,5 +290,5 @@ Three things hold the restore together. It reads **`Preferences.launchSidebarWid
 - **Remote projects require zmx preinstalled on the host** — auto-detected via PATH (profiles + a fallback dir list); if that fails (network-mounted home, exotic `/bin/sh`, non-POSIX shell config), set the project's `zmxPath` to an absolute path. A missing binary surfaces a `macterm: zmx not found` diagnostic in the pane (not a silent close). No upload/install flow yet.
 - **Remote orphan sessions aren't reaped** — the reaper is local-only by design (a shared host's detached `macterm-*` sessions may belong to another machine); crash leftovers on a remote are the user's to `zmx kill`.
 - **Single window only** — multi-window would require a tmux-like daemon; out of scope.
-- **Not code-signed with a Developer ID** — first launch needs `xattr -cr /Applications/Macterm.app` (or Homebrew install); Sparkle updates verify EdDSA after that.
+- **Not code-signed with a Developer ID** — first launch needs `xattr -cr /Applications/Macterm.app` (or Homebrew install); Sparkle updates verify EdDSA after that. Releases are signed with a stable self-signed certificate, so TCC privacy grants (Documents, Downloads, Full Disk Access, …) persist across updates — under the old ad-hoc signing they reset on every update.
 - **Pane IDs not stable across restarts** — fresh views are created on restore.

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -459,16 +459,44 @@ private struct GeneralSettings: View {
     @State
     private var ghosttyConfigPath: String = Preferences.shared.userGhosttyConfigPath
 
+    /// Re-probed when the app becomes active, so returning from System
+    /// Settings after flipping the toggle clears the banner. `nil` (no
+    /// evidence) hides it — never nag about a grant we can't disprove.
+    @State
+    private var hasFullDiskAccess: Bool? = FullDiskAccess.isGranted()
+
+    /// Whether the user's raw ghostty config opts into an ssh
+    /// shell-integration feature (`ssh-env` / `ssh-terminfo`, both default
+    /// OFF). Those wrappers are the only thing that execs the external ghostty
+    /// CLI in a way worth warning about — the `path` feature also needs the
+    /// binary, but it's vacuous without Ghostty.app installed (there'd be no
+    /// bin dir to add to PATH). Computed once per view creation: it reads the
+    /// user's config file, and disk has no place in `body`.
+    @State
+    private var wantsCLISSHFeatures: Bool = {
+        let text = MactermConfig.userGhosttyConfigText()
+        return ShellIntegrationFeatures.isEnabled("ssh-env", inConfigText: text)
+            || ShellIntegrationFeatures.isEnabled("ssh-terminfo", inConfigText: text)
+    }()
+
     var body: some View {
         Form {
+            if hasFullDiskAccess == false {
+                FullDiskAccessBanner()
+            }
+
             // Read the CLI probe from the process-lifetime cache — never spawn
             // `ghostty +help` from inside `body` (it re-ran on every @State
             // change, e.g. each scroll-speed slider tick, blocking the main
-            // thread on `waitUntilExit`; #3.1).
-            if !GhosttyCLIProbe.isInstalled {
-                GhosttyCLIBanner(reason: .notInstalled)
-            } else if GhosttyCLIProbe.sshWrapperBinDir == nil {
-                GhosttyCLIBanner(reason: .tooOldForSSH)
+            // thread on `waitUntilExit`; #3.1). Gated on the user actually
+            // opting into an ssh feature: before the gate this warned every
+            // Ghostty-less install about features nobody had turned on.
+            if wantsCLISSHFeatures {
+                if !GhosttyCLIProbe.isInstalled {
+                    GhosttyCLIBanner(reason: .notInstalled)
+                } else if GhosttyCLIProbe.sshWrapperBinDir == nil {
+                    GhosttyCLIBanner(reason: .tooOldForSSH)
+                }
             }
 
             Section("Ghostty Config") {
@@ -531,6 +559,14 @@ private struct GeneralSettings: View {
             }
         }
         .formStyle(.grouped)
+        // Granting FDA happens in System Settings, so the state can only have
+        // changed while this app was inactive — re-probe on every activation
+        // rather than polling.
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+        ) { _ in
+            hasFullDiskAccess = FullDiskAccess.isGranted()
+        }
     }
 
     /// Push the text-field's current value into Preferences and reload. We
@@ -561,14 +597,52 @@ private struct GeneralSettings: View {
     }
 }
 
+// MARK: - Full Disk Access banner
+
+/// Shown in General settings while macOS hasn't granted the app Full Disk
+/// Access. Without it, TCC prompts folder by folder (Documents, Downloads, …)
+/// as terminal commands first touch each one; one FDA grant covers them all —
+/// and persists across updates, now that releases are signed with a stable
+/// certificate. FDA can't be requested programmatically (there is no prompt to
+/// trigger), so the button deep-links to the System Settings pane and
+/// `GeneralSettings` re-probes when the app becomes active again.
+private struct FullDiskAccessBanner: View {
+    var body: some View {
+        Section {
+            Label {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Full Disk Access is off")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(
+                        "macOS will ask folder by folder as terminal commands touch "
+                            + "Documents, Downloads, and other protected locations. "
+                            + "One Full Disk Access grant covers them all."
+                    )
+                    .settingsCaption()
+                    if let url = FullDiskAccess.settingsURL {
+                        Button("Open System Settings…") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                }
+            } icon: {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(MactermTheme.warning)
+            }
+            .padding(.vertical, 2)
+        }
+    }
+}
+
 // MARK: - Missing CLI banner
 
 /// Shown in General settings when the standalone ghostty CLI (shipped in
 /// Ghostty.app) is missing or too old to drive the shell-integration wrappers.
 /// A few wrappers exec that binary (the `ssh` wrapper calls `ghostty +ssh`), so
 /// without a compatible CLI those features are disabled and fall through to the
-/// plain command — the README link spells out which. Embedded directly in a
-/// `Form`, so it renders as its own section.
+/// plain command — the README link spells out which. Shown only to users whose
+/// own ghostty config enables an ssh feature (see `wantsCLISSHFeatures`).
+/// Embedded directly in a `Form`, so it renders as its own section.
 private struct GhosttyCLIBanner: View {
     enum Reason {
         case notInstalled

--- a/Macterm/System/FullDiskAccess.swift
+++ b/Macterm/System/FullDiskAccess.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Detects whether the app has been granted Full Disk Access.
+///
+/// macOS has no API to ask TCC directly, so the standard technique is
+/// attempting to open a file FDA protects. The probe files are all owned by
+/// the user with readable modes, so a failed `open(2)` can only mean TCC
+/// blocked it — plain UNIX permissions can't confound the verdict. Probing is
+/// side-effect free: FDA is grant-only in System Settings, so a denied open
+/// never triggers a permission prompt.
+///
+/// The verdict is `Bool?` because "nothing probeable exists" is a real state
+/// (however unlikely — the user TCC database is created at first login): a
+/// caller shown no evidence should stay quiet rather than nag about a grant
+/// that may already be in place.
+enum FullDiskAccess {
+    /// Deep link to System Settings → Privacy & Security → Full Disk Access.
+    /// Optional only to satisfy `URL(string:)` — the literal always parses;
+    /// callers `if let` it, matching `GhosttyCLIBanner.detailsURL`.
+    static let settingsURL =
+        URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")
+
+    enum ProbeResult {
+        /// The file opened — TCC let us through.
+        case readable
+        /// The file exists but `open(2)` failed — TCC denied it.
+        case denied
+        /// The file doesn't exist; says nothing about the grant.
+        case missing
+    }
+
+    /// FDA-protected, user-owned files. The user TCC database always exists;
+    /// Safari's store is a second witness in case that ever changes.
+    private static let probePaths = [
+        "Library/Application Support/com.apple.TCC/TCC.db",
+        "Library/Safari/CloudTabs.db",
+    ]
+
+    /// The decision over a set of probe results — pure, so it's the tested
+    /// piece. Any readable file proves the grant (a denial alongside it would
+    /// be some other restriction, not FDA); any denial without one disproves
+    /// it; all-missing is no evidence either way.
+    static func verdict(_ results: [ProbeResult]) -> Bool? {
+        if results.contains(.readable) { return true }
+        if results.contains(.denied) { return false }
+        return nil
+    }
+
+    /// Probe the real system. `nil` means no evidence — treat as granted.
+    static func isGranted() -> Bool? {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return verdict(probePaths.map { probe(home.appendingPathComponent($0).path) })
+    }
+
+    private static func probe(_ path: String) -> ProbeResult {
+        let fd = open(path, O_RDONLY)
+        if fd >= 0 {
+            close(fd)
+            return .readable
+        }
+        return errno == ENOENT ? .missing : .denied
+    }
+}

--- a/MactermTests/System/FullDiskAccessTests.swift
+++ b/MactermTests/System/FullDiskAccessTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+/// The live probe's answer depends on the machine running the tests (whether
+/// the hosting app has the FDA grant), so coverage targets the pure verdict
+/// over probe results, plus the System Settings deep link the banner opens.
+struct FullDiskAccessTests {
+    @Test
+    func aReadableFileProvesTheGrant() {
+        #expect(FullDiskAccess.verdict([.readable, .missing]) == true)
+        // A denial alongside a readable file is some other restriction on
+        // that one file — the grant itself is still proven.
+        #expect(FullDiskAccess.verdict([.denied, .readable]) == true)
+    }
+
+    @Test
+    func aDenialWithoutAReadableFileDisprovesIt() {
+        #expect(FullDiskAccess.verdict([.denied, .missing]) == false)
+        #expect(FullDiskAccess.verdict([.missing, .denied]) == false)
+    }
+
+    @Test
+    func noEvidenceStaysUndecided() {
+        #expect(FullDiskAccess.verdict([.missing, .missing]) == nil)
+        #expect(FullDiskAccess.verdict([]) == nil)
+    }
+
+    @Test
+    func settingsURLTargetsTheFullDiskAccessPane() {
+        #expect(
+            FullDiskAccess.settingsURL?.absoluteString
+                == "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+        )
+    }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,6 +17,21 @@ source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 BUILD_NUMBER="$(sparkle_comparison_version "$VERSION")"
 GIT_COMMIT=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 SPARKLE_ED_PUBLIC_KEY="${SPARKLE_ED_PUBLIC_KEY:-SPARKLE_ED_PUBLIC_KEY_PLACEHOLDER}"
+
+# Optional stable code-signing identity (a SHA-1 identity hash or a certificate
+# name resolvable in the keychain). macOS TCC keys privacy grants (Documents,
+# Downloads, …) to the app's code-signing designated requirement; an ad-hoc
+# signature's requirement is the per-build CDHash, so every update looks like a
+# brand-new app to TCC and drops every grant. Release CI sets this to the
+# imported self-signed release certificate (see release.yml's "Import signing
+# certificate" step) so the requirement stays stable across releases and grants
+# survive updates. Unset = ad-hoc (project.yml's default), which is fine for
+# local and benchmark builds that are never distributed.
+CODESIGN_IDENTITY="${MACTERM_CODESIGN_IDENTITY:-}"
+SIGNING_OVERRIDES=()
+if [[ -n "$CODESIGN_IDENTITY" ]]; then
+  SIGNING_OVERRIDES+=(CODE_SIGN_IDENTITY="$CODESIGN_IDENTITY")
+fi
 DMG_NAME="Macterm-${VERSION}.dmg"
 DERIVED_DATA="$BUILD_DIR/DerivedData"
 ARCHIVE_PATH="$BUILD_DIR/Macterm.xcarchive"
@@ -47,12 +62,14 @@ xcodebuild \
   CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
   GIT_COMMIT="$GIT_COMMIT" \
   SPARKLE_ED_PUBLIC_KEY="$SPARKLE_ED_PUBLIC_KEY" \
+  ${SIGNING_OVERRIDES[@]+"${SIGNING_OVERRIDES[@]}"} \
   archive \
   | (xcbeautify --quiet 2>/dev/null || cat)
 
-# Copy the .app straight out of the archive. We ship ad-hoc-signed, so there's
-# nothing to re-sign or notarize — the archive's Products/Applications already
-# holds the fully-built, signed bundle (Sparkle and its XPC services included).
+# Copy the .app straight out of the archive. There's nothing to re-sign or
+# notarize — the archive's Products/Applications already holds the fully-built,
+# signed bundle (Sparkle and its XPC services included), signed either ad-hoc
+# (local) or with the stable release certificate (CI, via SIGNING_OVERRIDES).
 # `ditto` (not cp) preserves the framework symlinks a valid macOS bundle needs.
 #
 # This deliberately avoids `xcodebuild -exportArchive`: its `-exportOptionsPlist`
@@ -71,6 +88,14 @@ APP_BUNDLE="$EXPORT_PATH/Macterm.app"
 # Sanity-check the copy is a valid, signed bundle before building a DMG from it.
 if ! codesign --verify --deep --strict "$APP_BUNDLE" 2>/dev/null; then
   echo "ERROR: exported $APP_BUNDLE failed code-signature verification" >&2
+  exit 1
+fi
+# When a stable identity was requested, an ad-hoc signature slipping through
+# would ship an update that silently resets every user's TCC grants — exactly
+# what the identity exists to prevent — so fail rather than package it.
+if [[ -n "$CODESIGN_IDENTITY" ]] \
+  && codesign --display --verbose "$APP_BUNDLE" 2>&1 | grep -q "Signature=adhoc"; then
+  echo "ERROR: $APP_BUNDLE is ad-hoc signed despite MACTERM_CODESIGN_IDENTITY being set" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Why

Every update reset the user's TCC grants (Documents, Downloads, etc.), forcing folder-by-folder re-approval. Root cause: releases were ad-hoc signed, and TCC keys grants to the app's code-signing designated requirement — for an ad-hoc signature that's the per-build CDHash, so each update looked like a brand-new app.

## What changed

**Stable release signing** — CI now signs every release with one self-signed certificate (imported from the `MACTERM_SIGNING_CERT_P12` / `MACTERM_SIGNING_CERT_PASSWORD` repo secrets, already set), giving a stable designated requirement so grants persist across updates. `build.sh` grows an optional `MACTERM_CODESIGN_IDENTITY` hook and refuses to package an ad-hoc bundle when an identity was requested; local/benchmark builds stay ad-hoc. Missing secrets fail the release loudly — a silent ad-hoc fallback would ship one more grants-reset. The once-a-decade generation recipe is documented in AGENTS.md rather than a script.

**Full Disk Access banner** — Settings → General warns while FDA isn't granted, with an *Open System Settings…* button deep-linking to the Privacy & Security → Full Disk Access pane. Detection probes user-owned FDA-protected files via `open(2)` (no API exists to ask TCC; probing never triggers a prompt, and no-evidence hides the banner rather than nagging). It re-probes on app activation, so it clears when the user returns from System Settings. Verdict logic is pure and unit-tested.

**Ghostty CLI banner gating** — now shows only when the user's ghostty config enables `ssh-env`/`ssh-terminfo` (both default off). Those wrappers are what execs the external `ghostty` binary; the `path` feature is vacuous without Ghostty.app. Previously every Ghostty-less install saw the warning about features nobody had enabled.

## Reviewer notes

- The first update from an ad-hoc build to a cert-signed build resets grants one last time (new identity); after that they stick. Sparkle accepts the identity change because updates are gated on the EdDSA signature.
- Gatekeeper is unchanged: still self-signed, first install still needs `xattr -cr`.
- A pinned-tag caveat inherited from the signing cert: rotating or losing it resets every user's grants once, so it's backed up alongside the Sparkle EdDSA key.
- Tests: full suite green locally (991 passed), including the new `FullDiskAccessTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)