### PR TITLE
fix: disable Sparkle in local builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,10 @@ jobs:
             echo "error: tag '$GITHUB_REF_NAME' is not $EXPECTED; refusing to build a placeholder release" >&2
             exit 1
           fi
+          if [[ -z "$SPARKLE_ED_PUBLIC_KEY" || "$SPARKLE_ED_PUBLIC_KEY" == "SPARKLE_ED_PUBLIC_KEY_PLACEHOLDER" ]]; then
+            echo "error: SPARKLE_ED_PUBLIC_KEY is missing or still set to the local-build placeholder; refusing to build a release without auto-updates" >&2
+            exit 1
+          fi
           # Release builds invoke the build script directly to skip the
           # format/lint/test deps on `mise run build` — main is already
           # format/lint-gated by checks.yml and test-gated by test.yml before

--- a/Macterm/App/Updater.swift
+++ b/Macterm/App/Updater.swift
@@ -2,6 +2,15 @@ import Combine
 import Sparkle
 import SwiftUI
 
+enum UpdaterAvailability {
+    static let placeholderPublicKey = "SPARKLE_ED_PUBLIC_KEY_PLACEHOLDER"
+
+    static func shouldStart(isDebug: Bool, isBenchmark: Bool, publicKey: String?) -> Bool {
+        guard !isDebug, !isBenchmark, let publicKey, !publicKey.isEmpty else { return false }
+        return publicKey != placeholderPublicKey
+    }
+}
+
 /// Thin wrapper around `SPUStandardUpdaterController` that exposes the
 /// observable bits SwiftUI views need.
 ///
@@ -36,22 +45,27 @@ final class Updater {
     private var cancellable: AnyCancellable?
 
     private init() {
-        // In debug builds Sparkle can't verify the unsigned dev binary against
-        // the production EdDSA key, so it pops an "Unable to Check For
-        // Updates" dialog on every launch. Start the controller without
-        // kicking off update checks; release builds still auto-check.
+        // Debug and local Release builds have no production EdDSA key, so
+        // Sparkle would show "Unable to Check For Updates" on launch. Only a
+        // distributed release with a real embedded key starts the updater.
         //
         // Benchmark mode is a Release build with the placeholder key
         // (scripts/bench.sh builds without SPARKLE_ED_PUBLIC_KEY), so the
         // updater fails to start and its app-modal alert blocks the run
         // loop at launch — on CI nobody can click OK.
-        let startUpdater: Bool = {
+        let isDebug: Bool = {
             #if DEBUG
-            return false
+            true
             #else
-            return !BenchmarkControl.isEnabled
+            false
             #endif
         }()
+        let publicKey = Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
+        let startUpdater = UpdaterAvailability.shouldStart(
+            isDebug: isDebug,
+            isBenchmark: BenchmarkControl.isEnabled,
+            publicKey: publicKey
+        )
 
         // Construct the controller WITHOUT starting the updater, so we can wire
         // the delegate callbacks before any check can fire. Referencing `self`
@@ -76,8 +90,8 @@ final class Updater {
         userDriverDelegate.onUpdateFound = { [weak self] in self?.updateAvailable = true }
         userDriverDelegate.onUpdateCleared = { [weak self] in self?.updateAvailable = false }
 
-        // Now that callbacks are wired, actually start the updater (release,
-        // non-benchmark). Debug/benchmark skip it (see `startUpdater` above).
+        // Now that callbacks are wired, actually start the updater. Local,
+        // Debug, and benchmark builds skip it (see `startUpdater` above).
         if startUpdater {
             controller.startUpdater()
         }

--- a/MactermTests/App/UpdaterChannelTests.swift
+++ b/MactermTests/App/UpdaterChannelTests.swift
@@ -16,6 +16,55 @@ import Testing
 @MainActor
 struct UpdaterChannelTests {
     @Test
+    func updater_starts_only_for_distributed_release_builds() {
+        let realKey = "real-release-public-key"
+
+        #expect(UpdaterAvailability.shouldStart(
+            isDebug: false, isBenchmark: false, publicKey: realKey
+        ))
+        #expect(!UpdaterAvailability.shouldStart(
+            isDebug: true, isBenchmark: false, publicKey: realKey
+        ))
+        #expect(!UpdaterAvailability.shouldStart(
+            isDebug: false, isBenchmark: true, publicKey: realKey
+        ))
+        #expect(!UpdaterAvailability.shouldStart(
+            isDebug: false,
+            isBenchmark: false,
+            publicKey: UpdaterAvailability.placeholderPublicKey
+        ))
+        #expect(!UpdaterAvailability.shouldStart(
+            isDebug: false, isBenchmark: false, publicKey: nil
+        ))
+    }
+
+    @Test
+    func placeholder_public_key_matches_the_build_and_release_contracts() throws {
+        let placeholder = UpdaterAvailability.placeholderPublicKey
+        let root = repoRoot()
+        let project = try String(
+            contentsOf: root.appendingPathComponent("project.yml"),
+            encoding: .utf8
+        )
+        let buildScript = try String(
+            contentsOf: root.appendingPathComponent("scripts/build.sh"),
+            encoding: .utf8
+        )
+        let releaseWorkflow = try String(
+            contentsOf: root.appendingPathComponent(".github/workflows/release.yml"),
+            encoding: .utf8
+        )
+
+        #expect(project.contains("SPARKLE_ED_PUBLIC_KEY: \(placeholder)"))
+        #expect(buildScript.contains(
+            #"SPARKLE_ED_PUBLIC_KEY="${SPARKLE_ED_PUBLIC_KEY:-\#(placeholder)}""#
+        ))
+        #expect(releaseWorkflow.contains(
+            "\"$SPARKLE_ED_PUBLIC_KEY\" == \"\(placeholder)\""
+        ))
+    }
+
+    @Test
     func beta_channel_name_matches_the_appcast_literal() throws {
         // Must equal the value in publish-appcast.sh's CHANNEL_LINE. Read the
         // script rather than restating "beta", so an edit to either side fails.

--- a/project.yml
+++ b/project.yml
@@ -91,8 +91,8 @@ targets:
         # via xcodebuild -override; defaults below apply for local dev builds.
         MARKETING_VERSION: "0.0.0"
         CURRENT_PROJECT_VERSION: "0.0.0"
-        # Public Sparkle key is overridden in CI release builds; placeholder
-        # is fine for local development since Sparkle never invokes itself.
+        # Public Sparkle key is overridden in CI release builds. Updater.swift
+        # treats this placeholder as an explicit local-build disable switch.
         SPARKLE_ED_PUBLIC_KEY: SPARKLE_ED_PUBLIC_KEY_PLACEHOLDER
         GIT_COMMIT: GIT_COMMIT_PLACEHOLDER
         # Bundle identifier of the in-bundle frameworks (Sparkle).


### PR DESCRIPTION
## What

Disable Sparkle in local builds that contain the placeholder EdDSA public key.

## Why

Local Release builds currently start Sparkle even though they cannot verify updates. This produces an "Unable to Check for Updates" alert. Debug and benchmark builds already avoid that failure.

## How

Start Sparkle only for non-Debug, non-benchmark builds with a nonempty, non-placeholder public key. CI release builds inject the real key and retain normal update behavior.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

## Notes for reviewers

The existing placeholder becomes an explicit local-build disable switch. Distributed release behavior is unchanged.
