### PR TITLE
Add a Close Tab command shared by pinned and normal tabs

### DIFF
--- a/Macterm/App/AppCommand.swift
+++ b/Macterm/App/AppCommand.swift
@@ -10,6 +10,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
     // Tabs
     case newTab
     case closePane
+    case closeTab
     case renameTab
     case nextTab
     case previousTab
@@ -61,6 +62,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         switch self {
         case .newTab: "New Tab"
         case .closePane: "Close Pane"
+        case .closeTab: "Close Tab"
         case .renameTab: "Rename Current Tab"
         case .nextTab: "Next Tab"
         case .previousTab: "Previous Tab"
@@ -109,6 +111,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         switch self {
         case .newTab,
              .closePane,
+             .closeTab,
              .renameTab,
              .nextTab,
              .previousTab,
@@ -159,6 +162,7 @@ enum AppCommand: String, CaseIterable, Identifiable {
         switch self {
         case .newTab: .newTab
         case .closePane: .closePane
+        case .closeTab: .closeTab
         case .nextTab: .nextGlobalTab
         case .previousTab: .previousGlobalTab
         case .nextTabInProject: .nextTabInProject

--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -30,6 +30,14 @@ extension AppCommand {
                     ctx.appState.requestClosePane(pane.id, projectID: projectID)
                 }
             }
+        case .closeTab:
+            // Close the active tab — pinned or normal. `requestCloseTab` owns
+            // the busy confirmation and routes a pinned tab to the unload path
+            // (sessions end, the record stays), so one command serves both.
+            guard let projectID,
+                  let tab = ctx.appState.workspaces[projectID]?.activeTab
+            else { return nil }
+            return { ctx.appState.requestCloseTab(tab.id, projectID: projectID) }
         case .nextTab:
             return { ctx.appState.selectGlobalTab(.next, projects: ctx.projectStore.projects) }
         case .previousTab:

--- a/Macterm/App/AppState+PinnedTabs.swift
+++ b/Macterm/App/AppState+PinnedTabs.swift
@@ -118,46 +118,6 @@ extension AppState {
         saveWorkspaces()
     }
 
-    /// Remove a pin ENTIRELY — the record, its `pinned.yaml` entry, and (when
-    /// loaded) the live tab with its sessions. The one pinned action that
-    /// kills, hence the busy confirmation; for an unloaded record there is
-    /// nothing running and it reduces to forgetting the declaration.
-    func requestRemovePinnedTab(_ tabID: UUID) {
-        let busy = pinnedWorkspace?.tabs
-            .first { $0.id == tabID }?
-            .splitRoot.allPanes()
-            .contains(where: \.needsConfirmClose) ?? false
-        if busy {
-            pendingRemovePinnedTab = AppState.PendingRemovePinnedTab(tabID: tabID)
-            return
-        }
-        removePinnedTab(tabID)
-    }
-
-    func confirmPendingRemovePinnedTab() {
-        guard let pending = pendingRemovePinnedTab else { return }
-        pendingRemovePinnedTab = nil
-        removePinnedTab(pending.tabID)
-    }
-
-    func cancelPendingRemovePinnedTab() {
-        pendingRemovePinnedTab = nil
-    }
-
-    func removePinnedTab(_ tabID: UUID) {
-        guard pinnedRecord(tabID) != nil else { return }
-        logger.info("removePinnedTab: \(tabID, privacy: .public)")
-        if let ws = pinnedWorkspace, let tab = ws.tabs.first(where: { $0.id == tabID }) {
-            for pane in tab.splitRoot.allPanes() {
-                pane.killPersistentSession(using: zmx)
-                pane.destroySurface()
-            }
-            ws.closeTab(tabID)
-        }
-        removePinnedRecord(forTab: tabID)
-        saveWorkspaces()
-    }
-
     /// Drop a record after its tab left the pinned workspace (a moveTab /
     /// merge out). The workspace side is the caller's job.
     func removePinnedRecord(forTab tabID: UUID) {

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -161,15 +161,6 @@ final class AppState {
 
     var pendingCloseTab: PendingCloseTab?
 
-    /// A pinned-tab REMOVAL staged for confirmation — unlike closing a
-    /// pinned tab (an unload that keeps the record), removal kills the
-    /// sessions AND forgets the pin, so a running program confirms first.
-    struct PendingRemovePinnedTab: Equatable {
-        let tabID: UUID
-    }
-
-    var pendingRemovePinnedTab: PendingRemovePinnedTab?
-
     /// A project removal staged for confirmation, same busy rule as tabs.
     /// Carries the full removal (AppState workspace + ProjectStore entry) as
     /// a closure, since the store lives with the caller.

--- a/Macterm/App/Hotkeys.swift
+++ b/Macterm/App/Hotkeys.swift
@@ -11,6 +11,7 @@ final class HotkeyCaptureState {
 enum HotkeyAction: String, CaseIterable, Identifiable {
     case newTab = "new_tab"
     case closePane = "close_pane"
+    case closeTab = "close_tab"
     case splitRight = "split_right"
     case splitDown = "split_down"
     case splitAuto = "split_auto"
@@ -66,6 +67,10 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         switch self {
         case .newTab: "cmd+t"
         case .closePane: "cmd+w"
+        // Unbound by default: cmd+w already closes the tab pane-by-pane, and
+        // a whole-tab close on a stray chord ends every session in it (busy
+        // panes still confirm; a pinned tab only unloads).
+        case .closeTab: "none"
         case .splitRight: "cmd+d"
         case .splitDown: "cmd+shift+d"
         case .splitAuto: "none"

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -60,22 +60,6 @@ struct MactermApp: App {
                 } message: {
                     Text("A process is still running in this tab. Closing the tab ends it.")
                 }
-                .alert(
-                    "Remove pinned tab with running processes?",
-                    isPresented: Binding(
-                        get: { appState.pendingRemovePinnedTab != nil },
-                        set: { if !$0 { appState.cancelPendingRemovePinnedTab() } }
-                    )
-                ) {
-                    Button("Cancel", role: .cancel) {
-                        appState.cancelPendingRemovePinnedTab()
-                    }
-                    Button("Remove", role: .destructive) {
-                        appState.confirmPendingRemovePinnedTab()
-                    }
-                } message: {
-                    Text("A process is still running in this tab. Removing the pin ends it and forgets the saved layout.")
-                }
                 // Every alert below that Settings also carries is gated on the
                 // staging call's `DialogHost` — see the enum's doc comment: an
                 // ungated binding presents in BOTH scenes, which opens the
@@ -202,6 +186,7 @@ struct MactermApp: App {
                 )
                 Divider()
                 AppCommandMenuItem(command: .closePane, appState: appState, projectStore: projectStore, titleOverride: "Close Pane")
+                AppCommandMenuItem(command: .closeTab, appState: appState, projectStore: projectStore, titleOverride: "Close Tab")
                 AppCommandMenuItem(command: .closeWindow, appState: appState, projectStore: projectStore, titleOverride: "Close Window")
             }
             CommandGroup(replacing: .sidebar) {

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -340,6 +340,7 @@ final class MainAppResponder: KeyResponder {
             .separateCurrentPane,
             .pinTab,
             .unpinTab,
+            .closeTab,
         ] {
             guard HotkeyRegistry.matches(event, action: action),
                   let command = AppCommand.allCases.first(where: { $0.hotkeyAction == action })

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -601,10 +601,11 @@ struct SidebarContent: View {
         }
     }
 
-    /// A pinned row's menu — three exits with distinct semantics: Unpin (a
-    /// move back to a project, nothing killed), Close (an unload: processes
-    /// end, the row and layout stay), and Remove from Pinned (gone for good,
-    /// busy-confirmed).
+    /// A pinned row's menu — two exits with distinct semantics: Unpin (a
+    /// move back to a project for a loaded tab, nothing killed; forgetting
+    /// the declaration for an unloaded record — the removal path) and Close
+    /// (an unload: processes end, the row and layout stay), matching the
+    /// normal tab menu's Close Tab.
     @ViewBuilder
     private func pinnedTabMenu(record: PinnedTabRecord) -> some View {
         let isLoaded = appState.isPinnedTabLoaded(record.id)
@@ -644,22 +645,20 @@ struct SidebarContent: View {
             }
         }
         Divider()
+        // Unpin = a MOVE back to the origin project for a loaded tab (nothing
+        // killed); an unloaded record has no live tab, so unpinning forgets
+        // the declaration — how a dead row is removed.
+        Button("Unpin Tab") {
+            appState.unpinTab(record.id, projects: projectStore.projects)
+        }
         if isLoaded {
-            // Unpin = a MOVE back to the origin project (nothing killed).
-            Button("Unpin Tab") {
-                appState.unpinTab(record.id, projects: projectStore.projects)
-            }
             // Close = UNLOAD: processes end, the dimmed row and its saved
-            // layout stay, and the next launch starts it again.
+            // layout stay, and the next launch starts it again. Same entry
+            // point as the normal tab menu's Close Tab and the closeTab
+            // command — `requestCloseTab` routes pinned tabs to the unload.
             Button("Close Tab", role: .destructive) {
                 appState.requestCloseTab(record.id, projectID: PinnedTabs.projectID)
             }
-        }
-        // Remove = gone for good: sessions end (busy-confirmed), the record
-        // and its pinned.yaml entry are forgotten. For an unloaded record
-        // nothing is running, so it just forgets the declaration.
-        Button("Remove from Pinned", role: .destructive) {
-            appState.requestRemovePinnedTab(record.id)
         }
     }
 

--- a/MactermTests/App/PinnedTabsTests.swift
+++ b/MactermTests/App/PinnedTabsTests.swift
@@ -128,60 +128,36 @@ struct PinnedTabsTests {
         #expect(fx.state.pinnedRecords.isEmpty)
     }
 
-    // MARK: - Remove from pinned
-
-    @Test
-    func removePinnedTab_idle_removes_record_and_live_tab() throws {
-        let fx = makeFixture()
-        let p = seedProject(fx.state)
-        let tab = try #require(fx.state.workspaces[p.id]?.activeTab)
-        fx.state.pinTab(tab.id, fromProject: p.id)
-
-        fx.state.requestRemovePinnedTab(tab.id)
-
-        #expect(fx.state.pinnedRecords.isEmpty)
-        #expect(fx.state.pinnedWorkspace?.tabs.isEmpty == true)
-        #expect(fx.state.pendingRemovePinnedTab == nil)
-    }
-
-    @Test
-    func removePinnedTab_confirmation_flow_removes_on_confirm() throws {
-        let fx = makeFixture()
-        let p = seedProject(fx.state)
-        let tab = try #require(fx.state.workspaces[p.id]?.activeTab)
-        fx.state.pinTab(tab.id, fromProject: p.id)
-
-        // Stage manually (busy detection needs a live surface — the same
-        // convention as the other pending-confirmation tests).
-        fx.state.pendingRemovePinnedTab = AppState.PendingRemovePinnedTab(tabID: tab.id)
-
-        fx.state.cancelPendingRemovePinnedTab()
-        #expect(fx.state.pendingRemovePinnedTab == nil)
-        #expect(fx.state.pinnedRecords.count == 1)
-
-        fx.state.pendingRemovePinnedTab = AppState.PendingRemovePinnedTab(tabID: tab.id)
-        fx.state.confirmPendingRemovePinnedTab()
-        #expect(fx.state.pendingRemovePinnedTab == nil)
-        #expect(fx.state.pinnedRecords.isEmpty)
-        #expect(fx.state.pinnedWorkspace?.tabs.isEmpty == true)
-    }
-
-    @Test
-    func removePinnedTab_unloaded_forgets_the_record() {
-        let fx = makeFixture()
-        let record = PinnedTabRecord(
-            id: UUID(),
-            declaration: LayoutTab(layout: .pane(LayoutPane(run: "btop"))),
-            originProjectID: nil
-        )
-        fx.state.pinnedRecords = [record]
-
-        fx.state.requestRemovePinnedTab(record.id)
-
-        #expect(fx.state.pinnedRecords.isEmpty)
-    }
-
     // MARK: - Close = unload
+
+    /// One `AppCommand.closeTab` serves both kinds of tab: on the pinned
+    /// workspace it unloads (record kept), on a project it closes for good.
+    @Test
+    func closeTab_command_unloads_pinned_and_closes_normal_tabs() throws {
+        let fx = makeFixture()
+        let storeTmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macterm-tests-projstore-\(UUID().uuidString).json")
+        let ctx = AppCommandContext(appState: fx.state, projectStore: ProjectStore(fileURL: storeTmp))
+        let p = seedProject(fx.state)
+        let tab = try #require(fx.state.workspaces[p.id]?.activeTab)
+        fx.state.pinTab(tab.id, fromProject: p.id)
+
+        // Active tab is the pinned one → close unloads, keeping the record.
+        // (Bound before calling: invoking the `#require` result directly
+        // crashes the Swift 6.3 frontend.)
+        let closePinned = try #require(AppCommand.closeTab.action(in: ctx))
+        closePinned()
+        #expect(fx.state.pinnedWorkspace?.tabs.isEmpty == true)
+        #expect(fx.state.pinnedRecords.map(\.id) == [tab.id])
+
+        // Back on the project (pinning moved its only tab out, so make a
+        // fresh one), close removes the tab outright.
+        fx.state.activeProjectID = p.id
+        _ = try #require(fx.state.createTab(projectID: p.id, projectPath: p.path))
+        let closeNormal = try #require(AppCommand.closeTab.action(in: ctx))
+        closeNormal()
+        #expect(fx.state.workspaces[p.id]?.tabs.isEmpty == true)
+    }
 
     @Test
     func requestCloseTab_unloads_pinned_tab_keeping_the_record() throws {


### PR DESCRIPTION
## What

Adds a `Close Tab` action to the shared `AppCommand` collection — so it shows up in the command palette, the File menu (between Close Pane and Close Window), and Settings → Keymaps as a rebindable hotkey (unbound by default) — and reworks the pinned row's context menu to end with the same **Unpin Tab / Close Tab** pair a normal tab gets, dropping **Remove from Pinned**.

## Why

Closing a tab was reachable only from the sidebar context menus; there was no palette command or bindable chord for it. And the pinned menu's "Remove from Pinned" contradicted both the design ("Unpin is the removal path") and the published docs, which already claimed "the only way a pinned tab actually goes away is unpinning it."

## How

- One `AppCommand.closeTab` closes the **active tab, pinned or normal**: its action calls `requestCloseTab`, which already owns the busy confirmation and routes pinned tabs to the unload path (sessions end, the dimmed row and saved layout stay). The context menu buttons keep calling the same entry point, so the paths can't drift.
- **Unpin Tab** now also shows for unloaded (dimmed) pinned rows — `unpinTab` already handled that case by forgetting the declaration, and it becomes the menu's removal path for a dead row (previously only "Remove from Pinned" could clear one).
- With its only entry point gone, the remove-pinned machinery is deleted: `requestRemovePinnedTab`/`removePinnedTab`, the confirm/cancel pair, the `PendingRemovePinnedTab` staging struct, and its alert in `MactermApp`.
- The new hotkey ships unbound: cmd+w already closes the tab pane-by-pane, and a whole-tab close on a stray chord ends every session in it.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

## Notes for reviewers

- The three `removePinnedTab` tests are replaced by `closeTab_command_unloads_pinned_and_closes_normal_tabs`, which drives the real `AppCommand.closeTab` action against both tab kinds. It binds the `#require`d closure to a local before calling it — `try #require(...)()` crashes the Swift 6.3 frontend (constraint-system assertion); there's a comment on it.
- `website/docs/pages/55-pinned-tabs.md` needed no change — it already describes this end state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)