### PR TITLE
fix: play sounds for terminal notifications

### DIFF
--- a/Macterm/App/NotificationHandler.swift
+++ b/Macterm/App/NotificationHandler.swift
@@ -12,14 +12,29 @@ private let logger = Logger(subsystem: appBundleID, category: "NotificationHandl
 @MainActor
 final class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
     static let shared = NotificationHandler()
+    static let authorizationOptions: UNAuthorizationOptions = [.alert, .sound]
+    nonisolated static let foregroundPresentationOptions: UNNotificationPresentationOptions = [.banner, .sound]
     weak var appState: AppState?
 
     func requestAuthorization() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { granted, _ in
+        UNUserNotificationCenter.current().requestAuthorization(options: Self.authorizationOptions) { granted, _ in
             if !granted {
                 logger.notice("Macterm notification authorization denied")
             }
         }
+    }
+
+    static func makeContent(
+        title: String,
+        body: String,
+        userInfo: [AnyHashable: Any]
+    ) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        content.userInfo = userInfo
+        return content
     }
 
     nonisolated func userNotificationCenter(
@@ -68,6 +83,6 @@ final class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
         willPresent _: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        completionHandler([])
+        completionHandler(Self.foregroundPresentationOptions)
     }
 }

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -419,14 +419,15 @@ private struct TerminalSurface: NSViewRepresentable {
     /// so the desktop-notification and command-finished paths can't drift and
     /// silently break tap-routing for one of them.
     private static func postPaneNotification(pane: Pane, title: String, body: String) {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
-        content.userInfo = [
-            "paneID": pane.id.uuidString,
-            "projectID": pane.projectID.uuidString,
-            "isQuickTerminal": pane.projectID == QuickTerminalService.ephemeralProjectID,
-        ]
+        let content = NotificationHandler.makeContent(
+            title: title,
+            body: body,
+            userInfo: [
+                "paneID": pane.id.uuidString,
+                "projectID": pane.projectID.uuidString,
+                "isQuickTerminal": pane.projectID == QuickTerminalService.ephemeralProjectID,
+            ]
+        )
         let request = UNNotificationRequest(
             identifier: "macterm-\(pane.id.uuidString)-\(UUID().uuidString)",
             content: content,

--- a/MactermTests/App/NotificationHandlerTests.swift
+++ b/MactermTests/App/NotificationHandlerTests.swift
@@ -1,0 +1,27 @@
+@testable import Macterm
+import Testing
+import UserNotifications
+
+@MainActor
+struct NotificationHandlerTests {
+    @Test
+    func requests_the_same_alert_and_sound_permissions_as_ghostty() {
+        #expect(NotificationHandler.authorizationOptions == [.alert, .sound])
+    }
+
+    @Test
+    func notification_content_uses_the_default_system_sound() {
+        let content = NotificationHandler.makeContent(
+            title: "Title",
+            body: "Body",
+            userInfo: [:]
+        )
+
+        #expect(content.sound?.isEqual(UNNotificationSound.default) == true)
+    }
+
+    @Test
+    func foreground_notifications_present_with_a_banner_and_sound() {
+        #expect(NotificationHandler.foregroundPresentationOptions == [.banner, .sound])
+    }
+}


### PR DESCRIPTION
Match Ghostty and standard macOS app behavior by playing the default system sound for notifications.

Not everyone might want notification sounds, but they can be turned off for Macterm in macOS System Settings → Notifications.