### PR TITLE
Recover a pane whose keyboard dies when focus leaves mid-IME-composition

### DIFF
--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -665,6 +665,10 @@ final class GhosttyTerminalNSView: NSView {
     func destroySurface() {
         isDestroyed = true
         clearCommandSubmissionEvidence()
+        // A composition in flight has nowhere left to commit — drop it before
+        // the surface goes, so a reattached surface starts uncomposed rather
+        // than inheriting a preedit that can never be resolved.
+        discardMarkedText()
         if let surface { ghostty_surface_free(surface) }
         surface = nil
         accessibilityScreenContentsCache = nil
@@ -872,6 +876,11 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func resignFirstResponder() -> Bool {
+        // Before super, while `inputContext` still resolves to ours. Focus
+        // moves off a pane constantly (tab switch, split focus, palette), and
+        // any of those landing mid-composition would otherwise strand
+        // `_markedRange` and kill plain-key input in this pane for good.
+        discardMarkedText()
         let result = super.resignFirstResponder()
         if result, let surface { ghostty_surface_set_focus(surface, false) }
         if result { syncSecureInputFocus(false) }
@@ -1671,9 +1680,12 @@ extension GhosttyTerminalNSView {
 extension GhosttyTerminalNSView: @preconcurrency NSTextInputClient {
     func insertText(_ string: Any, replacementRange: NSRange) {
         let text = (string as? String) ?? (string as? NSAttributedString)?.string ?? ""
-        guard !text.isEmpty else { return }
+        // A commit always ends the composition — including an empty one, which
+        // is how some input sources signal "abandon what you were composing".
+        // Clearing before the empty-text bail keeps `hasMarkedText` honest.
         _markedRange = NSRange(location: NSNotFound, length: 0)
         if let surface { ghostty_surface_preedit(surface, nil, 0) }
+        guard !text.isEmpty else { return }
         if currentKeyEvent != nil {
             keyTextAccumulator.append(text)
         } else if let surface {
@@ -1687,17 +1699,23 @@ extension GhosttyTerminalNSView: @preconcurrency NSTextInputClient {
         }
     }
 
+    /// `_markedRange` mirrors AppKit's composition state, so it is maintained on
+    /// EVERY call the input system makes — never gated on there being a surface.
+    /// A `guard let surface` here used to skip the bookkeeping, which desynced
+    /// the mirror from AppKit in both directions across a `destroySurface()`:
+    /// a composition begun without a surface read as not-composing, and one
+    /// ended without a surface stayed marked forever. The latter is the
+    /// damaging direction — see `discardMarkedText`.
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
-        guard let surface else { return }
         let text = (string as? String) ?? (string as? NSAttributedString)?.string ?? ""
         _markedRange = text.isEmpty ? NSRange(location: NSNotFound, length: 0) : NSRange(location: 0, length: text.utf16.count)
+        guard let surface else { return }
         text.withCString { ghostty_surface_preedit(surface, $0, UInt(text.utf8.count)) }
     }
 
     func unmarkText() {
-        guard let surface else { return }
         _markedRange = NSRange(location: NSNotFound, length: 0)
-        ghostty_surface_preedit(surface, nil, 0)
+        if let surface { ghostty_surface_preedit(surface, nil, 0) }
     }
 
     func selectedRange() -> NSRange {
@@ -1714,6 +1732,28 @@ extension GhosttyTerminalNSView: @preconcurrency NSTextInputClient {
 
     func hasMarkedText() -> Bool {
         _markedRange.location != NSNotFound
+    }
+
+    /// Abandons an in-flight IME composition, clearing both our mirror of it
+    /// and the input source's own state.
+    ///
+    /// AppKit does not promise an `unmarkText` (or a commit) when focus leaves
+    /// a view mid-composition, and a stranded `_markedRange` is not a cosmetic
+    /// leak: `keyDown`'s composing branch forwards NOTHING for an unmodified
+    /// key — not the translated text, not even an encoded keypress — so the
+    /// pane's keyboard goes dead for ordinary typing while modifier chords keep
+    /// working. Nothing in the view could recover from that state on its own,
+    /// because the only two exits (`insertText`/`unmarkText`) are calls the
+    /// input system makes and it believes the composition is already over.
+    ///
+    /// `discardMarkedText()` is what tells the input source to drop its half;
+    /// our own state is cleared first so a re-entrant callback can't revive it.
+    /// `inputContext` is read before `super.resignFirstResponder()` runs, since
+    /// AppKit returns nil for a view that is no longer the first responder.
+    func discardMarkedText() {
+        guard hasMarkedText() else { return }
+        unmarkText()
+        inputContext?.discardMarkedText()
     }
 
     func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {

--- a/MactermTests/Views/Terminal/GhosttyTerminalNSViewTests.swift
+++ b/MactermTests/Views/Terminal/GhosttyTerminalNSViewTests.swift
@@ -49,4 +49,81 @@ struct GhosttyTerminalNSViewTests {
         #expect(GhosttyTerminalNSView.cursor(for: GHOSTTY_MOUSE_SHAPE_WAIT) == nil)
         #expect(GhosttyTerminalNSView.cursor(for: GHOSTTY_MOUSE_SHAPE_PROGRESS) == nil)
     }
+
+    // MARK: - IME composition state
+
+    private func makeView() -> GhosttyTerminalNSView {
+        GhosttyTerminalNSView(
+            paneID: UUID(),
+            workingDirectory: "/tmp",
+            sessionName: "marked-text-test"
+        )
+    }
+
+    /// The mirror has to track AppKit's calls even with no surface attached —
+    /// it used to be gated on one, so a composition begun before the surface
+    /// existed read as not-composing.
+    @Test
+    func markedText_tracksCompositionWithoutASurface() {
+        let view = makeView()
+        #expect(!view.hasMarkedText())
+
+        view.setMarkedText("か", selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(view.hasMarkedText())
+        #expect(view.markedRange() == NSRange(location: 0, length: 1))
+    }
+
+    /// `unmarkText` was gated on a surface too — the damaging direction, since
+    /// a stranded range makes `keyDown` drop every unmodified key.
+    @Test
+    func markedText_unmarkClearsWithoutASurface() {
+        let view = makeView()
+        view.setMarkedText("か", selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(view.hasMarkedText())
+
+        view.unmarkText()
+
+        #expect(!view.hasMarkedText())
+        #expect(view.markedRange() == NSRange(location: NSNotFound, length: 0))
+    }
+
+    /// An empty commit is how some input sources abandon a composition, and it
+    /// bailed out ahead of the clear.
+    @Test
+    func markedText_emptyCommitEndsTheComposition() {
+        let view = makeView()
+        view.setMarkedText("か", selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(view.hasMarkedText())
+
+        view.insertText("", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(!view.hasMarkedText())
+    }
+
+    /// Focus leaving mid-composition is the path with no AppKit guarantee of an
+    /// `unmarkText`, and the one that left a pane unable to type.
+    @Test
+    func markedText_focusLossAbandonsTheComposition() {
+        let view = makeView()
+        view.setMarkedText("か", selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(view.hasMarkedText())
+
+        _ = view.resignFirstResponder()
+
+        #expect(!view.hasMarkedText())
+    }
+
+    /// A destroyed surface has nowhere to commit, so the preedit must not
+    /// outlive it into a reattached surface.
+    @Test
+    func markedText_surfaceTeardownAbandonsTheComposition() {
+        let view = makeView()
+        view.setMarkedText("か", selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(view.hasMarkedText())
+
+        view.destroySurface()
+
+        #expect(!view.hasMarkedText())
+    }
 }


### PR DESCRIPTION
## What

Discards an in-flight IME composition when a terminal pane loses focus, and stops three other paths from stranding `GhosttyTerminalNSView`'s `_markedRange`.

## Why

`_markedRange` mirrors AppKit's composition state, and its only two exits are `insertText` and `unmarkText` — both calls the *input system* makes. AppKit does not promise either one when focus leaves a view mid-composition, so nothing in the view could recover: the input source believes the composition is over and never calls again.

A stranded mirror is not a cosmetic leak. `keyDown`'s composing branch forwards **nothing** for an unmodified key — not the translated text, not even an encoded keypress:

```swift
} else if !hasMarkedText() {
    …forward the key…
}
```

So the pane silently stops accepting ordinary typing, for the life of the pane, while modifier chords (which take the earlier `.control`/`.command` branches) keep working. Focus leaves a pane constantly — tab switch, split-focus move, command palette — so any of those landing mid-composition was enough.

## How

`discardMarkedText()` clears our mirror and the surface's preedit, then tells the input source to drop its half. Called from `resignFirstResponder` **before** `super`, since AppKit returns nil `inputContext` for a view that is no longer the first responder. Our own state is cleared first, so a re-entrant callback can't revive it.

Three adjacent strandings shared the cause and went with it:

- `setMarkedText` and `unmarkText` gated their bookkeeping on a live surface (`guard let surface else { return }`), which desynced the mirror from AppKit in both directions across a `destroySurface()` — a composition begun without a surface read as not-composing, one ended without a surface stayed marked forever. The mirror is now maintained on every call; only the `ghostty_surface_preedit` notification stays conditional.
- `insertText` bailed on empty text *ahead of* the clear. An empty commit is how some input sources say "abandon what you were composing", so it now clears first and bails after.
- `destroySurface` discards as well, so a reattached surface can't inherit a preedit that has nowhere left to commit.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [ ] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

Five tests in `GhosttyTerminalNSViewTests` cover the composition lifecycle without a live surface. I confirmed they are load-bearing by stashing the source change and re-running: all five fail against the unfixed source and pass with it.

## Notes for reviewers

**The manual-in-app check is the gap.** Reproducing the original state needs a real IME composition interrupted by a focus change, which needs a non-Latin input source and an Accessibility grant to drive synthetically — so this is verified at the unit level only. Worth a hands-on pass by someone who types with an IME day to day: start a composition in a pane, switch tabs mid-syllable, come back, and confirm plain keys still reach the shell.

One judgement call worth a look: `discardMarkedText()` is named after the `NSTextInputContext` method it delegates to, and lives in the `NSTextInputClient` conformance extension next to the rest of the marked-text machinery even though it isn't part of that protocol. Happy to rename or relocate it if that reads as confusing.
