### PR TITLE
Mirror ghostty's pane-local drop-zone algorithm in the drag overlay

### DIFF
--- a/Macterm/Model/TabDropPlacement.swift
+++ b/Macterm/Model/TabDropPlacement.swift
@@ -1,11 +1,14 @@
 import CoreGraphics
 import Foundation
 
-/// Where a sidebar tab dragged over the workspace would land (#227). The
-/// cursor picks a LEVEL in the split tree, not just a side of the hovered
-/// pane, so one drag can produce a whole-edge pane, an equal sibling at a
-/// divider, or a plain local split.
+/// Where a drag over the workspace would land (#227): a resolved drop target
+/// plus the workspace-normalized rect it would occupy.
 struct TabDropResolution: Equatable {
+    /// The placement grammar shared by pane drags, sidebar-tab merges, and
+    /// the headless debug verbs (`pane move`, `tab merge`). Drags resolve
+    /// only to `.pane` — `TabDropPlacer` mirrors Ghostty's pane-local
+    /// algorithm — while `.rootEdge` and `.divider` stay expressible for the
+    /// CLI and `TerminalTab.mergeTree`.
     enum Target: Equatable {
         /// Split the whole workspace on this side: the dropped tree becomes a
         /// new top-level sibling, equalized along that axis.
@@ -18,135 +21,35 @@ struct TabDropResolution: Equatable {
     }
 
     let target: Target
-    /// Workspace-normalized rect the dropped tab would occupy — the drop
+    /// Workspace-normalized rect the dropped tree would occupy — the drop
     /// preview highlights exactly this region, so the user sees the outcome
     /// before releasing.
     let preview: CGRect
 }
 
-/// Resolves a workspace-normalized cursor point against the split tree.
+/// Resolves a workspace-normalized cursor point against the split tree,
+/// mirroring Ghostty's drop-zone algorithm (`TerminalSplitDropZone`): the
+/// drop is always LOCAL to the hovered pane. Its four triangular regions —
+/// formed by the pane's diagonals — pick the closest edge, and the preview
+/// is the half of that pane the drop would occupy.
 ///
-/// The rule of thumb is "drop where the new pane will appear":
-/// - Within `boundaryBand` of a workspace edge that lies on the root split's
-///   own axis → a new top-level sibling on that side (H(a,b) dropped far left
-///   becomes thirds).
-/// - Within `boundaryBand` of an internal divider → insert at that divider,
-///   equalized (H(a,b) dropped in the middle becomes thirds).
-/// - A side PERPENDICULAR to the root axis has no divider or edge band of its
-///   own, so its root-level band sits just past the workspace midline — e.g.
-///   with two columns, a whole-bottom pane is grabbed at "the top side of the
-///   bottom half" (`0.5...perpendicularBandEnd`), while dragging deeper stays
-///   a local split of the hovered pane.
-/// - Anywhere else → the hovered pane's four-triangle zone, split locally.
-///
-/// Deep trees are handled by the same bands: only the ROOT's direction picks
-/// same-axis vs perpendicular behavior, which keeps the rule predictable.
+/// Deliberately NO workspace-edge or divider escalation (an earlier revision
+/// had root-level and divider bands): every cursor position maps to exactly
+/// one pane + zone, so no two overlay shapes can describe the same final
+/// tree. The old root-edge band duplicated the local split whenever removing
+/// the dragged pane left a single sibling — H(a,b) with a in hand showed
+/// both a full-width top strip and b's top half for the same V(a,b) outcome.
 @MainActor
 enum TabDropPlacer {
-    /// Within this fraction of the workspace, an edge or divider captures the
-    /// drop and escalates it past the hovered pane.
-    static let boundaryBand: CGFloat = 0.15
-    /// A band may claim at most this fraction of the HOVERED pane's extent on
-    /// its axis. Without the cap, four side-by-side panes (each 0.25 wide)
-    /// are swallowed whole by the fixed workspace-relative bands — the edge
-    /// band claims x < 0.15 and the divider band claims x > 0.10 — leaving no
-    /// pixel that can express a top/bottom split. Capped, every pane keeps at
-    /// least the middle 40% of itself for the zone-driven placements. At two
-    /// panes the cap equals `boundaryBand`, so wide layouts are unchanged.
-    static let paneBandCap: CGFloat = 0.3
-    /// The far end of the perpendicular root band: between the midline and
-    /// this coordinate the drop splits the whole workspace; past it the drop
-    /// is local to the hovered pane.
-    static let perpendicularBandEnd: CGFloat = 0.75
-
     static func resolve(point: CGPoint, in root: SplitNode) -> TabDropResolution? {
         // Clamp inside the unit square so an edge-exact drop still lands in a
         // pane (CGRect.contains excludes max edges).
         let p = CGPoint(x: min(max(point.x, 0), 0.9999), y: min(max(point.y, 0), 0.9999))
-        let frames = root.paneFrames()
-        guard let hovered = frames.first(where: { $0.value.contains(p) }) else { return nil }
+        guard let hovered = root.paneFrames().first(where: { $0.value.contains(p) }) else { return nil }
         let (paneID, frame) = hovered
         let local = CGPoint(x: p.x - frame.minX, y: p.y - frame.minY)
         let zone = PaneDropZone.calculate(at: local, in: frame.size)
-
-        guard case let .split(rootBranch) = root else {
-            // A single pane: a root split IS the local split.
-            return TabDropResolution(target: .pane(paneID, zone), preview: paneHalf(frame, zone))
-        }
-
-        // Side-by-side placements on the ROOT's own axis claim their margins
-        // at FULL cross-axis extent, not gated by the hovered pane's corner
-        // triangles — otherwise the top/bottom zones pinch their hitbox near
-        // those edges and edge/divider drops get hard to hit at any height.
-        let rootAxis = rootBranch.direction
-        let alongRoot = rootAxis == .horizontal ? p.x : p.y
-        let rootUnits = root.tileUnits(along: rootAxis)
-        let rootFraction = 1 / CGFloat(rootUnits + 1)
-        let firstZone: PaneDropZone = rootAxis == .horizontal ? .left : .top
-        let secondZone: PaneDropZone = rootAxis == .horizontal ? .right : .bottom
-        let rootExtent = rootAxis == .horizontal ? frame.width : frame.height
-        let rootBand = min(boundaryBand, rootExtent * paneBandCap)
-        if alongRoot < rootBand {
-            return TabDropResolution(target: .rootEdge(firstZone), preview: edgeStrip(zone: firstZone, fraction: rootFraction))
-        }
-        if alongRoot > 1 - rootBand {
-            return TabDropResolution(target: .rootEdge(secondZone), preview: edgeStrip(zone: secondZone, fraction: rootFraction))
-        }
-        let leadEdge = rootAxis == .horizontal ? frame.minX : frame.minY
-        let trailEdge = rootAxis == .horizontal ? frame.maxX : frame.maxY
-        if leadEdge > 0.0001, abs(alongRoot - leadEdge) < rootBand {
-            return TabDropResolution(
-                target: .divider(paneID, firstZone),
-                preview: dividerStrip(at: leadEdge, fraction: rootFraction, crossing: frame, zone: firstZone)
-            )
-        }
-        if trailEdge < 0.9999, abs(alongRoot - trailEdge) < rootBand {
-            return TabDropResolution(
-                target: .divider(paneID, secondZone),
-                preview: dividerStrip(at: trailEdge, fraction: rootFraction, crossing: frame, zone: secondZone)
-            )
-        }
-
-        // Everything else is zone-driven: the perpendicular whole-edge band,
-        // nested (perpendicular-axis) dividers, and local pane splits.
-        let axis = zone.splitDirection
-        let edge = edgeCoordinate(of: frame, zone: zone)
-        let cursor = axis == .horizontal ? p.x : p.y
-        let workspaceEdge: CGFloat = zone.splitPosition == .first ? 0 : 1
-        let fraction = 1 / CGFloat(root.tileUnits(along: axis) + 1)
-
-        if abs(edge - workspaceEdge) < 0.0001 {
-            // The hovered pane's edge on this side IS the workspace boundary.
-            // A side perpendicular to the root axis has no divider or edge
-            // margin of its own, so its root-level band sits just past the
-            // midline; deeper is a local split of the hovered pane.
-            if rootBranch.direction != axis {
-                let inRootBand = zone.splitPosition == .second
-                    ? (cursor >= 0.5 && cursor < perpendicularBandEnd)
-                    : (cursor <= 0.5 && cursor > 1 - perpendicularBandEnd)
-                if inRootBand {
-                    return TabDropResolution(target: .rootEdge(zone), preview: edgeStrip(zone: zone, fraction: fraction))
-                }
-            }
-        } else if abs(cursor - edge) < min(boundaryBand, (axis == .horizontal ? frame.width : frame.height) * paneBandCap) {
-            // The pane's edge adjoins a sibling: insert at the divider.
-            return TabDropResolution(
-                target: .divider(paneID, zone),
-                preview: dividerStrip(at: edge, fraction: fraction, crossing: frame, zone: zone)
-            )
-        }
         return TabDropResolution(target: .pane(paneID, zone), preview: paneHalf(frame, zone))
-    }
-
-    // MARK: - Geometry helpers
-
-    private static func edgeCoordinate(of frame: CGRect, zone: PaneDropZone) -> CGFloat {
-        switch zone {
-        case .left: frame.minX
-        case .right: frame.maxX
-        case .top: frame.minY
-        case .bottom: frame.maxY
-        }
     }
 
     private static func paneHalf(_ frame: CGRect, _ zone: PaneDropZone) -> CGRect {
@@ -155,25 +58,6 @@ enum TabDropPlacer {
         case .right: CGRect(x: frame.midX, y: frame.minY, width: frame.width / 2, height: frame.height)
         case .top: CGRect(x: frame.minX, y: frame.minY, width: frame.width, height: frame.height / 2)
         case .bottom: CGRect(x: frame.minX, y: frame.midY, width: frame.width, height: frame.height / 2)
-        }
-    }
-
-    private static func edgeStrip(zone: PaneDropZone, fraction: CGFloat) -> CGRect {
-        switch zone {
-        case .left: CGRect(x: 0, y: 0, width: fraction, height: 1)
-        case .right: CGRect(x: 1 - fraction, y: 0, width: fraction, height: 1)
-        case .top: CGRect(x: 0, y: 0, width: 1, height: fraction)
-        case .bottom: CGRect(x: 0, y: 1 - fraction, width: 1, height: fraction)
-        }
-    }
-
-    /// A strip centered on the divider, spanning the hovered pane's extent on
-    /// the cross axis (so a nested divider previews within its own column).
-    private static func dividerStrip(at edge: CGFloat, fraction: CGFloat, crossing frame: CGRect, zone: PaneDropZone) -> CGRect {
-        let start = min(max(edge - fraction / 2, 0), 1 - fraction)
-        return switch zone.splitDirection {
-        case .horizontal: CGRect(x: start, y: frame.minY, width: fraction, height: frame.height)
-        case .vertical: CGRect(x: frame.minX, y: start, width: frame.width, height: fraction)
         }
     }
 }

--- a/Macterm/Views/PaneDragDrop.swift
+++ b/Macterm/Views/PaneDragDrop.swift
@@ -393,7 +393,7 @@ struct WorkspaceDropPreview: View {
 /// and SwiftUI's topmost-wins routing means a full-area target would shadow
 /// everything beneath. Each leaf converts its local location into workspace
 /// space via the pane's frame in the tree and resolves through the same
-/// `TabDropPlacer` into the shared resolution, so the placement bands and
+/// `TabDropPlacer` into the shared resolution, so the placement zones and
 /// preview are identical for every drag. The dragged pane's own leaf carries
 /// no target (a self-drop is meaningless and an invalid drop animates back).
 struct LeafDropDelegate: DropDelegate {
@@ -483,17 +483,15 @@ struct LeafDropDelegate: DropDelegate {
             )
             return TabDropPlacer.resolve(point: point, in: context.root)
         }
-        // A target aimed at the dragged pane itself is meaningless; show
-        // nothing rather than a lying preview.
-        if let dragged = context.draggedPaneID {
-            switch resolved?.target {
-            case let .pane(id, _) where id == dragged,
-                 let .divider(id, _) where id == dragged:
-                context.resolution.wrappedValue = nil
-                return
-            default:
-                break
-            }
+        // A target aimed at the dragged pane itself is meaningless (reachable
+        // despite the source leaf carrying no target: a point on the exact
+        // shared edge resolves into the neighbor); show nothing rather than a
+        // lying preview.
+        if let dragged = context.draggedPaneID,
+           case let .pane(id, _) = resolved?.target, id == dragged
+        {
+            context.resolution.wrappedValue = nil
+            return
         }
         context.resolution.wrappedValue = resolved
     }

--- a/MactermTests/Model/TabDropPlacementTests.swift
+++ b/MactermTests/Model/TabDropPlacementTests.swift
@@ -2,153 +2,104 @@ import Foundation
 @testable import Macterm
 import Testing
 
-/// Pins the "globality" bands from #227: where the cursor sits over the
-/// workspace decides the LEVEL of the split a dropped tab produces, not just
-/// the side. The scenarios mirror the issue discussion's two-columns
-/// examples.
+/// Pins the Ghostty-mirror drop algorithm: a drag resolves purely LOCALLY to
+/// the hovered pane — its four triangular edge zones pick the closest edge
+/// and the preview is that pane's half. Never a root-edge or divider target:
+/// the old workspace bands could show two different overlays for the same
+/// final tree (H(a,b) with a in hand: a full-width top strip and b's top
+/// half both produced V(a,b)).
 @MainActor
 struct TabDropPlacementTests {
     private func twoColumns() -> (SplitNode, [String: UUID]) {
         build(H(pane("a"), pane("b")))
     }
 
-    // MARK: - Same-axis bands (side-by-side-by-side)
+    // MARK: - Triangular zones (relative to the hovered pane)
 
     @Test
-    func far_out_at_the_workspace_edge_targets_the_root() throws {
-        let (root, _) = twoColumns()
-        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.05, y: 0.5), in: root))
-        #expect(r.target == .rootEdge(.left))
-        // Preview shows the even third the new column will take.
-        #expect(abs(r.preview.width - 1.0 / 3.0) < 0.001)
-        #expect(abs(r.preview.minX) < 0.001)
-        #expect(abs(r.preview.height - 1) < 0.001)
-    }
-
-    @Test
-    func between_edge_and_middle_splits_the_pane_locally() throws {
+    func top_zone_of_a_pane_previews_that_panes_top_half() throws {
         let (root, ids) = twoColumns()
-        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.2, y: 0.5), in: root))
-        #expect(try r.target == .pane(#require(ids["a"]), .left))
-        // Preview is the pane's half: the 1/4 1/4 1/2 outcome.
-        #expect(abs(r.preview.width - 0.25) < 0.001)
+        // Top-center of pane b — the user-visible case that used to also be
+        // reachable as a full-width rootEdge strip.
+        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.75, y: 0.1), in: root))
+        #expect(try r.target == .pane(#require(ids["b"]), .top))
+        #expect(r.preview == CGRect(x: 0.5, y: 0, width: 0.5, height: 0.5))
     }
 
     @Test
-    func the_middle_targets_the_divider() throws {
+    func zones_are_relative_to_the_pane_not_the_workspace() throws {
+        // Pane a spans x 0..0.5; its zone triangles normalize to ITS size, so
+        // x=0.45 (90% across the pane) is the right zone even though it sits
+        // left of the workspace midline.
         let (root, ids) = twoColumns()
-        let left = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.45, y: 0.5), in: root))
-        #expect(try left.target == .divider(#require(ids["a"]), .right))
-        let right = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.55, y: 0.5), in: root))
-        #expect(try right.target == .divider(#require(ids["b"]), .left))
-        // Both previews are the same middle third straddling the divider.
-        #expect(abs(left.preview.midX - 0.5) < 0.001)
-        #expect(abs(left.preview.width - 1.0 / 3.0) < 0.001)
-        #expect(left.preview == right.preview)
-    }
-
-    // MARK: - Perpendicular bands (whole bottom pane)
-
-    @Test
-    func just_past_the_midline_targets_the_whole_bottom() throws {
-        let (root, _) = twoColumns()
-        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.25, y: 0.6), in: root))
-        #expect(r.target == .rootEdge(.bottom))
-        // Preview: the full-width bottom half.
-        #expect(abs(r.preview.width - 1) < 0.001)
-        #expect(abs(r.preview.height - 0.5) < 0.001)
-        #expect(abs(r.preview.minY - 0.5) < 0.001)
+        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.45, y: 0.5), in: root))
+        #expect(try r.target == .pane(#require(ids["a"]), .right))
+        #expect(r.preview == CGRect(x: 0.25, y: 0, width: 0.25, height: 1))
     }
 
     @Test
-    func past_the_global_band_the_local_split_takes_over() throws {
-        let (root, ids) = twoColumns()
-        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.25, y: 0.8), in: root))
-        #expect(try r.target == .pane(#require(ids["a"]), .bottom))
+    func corner_and_center_ties_break_left_then_right_like_ghostty() throws {
+        // Ghostty's check order is left → right → top → bottom; corners and
+        // the exact center resolve to a horizontal zone, never top/bottom.
+        let (root, ids) = build(pane("a"))
+        let a = try #require(ids["a"])
+        #expect(try #require(TabDropPlacer.resolve(point: .zero, in: root)).target == .pane(a, .left))
+        #expect(try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.5, y: 0.5), in: root)).target == .pane(a, .left))
+        #expect(try #require(TabDropPlacer.resolve(point: CGPoint(x: 1, y: 1), in: root)).target == .pane(a, .right))
     }
 
     @Test
-    func side_by_side_margins_span_the_full_height() throws {
-        // The root-axis edge and divider bands are NOT gated by the corner
-        // triangles: a drop near the workspace edge or a divider reads as
-        // side-by-side at any height, even deep in a pane's bottom corner.
-        let (root, ids) = twoColumns()
-        let atEdge = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.05, y: 0.9), in: root))
-        #expect(atEdge.target == .rootEdge(.left))
-        let atDivider = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.45, y: 0.9), in: root))
-        #expect(try atDivider.target == .divider(#require(ids["a"]), .right))
-    }
-
-    @Test
-    func deep_in_a_pane_splits_that_pane_down() throws {
-        let (root, ids) = twoColumns()
-        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.25, y: 0.9), in: root))
-        #expect(try r.target == .pane(#require(ids["a"]), .bottom))
-        // Preview: that pane's bottom half only.
-        #expect(abs(r.preview.width - 0.5) < 0.001)
-        #expect(abs(r.preview.height - 0.5) < 0.001)
-    }
-
-    @Test
-    func the_top_band_mirrors_the_bottom() throws {
-        let (root, _) = twoColumns()
-        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.75, y: 0.4), in: root))
-        #expect(r.target == .rootEdge(.top))
-    }
-
-    // MARK: - Skinny panes (band cap)
-
-    /// Four equal columns; without the per-pane band cap the fixed 0.15
-    /// workspace bands swallow every pixel of every 0.25-wide pane and no
-    /// top/bottom placement is reachable at all.
-    private func fourColumns() -> (SplitNode, [String: UUID]) {
-        build(H(pane("a"), H(pane("b"), H(pane("c"), pane("d"), ratio: 0.5), ratio: 1.0 / 3.0), ratio: 0.25))
-    }
-
-    @Test
-    func skinny_pane_can_still_take_the_whole_bottom() throws {
-        let (root, _) = fourColumns()
-        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.125, y: 0.6), in: root))
-        #expect(r.target == .rootEdge(.bottom))
-    }
-
-    @Test
-    func skinny_pane_can_still_split_top_down_locally() throws {
-        let (root, ids) = fourColumns()
-        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.125, y: 0.9), in: root))
-        #expect(try r.target == .pane(#require(ids["a"]), .bottom))
-    }
-
-    @Test
-    func skinny_pane_keeps_proportional_edge_and_divider_bands() throws {
-        let (root, ids) = fourColumns()
-        // Bands shrink to 0.3 × 0.25 = 0.075 of the workspace.
-        let edge = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.05, y: 0.5), in: root))
-        #expect(edge.target == .rootEdge(.left))
-        let divider = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.24, y: 0.5), in: root))
-        #expect(try divider.target == .divider(#require(ids["a"]), .right))
-        // The middle of the pane stays out of both bands.
-        let mid = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.1, y: 0.5), in: root))
-        #expect(try mid.target == .pane(#require(ids["a"]), .left))
-    }
-
-    // MARK: - Structure edge cases
-
-    @Test
-    func single_pane_root_is_always_a_local_split() throws {
+    func single_pane_root_splits_locally() throws {
         let (root, ids) = build(pane("a"))
         let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.02, y: 0.5), in: root))
         #expect(try r.target == .pane(#require(ids["a"]), .left))
+        #expect(r.preview == CGRect(x: 0, y: 0, width: 0.5, height: 1))
     }
 
     @Test
-    func nested_divider_resolves_within_its_column() throws {
-        // Right column split vertically; hover near ITS internal divider.
+    func nested_pane_resolves_within_its_own_frame() throws {
+        // Right column split vertically; near b's bottom edge — the old
+        // algorithm escalated this to the b/c divider.
         let (root, ids) = build(H(pane("a"), V(pane("b"), pane("c"))))
         let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 0.75, y: 0.45), in: root))
-        #expect(try r.target == .divider(#require(ids["b"]), .bottom))
-        // Preview stays inside the right column.
-        #expect(abs(r.preview.minX - 0.5) < 0.001)
-        #expect(abs(r.preview.width - 0.5) < 0.001)
+        #expect(try r.target == .pane(#require(ids["b"]), .bottom))
+        #expect(r.preview == CGRect(x: 0.5, y: 0.25, width: 0.5, height: 0.25))
+    }
+
+    @Test
+    func out_of_range_points_clamp_into_the_nearest_pane() throws {
+        let (root, ids) = twoColumns()
+        let r = try #require(TabDropPlacer.resolve(point: CGPoint(x: 1.2, y: 0.5), in: root))
+        #expect(try r.target == .pane(#require(ids["b"]), .right))
+    }
+
+    // MARK: - No escalation, no duplicate outcomes
+
+    @Test
+    func every_point_resolves_to_the_hovered_panes_half_and_nothing_else() throws {
+        // Sweep a grid over two tree shapes: the target is always a local
+        // pane split whose preview is exactly half the hovered pane — the
+        // property that makes one final state reachable by one overlay only.
+        let trees = [twoColumns(), build(H(pane("a"), V(pane("b"), pane("c"))))]
+        for (root, _) in trees {
+            let frames = root.paneFrames()
+            for xi in 0 ... 20 {
+                for yi in 0 ... 20 {
+                    let point = CGPoint(x: CGFloat(xi) / 20, y: CGFloat(yi) / 20)
+                    let r = try #require(TabDropPlacer.resolve(point: point, in: root))
+                    guard case let .pane(paneID, zone) = r.target else {
+                        Issue.record("non-local target \(r.target) at \(point)")
+                        return
+                    }
+                    let frame = try #require(frames[paneID])
+                    let half = zone.splitDirection == .horizontal
+                        ? frame.width / 2
+                        : frame.height / 2
+                    let extent = zone.splitDirection == .horizontal ? r.preview.width : r.preview.height
+                    #expect(abs(extent - half) < 0.0001)
+                    #expect(frame.insetBy(dx: -0.0001, dy: -0.0001).contains(r.preview))
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

Rewrites `TabDropPlacer.resolve` to ghostty's drop-zone algorithm: a drag resolves purely locally to the hovered pane — closest edge via the four triangular regions formed by its diagonals — and the overlay previews that pane's half. The workspace-level escalation (root-edge bands, divider bands, the perpendicular midline band, the band cap) is removed.

## Why

The bands were the deviation from ghostty, and they made the overlay both ambiguous and unpredictable:

- **Duplicate representations of one outcome.** With two panes H(a,b) and a in hand, both the full-width root-edge top strip and b's local top half produced the identical final tree V(a,b) — once the dragged pane detaches, only one sibling remains, so "split the root" and "split the pane" collapse into the same result. The overlay showed two different shapes for one outcome.
- **Unpredictability.** Four overlapping band rules keyed off workspace-relative coordinates meant small cursor moves jumped between placement kinds. Ghostty's rule is one rule: every cursor position maps to exactly one pane + zone.

## How

- `PaneDropZone.calculate` already matched ghostty's `TerminalSplitDropZone.calculate` byte-for-byte (same tie-break order: left → right → top → bottom), so the placer just finds the hovered pane, computes the zone locally, and returns `.pane` + that pane's half as the preview.
- **The animation is kept**: `WorkspaceDropPreview`'s single workspace-spanning rect still morphs between positions — ghostty's own overlays are static per-leaf; ours still glides.
- **The `Target` grammar (`.rootEdge`/`.divider`) and model paths stay**: the headless debug verbs (`pane move`, `tab merge`, #227) and `TerminalTab.mergeTree` still exercise them; drags just never emit anything but `.pane`.
- Trimmed the now-unreachable `.divider` arm from `LeafDropDelegate`'s self-drop guard (the `.pane` arm stays — an exact-shared-edge point can resolve into the neighbor, which can be the dragged pane).

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [ ] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

`TabDropPlacementTests` rewritten to pin the mirror: the duplicate-overlay regression case, pane-relative zone normalization, ghostty's corner/center tie-breaks, nested trees, and a 21×21 grid sweep asserting every cursor position resolves to a local pane half.

## Notes for reviewers

Sidebar **tab** drags share this resolution, so they also became pane-local — the "drop mid-divider for thirds" placement is no longer reachable by drag (it never existed in ghostty either). It remains reachable via the debug CLI and model API; re-adding it scoped to tab payloads is a small follow-up if it's missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)