### PR TITLE
Probe Full Disk Access via protected directories, not files

### DIFF
--- a/Macterm/System/FullDiskAccess.swift
+++ b/Macterm/System/FullDiskAccess.swift
@@ -2,17 +2,26 @@ import Foundation
 
 /// Detects whether the app has been granted Full Disk Access.
 ///
-/// macOS has no API to ask TCC directly, so the standard technique is
-/// attempting to open a file FDA protects. The probe files are all owned by
-/// the user with readable modes, so a failed `open(2)` can only mean TCC
-/// blocked it — plain UNIX permissions can't confound the verdict. Probing is
-/// side-effect free: FDA is grant-only in System Settings, so a denied open
-/// never triggers a permission prompt.
+/// macOS has no API to ask TCC directly, so the check is attempting to open
+/// something FDA protects. **The probes must be directories, not files** —
+/// measured on macOS 27, TCC *hides* protected files rather than denying them:
+/// `open(2)` on `~/Library/Application Support/com.apple.TCC/TCC.db` or
+/// `~/Library/Safari/CloudTabs.db` fails with `ENOENT` while the files plainly
+/// exist, so a file probe can never observe a denial — it reads every denial
+/// as "missing" and the verdict degrades to "no evidence" forever (the v1.24.0
+/// banner never appeared because of exactly this). Protected *directories*
+/// (`~/Library/Safari`, `~/Library/Mail`, `~/Library/Messages`, all verified)
+/// fail with `EPERM` instead, which is a real, observable denial. All are
+/// user-owned with traversable modes, so plain UNIX permissions can't confound
+/// the verdict. Probing is side-effect free: FDA is grant-only in System
+/// Settings, so a denied open never triggers a permission prompt.
 ///
 /// The verdict is `Bool?` because "nothing probeable exists" is a real state
-/// (however unlikely — the user TCC database is created at first login): a
-/// caller shown no evidence should stay quiet rather than nag about a grant
-/// that may already be in place.
+/// (a pristine account may lack some of these directories): a caller shown no
+/// evidence should stay quiet rather than nag about a grant it can't
+/// disprove. Note ENOENT is also what TCC's file-hiding returns, so a hidden
+/// path and an absent one are indistinguishable by design — which is why the
+/// probe list is several directories: one EPERM anywhere is proof enough.
 enum FullDiskAccess {
     /// Deep link to System Settings → Privacy & Security → Full Disk Access.
     /// Optional only to satisfy `URL(string:)` — the literal always parses;
@@ -21,25 +30,27 @@ enum FullDiskAccess {
         URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")
 
     enum ProbeResult {
-        /// The file opened — TCC let us through.
+        /// The directory opened — TCC let us through.
         case readable
-        /// The file exists but `open(2)` failed — TCC denied it.
+        /// `open(2)` failed with something other than ENOENT — TCC denied it.
         case denied
-        /// The file doesn't exist; says nothing about the grant.
+        /// ENOENT: absent, or a TCC-hidden file; says nothing either way.
         case missing
     }
 
-    /// FDA-protected, user-owned files. The user TCC database always exists;
-    /// Safari's store is a second witness in case that ever changes.
+    /// FDA-protected, user-owned directories (see the type comment for why
+    /// directories). Safari's exists on effectively every account; Mail and
+    /// Messages back it up on unusual ones.
     private static let probePaths = [
-        "Library/Application Support/com.apple.TCC/TCC.db",
-        "Library/Safari/CloudTabs.db",
+        "Library/Safari",
+        "Library/Mail",
+        "Library/Messages",
     ]
 
     /// The decision over a set of probe results — pure, so it's the tested
-    /// piece. Any readable file proves the grant (a denial alongside it would
-    /// be some other restriction, not FDA); any denial without one disproves
-    /// it; all-missing is no evidence either way.
+    /// piece. Any readable directory proves the grant (a denial alongside it
+    /// would be some other restriction, not FDA); any denial without one
+    /// disproves it; all-missing is no evidence either way.
     static func verdict(_ results: [ProbeResult]) -> Bool? {
         if results.contains(.readable) { return true }
         if results.contains(.denied) { return false }
@@ -52,7 +63,7 @@ enum FullDiskAccess {
         return verdict(probePaths.map { probe(home.appendingPathComponent($0).path) })
     }
 
-    private static func probe(_ path: String) -> ProbeResult {
+    static func probe(_ path: String) -> ProbeResult {
         let fd = open(path, O_RDONLY)
         if fd >= 0 {
             close(fd)

--- a/MactermTests/System/FullDiskAccessTests.swift
+++ b/MactermTests/System/FullDiskAccessTests.swift
@@ -33,4 +33,20 @@ struct FullDiskAccessTests {
                 == "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
         )
     }
+
+    // The errno mapping is testable only at its deterministic edges — a
+    // protected path's result depends on the host's grant. These two pin the
+    // ends that never do.
+
+    @Test
+    func probeMapsAnAbsentPathToMissing() {
+        let absent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fda-probe-\(UUID().uuidString)").path
+        #expect(FullDiskAccess.probe(absent) == .missing)
+    }
+
+    @Test
+    func probeMapsAnOpenableDirectoryToReadable() {
+        #expect(FullDiskAccess.probe("/") == .readable)
+    }
 }


### PR DESCRIPTION
## Why

The Full Disk Access banner shipped in v1.24.0-beta.1 (#273) never appears, even without the grant.

Root cause, measured on macOS 27: TCC **hides** FDA-protected *files* instead of denying them. `open(2)` on `~/Library/Application Support/com.apple.TCC/TCC.db` or `~/Library/Safari/CloudTabs.db` fails with **ENOENT** while both files plainly exist. The probe mapped ENOENT to `.missing`, so a denial was never observable — the verdict permanently degraded to "no evidence", which (correctly, per its fail-quiet design) hides the banner.

Protected *directories* behave differently: `~/Library/Safari`, `~/Library/Mail`, `~/Library/Messages` (and others) fail with **EPERM** — a real, observable denial.

## What changed

- `FullDiskAccess` now probes those three directories instead of the two files. Verdict logic is unchanged: any readable → granted, any EPERM → denied, all-ENOENT → no evidence (still fail-quiet, since ENOENT can't distinguish absent from TCC-hidden).
- The errno mapping gains tests at its two deterministic edges (absent path → `.missing`, `/` → `.readable`); the protected paths themselves can't be asserted in tests because the result depends on the host's grant.

## Reviewer notes

- Verified empirically from a no-FDA process on macOS 27: both old file probes return ENOENT, all three directory probes return EPERM. With FDA granted, the directories open, so the granted state maps to `.readable`.
- One caveat discovered along the way, for future FDA work: a probe run *inside a pane* tests the zmx daemon's TCC lineage (the daemon survives app restarts and may predate the running app), not the GUI process — the banner's probe runs in the right context, but don't move it into a pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)