### PR TITLE
Remove the Enable Quick Terminal toggle in favor of clearing the keybind

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -407,10 +407,6 @@ final class Preferences {
 
     // MARK: - Quick terminal
 
-    var quickTerminalEnabled: Bool {
-        didSet { defaults.set(quickTerminalEnabled, forKey: Keys.quickTerminalEnabled) }
-    }
-
     /// Fraction of screen width (0–1).
     var quickTerminalWidthFraction: Double {
         didSet { defaults.set(quickTerminalWidthFraction, forKey: Keys.quickTerminalWidth) }
@@ -532,7 +528,6 @@ final class Preferences {
         hideTitleBar = defaults.object(forKey: Keys.hideTitleBar) as? Bool ?? false
         userGhosttyConfigPath = defaults.string(forKey: Keys.userGhosttyConfigPath) ?? "~/.config/ghostty/config"
         passthroughPrograms = defaults.string(forKey: Keys.passthroughPrograms) ?? ""
-        quickTerminalEnabled = defaults.object(forKey: Keys.quickTerminalEnabled) as? Bool ?? true
         quickTerminalWidthFraction = Self.clampFraction(defaults.double(forKey: Keys.quickTerminalWidth), fallback: 0.6)
         quickTerminalHeightFraction = Self.clampFraction(defaults.double(forKey: Keys.quickTerminalHeight), fallback: 0.5)
         quickTerminalPositionMode = (defaults.string(forKey: Keys.quickTerminalPositionMode))
@@ -646,7 +641,6 @@ final class Preferences {
         static let hideTitleBar = "macterm.window.hideTitleBar"
         static let userGhosttyConfigPath = "macterm.ghostty.userConfigPath"
         static let passthroughPrograms = "macterm.hotkey.passthroughPrograms"
-        static let quickTerminalEnabled = "macterm.quickTerminal.enabled"
         static let quickTerminalWidth = "macterm.quickTerminal.width"
         static let quickTerminalHeight = "macterm.quickTerminal.height"
         static let quickTerminalPositionMode = "macterm.quickTerminal.positionMode"

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -851,10 +851,6 @@ private struct AppearanceSettings: View {
 // MARK: - Quick Terminal
 
 private struct QuickTerminalSettings: View {
-    /// Seeded from / written back through `Preferences` — not `@AppStorage`
-    /// (banned `UserDefaults.standard`), and previously `enabled` wrote no
-    /// Preferences value at all, so the observable stayed stale.
-    @State private var enabled: Bool = Preferences.shared.quickTerminalEnabled
     @State
     private var positionMode: QuickTerminalAdjustMode = Preferences.shared.quickTerminalPositionMode
     @State
@@ -873,105 +869,88 @@ private struct QuickTerminalSettings: View {
     var body: some View {
         Form {
             Section("Quick Terminal") {
-                Toggle("Enable quick terminal", isOn: $enabled)
-                    .onChange(of: enabled) { _, v in
-                        Preferences.shared.quickTerminalEnabled = v
-                    }
                 LabeledContent(
                     "Shortcut",
                     value: HotkeyRegistry.displayString(
                         for: HotkeyRegistry.selectedShortcutString(for: .toggleQuickTerminal)
                     )
                 )
-                Text("Works globally, even when Macterm isn't active. Rebind it in Keymaps.")
+                Text("Works globally, even when Macterm isn't active. Rebind it in Keymaps, or clear it to disable the quick terminal.")
                     .settingsCaption()
             }
 
-            // The shared `!enabled` gate sits on each section's Group so the
-            // captions dim with their controls (nested `.disabled` ANDs with
-            // it — an inner `false` never re-enables).
             Section("Position") {
-                Group {
-                    Picker(selection: $positionMode) {
-                        ForEach(QuickTerminalAdjustMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode)
-                        }
-                    } label: {
-                        Text("Mode").dimsWhenDisabled()
+                Picker("Mode", selection: $positionMode) {
+                    ForEach(QuickTerminalAdjustMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
                     }
-                    .onChange(of: positionMode) { _, v in
-                        Preferences.shared.quickTerminalPositionMode = v
-                    }
-                    Text("Fixed anchors the panel with the sliders. Dynamic adds a grab handle and remembers where you drag it.")
-                        .settingsCaption()
-
-                    SettingsSlider(
-                        label: "X",
-                        value: $fixedX,
-                        range: 0 ... 1,
-                        step: 0.05,
-                        display: { anchorName($0, zero: "Left", one: "Right") }
-                    )
-                    .onChange(of: fixedX) { _, v in
-                        Preferences.shared.quickTerminalFixedX = v
-                    }
-                    .disabled(positionMode != .fixed)
-
-                    SettingsSlider(
-                        label: "Y",
-                        value: $fixedYTopDown,
-                        range: 0 ... 1,
-                        step: 0.05,
-                        display: { anchorName($0, zero: "Top", one: "Bottom") }
-                    )
-                    .onChange(of: fixedYTopDown) { _, v in
-                        Preferences.shared.quickTerminalFixedY = 1 - v
-                    }
-                    .disabled(positionMode != .fixed)
                 }
-                .disabled(!enabled)
+                .onChange(of: positionMode) { _, v in
+                    Preferences.shared.quickTerminalPositionMode = v
+                }
+                Text("Fixed anchors the panel with the sliders. Dynamic adds a grab handle and remembers where you drag it.")
+                    .settingsCaption()
+
+                SettingsSlider(
+                    label: "X",
+                    value: $fixedX,
+                    range: 0 ... 1,
+                    step: 0.05,
+                    display: { anchorName($0, zero: "Left", one: "Right") }
+                )
+                .onChange(of: fixedX) { _, v in
+                    Preferences.shared.quickTerminalFixedX = v
+                }
+                .disabled(positionMode != .fixed)
+
+                SettingsSlider(
+                    label: "Y",
+                    value: $fixedYTopDown,
+                    range: 0 ... 1,
+                    step: 0.05,
+                    display: { anchorName($0, zero: "Top", one: "Bottom") }
+                )
+                .onChange(of: fixedYTopDown) { _, v in
+                    Preferences.shared.quickTerminalFixedY = 1 - v
+                }
+                .disabled(positionMode != .fixed)
             }
 
             Section("Size") {
-                Group {
-                    Picker(selection: $sizeMode) {
-                        ForEach(QuickTerminalAdjustMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode)
-                        }
-                    } label: {
-                        Text("Mode").dimsWhenDisabled()
+                Picker("Mode", selection: $sizeMode) {
+                    ForEach(QuickTerminalAdjustMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
                     }
-                    .onChange(of: sizeMode) { _, v in
-                        Preferences.shared.quickTerminalSizeMode = v
-                    }
-                    Text("Fixed sizes the panel with the sliders. Dynamic lets you resize it from its edges and reopens it at that size.")
-                        .settingsCaption()
-
-                    SettingsSlider(
-                        label: "Width",
-                        value: $qtWidth,
-                        range: 0.2 ... 1.0,
-                        step: 0.05,
-                        display: { "\(Int(($0 * 100).rounded()))%" }
-                    )
-                    .onChange(of: qtWidth) { _, v in
-                        Preferences.shared.quickTerminalWidthFraction = v
-                    }
-                    .disabled(sizeMode != .fixed)
-
-                    SettingsSlider(
-                        label: "Height",
-                        value: $qtHeight,
-                        range: 0.2 ... 1.0,
-                        step: 0.05,
-                        display: { "\(Int(($0 * 100).rounded()))%" }
-                    )
-                    .onChange(of: qtHeight) { _, v in
-                        Preferences.shared.quickTerminalHeightFraction = v
-                    }
-                    .disabled(sizeMode != .fixed)
                 }
-                .disabled(!enabled)
+                .onChange(of: sizeMode) { _, v in
+                    Preferences.shared.quickTerminalSizeMode = v
+                }
+                Text("Fixed sizes the panel with the sliders. Dynamic lets you resize it from its edges and reopens it at that size.")
+                    .settingsCaption()
+
+                SettingsSlider(
+                    label: "Width",
+                    value: $qtWidth,
+                    range: 0.2 ... 1.0,
+                    step: 0.05,
+                    display: { "\(Int(($0 * 100).rounded()))%" }
+                )
+                .onChange(of: qtWidth) { _, v in
+                    Preferences.shared.quickTerminalWidthFraction = v
+                }
+                .disabled(sizeMode != .fixed)
+
+                SettingsSlider(
+                    label: "Height",
+                    value: $qtHeight,
+                    range: 0.2 ... 1.0,
+                    step: 0.05,
+                    display: { "\(Int(($0 * 100).rounded()))%" }
+                )
+                .onChange(of: qtHeight) { _, v in
+                    Preferences.shared.quickTerminalHeightFraction = v
+                }
+                .disabled(sizeMode != .fixed)
             }
         }
         .formStyle(.grouped)

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -37,10 +37,6 @@ final class QuickTerminalService: NSObject {
     /// String form of the shortcut we currently have registered with Carbon,
     /// so `userDefaultsDidChange` can detect rebinds and re-register.
     private var lastRegisteredShortcutID: String?
-    /// Snapshot of `isEnabled` after the most recent reconcile. Used to detect
-    /// flips when `UserDefaults.didChangeNotification` fires, since that
-    /// notification doesn't tell us which key changed.
-    private var lastKnownEnabled: Bool = Preferences.shared.quickTerminalEnabled
     /// The app that was frontmost just before we showed the quick terminal.
     /// Captured so we can re-activate it on hide if Macterm somehow took over —
     /// without this, dismissing the panel would leave focus on Macterm even
@@ -48,15 +44,6 @@ final class QuickTerminalService: NSObject {
     private var previousFrontmostApp: NSRunningApplication?
     let splitState = QuickTerminalSplitState()
     var suppressAutoHide = false
-    private var isEnabled: Bool {
-        // Read directly from UserDefaults instead of Preferences.shared.
-        // Preferences caches the value in a stored property that's only set on
-        // init and via its own setter — Settings writes through @AppStorage,
-        // which bypasses Preferences entirely. Reading defaults here keeps the
-        // service in sync with whatever the toggle's current persisted value
-        // actually is.
-        Preferences.defaults.object(forKey: Preferences.Keys.quickTerminalEnabled) as? Bool ?? true
-    }
 
     override private init() {
         super.init()
@@ -67,11 +54,10 @@ final class QuickTerminalService: NSObject {
             name: .autoTilingEnabledDidChange,
             object: nil
         )
-        // Observe UserDefaults broadly so we hot-reload no matter who flips the
-        // toggle. Settings uses @AppStorage which writes through UserDefaults
-        // without going through Preferences.shared, so observing the
-        // Preferences object would miss those writes. didChangeNotification
-        // fires on any key change; we filter by snapshotting the value.
+        // Observe UserDefaults broadly so a Settings → Keymaps rebind of the
+        // global shortcut takes effect immediately. didChangeNotification
+        // fires on any key change; we filter by comparing the registered
+        // binding against the current one.
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(userDefaultsDidChange),
@@ -87,7 +73,7 @@ final class QuickTerminalService: NSObject {
             name: .mactermConfigDidChange,
             object: nil
         )
-        if isEnabled { registerHotKey() }
+        registerHotKey()
     }
 
     @objc
@@ -98,24 +84,13 @@ final class QuickTerminalService: NSObject {
 
     @objc
     private func userDefaultsDidChange() {
-        // Two unrelated keys we react to: the enable toggle and the hotkey
-        // binding. Reconcile both each time since UserDefaults' change
-        // notification doesn't tell us which key changed.
-        let now = isEnabled
-        if now != lastKnownEnabled {
-            lastKnownEnabled = now
-            if now {
-                registerHotKey()
-            } else {
-                if isVisible { hide() }
-                unregisterHotKey()
-            }
-        }
         // Re-register on hotkey-binding changes so a Settings → Keymaps
-        // rebind takes effect immediately, not after restart.
+        // rebind takes effect immediately, not after restart. A cleared
+        // binding unregisters and registers nothing — that's how the user
+        // opts out of the quick terminal.
         let currentBindingID = lastRegisteredShortcutID
         let newBindingID = HotkeyRegistry.selectedShortcut(for: .toggleQuickTerminal)?.id
-        if now, currentBindingID != newBindingID {
+        if currentBindingID != newBindingID {
             unregisterHotKey()
             registerHotKey()
         }
@@ -129,15 +104,10 @@ final class QuickTerminalService: NSObject {
 
     @objc
     func toggle() {
-        guard isEnabled else {
-            if isVisible { hide() }
-            return
-        }
         if isVisible { hide() } else { show() }
     }
 
     func showPanel() {
-        guard isEnabled else { return }
         if isVisible {
             if let panel, orderPanelFront(panel), let focusedID = splitState.focusedPaneID {
                 FocusRestoration.restoreFocus(to: focusedID, in: splitState.splitRoot, window: panel)


### PR DESCRIPTION
## What

Removes the **Enable quick terminal** toggle from Settings → Quick Terminal. Opting out of the quick terminal is now done the same way as any other shortcut: clear the `Toggle Quick Terminal` binding in Keymaps.

- **SettingsView**: dropped the toggle and its `enabled` state, plus the `.disabled(!enabled)` gates (and their now-unneeded `Group` wrappers) on the Position/Size sections. The Shortcut caption now points at clearing the binding.
- **QuickTerminalService**: removed `isEnabled` / `lastKnownEnabled` and the enable-flip reconcile. The service always registers the hotkey at launch; `userDefaultsDidChange` now reconciles only on binding changes.
- **Preferences**: removed `quickTerminalEnabled` and the `macterm.quickTerminal.enabled` key.

## Why

The toggle duplicated what the Keymaps pane already expresses. `registerHotKey` already registered nothing when the binding is cleared, and the reconcile on `UserDefaults.didChangeNotification` already handles rebinds live — so clearing the binding unregisters the Carbon hotkey immediately and rebinding brings it back, no restart needed. One setting, one place.

## Reviewer notes

- A user who previously had the toggle **off** keeps a now-ignored stale default; on next launch the global hotkey comes back until they clear the binding. Judged acceptable for a niche state rather than adding a one-time migration.
- The palette/menu toggle command still works regardless of the binding (unchanged behavior — it never went through the Carbon hotkey).
- `mise run format`, `lint`, and `test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)