### PR TITLE
Add a setting to keep the agent logo instead of the busy spinner (#225)

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -155,6 +155,16 @@ final class Preferences {
         didSet { defaults.set(showTabStatusIndicator, forKey: Keys.showTabStatusIndicator) }
     }
 
+    /// Whether the running spinner also replaces an AI agent's logo (#225).
+    /// Off keeps the agent logo while the agent works — agent CLIs draw their
+    /// own busy indicator in the tab title, so the spinner is redundant there —
+    /// while the done dot still appears (it overlays the logo rather than
+    /// replacing it). Meaningful only while `showTabStatusIndicator` and
+    /// `showAgentIcons` are both on.
+    var showSpinnerOverAgentIcons: Bool {
+        didSet { defaults.set(showSpinnerOverAgentIcons, forKey: Keys.showSpinnerOverAgentIcons) }
+    }
+
     /// Auto-name tabs after the live foreground process / OSC title (on by
     /// default). Off = tabs hold their static fallback (login shell name, or
     /// the host name for remote panes); a user-set custom title always wins
@@ -585,6 +595,7 @@ final class Preferences {
         tabIconSymbol = defaults.string(forKey: Keys.tabIconSymbol) ?? "terminal"
         showAgentIcons = defaults.object(forKey: Keys.showAgentIcons) as? Bool ?? true
         showTabStatusIndicator = defaults.object(forKey: Keys.showTabStatusIndicator) as? Bool ?? false
+        showSpinnerOverAgentIcons = defaults.object(forKey: Keys.showSpinnerOverAgentIcons) as? Bool ?? true
         autoNameTabs = defaults.object(forKey: Keys.autoNameTabs) as? Bool ?? true
         showNewProjectButton = defaults.object(forKey: Keys.showNewProjectButton) as? Bool ?? true
         backgroundSSHConnections = defaults.object(forKey: Keys.backgroundSSHConnections) as? Bool ?? true
@@ -682,6 +693,7 @@ final class Preferences {
         static let tabIconSymbol = "macterm.sidebar.tabIcon"
         static let showAgentIcons = "macterm.sidebar.showAgentIcons"
         static let showTabStatusIndicator = "macterm.sidebar.showTabStatusIndicator"
+        static let showSpinnerOverAgentIcons = "macterm.sidebar.showSpinnerOverAgentIcons"
         static let autoNameTabs = "macterm.tabs.autoName"
         static let showNewProjectButton = "macterm.sidebar.showNewProjectButton"
         static let backgroundSSHConnections = "macterm.remote.backgroundSSHConnections"

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -628,6 +628,7 @@ private struct AppearanceSettings: View {
     @State private var tabIconSymbol: String = Preferences.shared.tabIconSymbol
     @State private var showAgentIcons: Bool = Preferences.shared.showAgentIcons
     @State private var showTabStatusIndicator: Bool = Preferences.shared.showTabStatusIndicator
+    @State private var showSpinnerOverAgentIcons: Bool = Preferences.shared.showSpinnerOverAgentIcons
     @State private var autoNameTabs: Bool = Preferences.shared.autoNameTabs
     @State private var peekSidebarWhenHidden: Bool = Preferences.shared.peekSidebarWhenHidden
     @State private var showNewProjectButton: Bool = Preferences.shared.showNewProjectButton
@@ -756,6 +757,19 @@ private struct AppearanceSettings: View {
                     }
                 Text("Shows a spinner while a command runs, and a dot when it finishes.")
                     .settingsCaption()
+
+                Group {
+                    Toggle(isOn: $showSpinnerOverAgentIcons) {
+                        Text("Show spinner over agent icons").dimsWhenDisabled()
+                    }
+                    .onChange(of: showSpinnerOverAgentIcons) { _, v in
+                        Preferences.shared.showSpinnerOverAgentIcons = v
+                    }
+                    Text("When off, a tab running an AI agent keeps its logo while busy. The completion dot still appears.")
+                        .settingsCaption()
+                }
+                .disabled(!(showTabStatusIndicator && showAgentIcons))
+                .padding(.leading, 16)
 
                 Toggle("Show New Project button", isOn: $showNewProjectButton)
                     .onChange(of: showNewProjectButton) { _, v in Preferences.shared.showNewProjectButton = v }

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -670,6 +670,8 @@ private struct SidebarTabRow: View {
     private var showAgentIcons = true
     @AppStorage(Preferences.Keys.showTabStatusIndicator)
     private var showTabStatusIndicator = false
+    @AppStorage(Preferences.Keys.showSpinnerOverAgentIcons)
+    private var showSpinnerOverAgentIcons = true
     @State
     private var isRenaming = false
     @State
@@ -733,7 +735,13 @@ private struct SidebarTabRow: View {
                         // sentinel as an invisible Image that still reserves
                         // the icon column, nudging the title right of every
                         // other icon-less row.
-                        TabStatusGlyph(state: tab.executionState, symbol: tabIconSymbol, index: index, agent: agentIcon)
+                        TabStatusGlyph(
+                            state: tab.executionState,
+                            symbol: tabIconSymbol,
+                            index: index,
+                            agent: agentIcon,
+                            spinnerOverAgent: showSpinnerOverAgentIcons
+                        )
                     } else if let agentIcon {
                         // "None" suppresses the user's icon, not the agent
                         // logo — a live status signal, like the else branch.
@@ -747,7 +755,13 @@ private struct SidebarTabRow: View {
                     titleContent
                 } icon: {
                     if showTabStatusIndicator {
-                        TabStatusGlyph(state: tab.executionState, symbol: tabIconSymbol, index: index, agent: agentIcon)
+                        TabStatusGlyph(
+                            state: tab.executionState,
+                            symbol: tabIconSymbol,
+                            index: index,
+                            agent: agentIcon,
+                            spinnerOverAgent: showSpinnerOverAgentIcons
+                        )
                     } else {
                         SidebarRowIcon(symbol: tabIconSymbol, index: index, agent: agentIcon)
                             .foregroundStyle(.secondary)
@@ -787,26 +801,37 @@ private struct SidebarTabRow: View {
 /// suggestion): the user's chosen icon stays put, and status is additive.
 ///
 /// - `running`: a small spinner replaces the icon (temporary prominence,
-///   Xcode-build-navigator style).
+///   Xcode-build-navigator style) — unless the icon is an AI agent's logo and
+///   the user turned "Show spinner over agent icons" off (#225): agent CLIs
+///   draw their own busy indicator in the tab title, so the logo can stay put.
 /// - `done` (needs attention): the icon with a small solid status dot in the
 ///   bottom-trailing corner — like the Messages/FaceTime "available" dot. A
 ///   dot reads as "done/positive" without competing with the icon's identity,
 ///   and it avoids the heavy, off-platform look of a checkmark glyph badge.
+///   It overlays the agent logo the same way, regardless of the spinner
+///   preference — "unread agent messages" is the signal #225 asked to keep.
 /// - `idle`: the icon as-is.
 private struct TabStatusGlyph: View {
     let state: TerminalExecutionState
     let symbol: String
     let index: Int
     var agent: AgentIcon?
+    var spinnerOverAgent = true
 
     var body: some View {
         switch state {
         case .running:
-            ProgressView()
-                .controlSize(.small)
-                .tint(.secondary)
-                .help("Running")
-                .frame(width: 16, height: 16)
+            if let agent, !spinnerOverAgent {
+                SidebarRowIcon(symbol: symbol, index: index, agent: agent)
+                    .foregroundStyle(.secondary)
+                    .help("Running")
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.secondary)
+                    .help("Running")
+                    .frame(width: 16, height: 16)
+            }
         case .done:
             SidebarRowIcon(symbol: symbol, index: index, agent: agent)
                 .foregroundStyle(.secondary)


### PR DESCRIPTION
Closes #225.

## What

A nested toggle in **Settings → Appearance → Sidebar**, indented under "Show tab status indicator": **Show spinner over agent icons** (default **on**, preserving current behavior). It is enabled only while both "Show tab status indicator" and "Show AI agent icons" are on, and dims (with its caption) otherwise.

When turned off, a tab running an AI agent keeps the agent's logo while busy instead of the spinner — agent CLIs draw their own busy indicator in the tab title, so the spinner is redundant there. The **completion dot is untouched**: it already overlays the icon (agent logo included) rather than replacing it, so "unread agent messages" — the half of the behavior #225 explicitly asked to keep — still shows regardless of this setting. Tabs running ordinary programs also keep the spinner regardless.

## How

- `Preferences.showSpinnerOverAgentIcons` (`macterm.sidebar.showSpinnerOverAgentIcons`, default true).
- `TabStatusGlyph`'s `.running` case renders the agent `SidebarRowIcon` instead of the `ProgressView` when an agent icon is present and the preference is off; `.done` and `.idle` are unchanged.
- The "None" tab-icon branch already includes `agentIcon != nil` in its draw condition, so the logo-while-running case works there too.
- The settings row uses the existing `dimsWhenDisabled()` / `settingsCaption()` pattern so the label and caption fade with the disabled scope.

No new tests: the toggles are display-only view branches (UI is not unit-tested by convention), and `mise run format`, `lint`, and `test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)