### PR TITLE
Clear pane notifications once you've seen them, and say which pane they're from

### DIFF
--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -467,6 +467,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // handler.
         controlServer.start()
         UNUserNotificationCenter.current().delegate = NotificationHandler.shared
+        NotificationHandler.shared.registerCategories()
         if BenchmarkControl.isEnabled {
             // Under the CI benchmark, the notification-permission alert would
             // steal key focus mid-measurement and nobody is there to answer it.

--- a/Macterm/App/NotificationHandler.swift
+++ b/Macterm/App/NotificationHandler.swift
@@ -102,6 +102,38 @@ final class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
+    /// Deep link to System Settings > Notifications. The extension identifier
+    /// is read off the installed `NotificationsSettings.appex`, not guessed.
+    /// Optional only to satisfy `URL(string:)` — the literal always parses.
+    nonisolated static let settingsURL =
+        URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension")
+
+    /// Whether macOS will actually deliver what `post` sends.
+    ///
+    /// `nil` means the question isn't settled — the prompt has not been
+    /// answered, so there is nothing to complain about yet. The Settings banner
+    /// treats that as "no evidence, don't nag", the same rule
+    /// `FullDiskAccess.isGranted` follows.
+    ///
+    /// Authorized-but-muted counts as **not** delivering: an app whose alerts
+    /// the user switched off in System Settings is silent in exactly the way
+    /// the banner exists to explain, and `authorizationStatus` alone would call
+    /// that healthy.
+    nonisolated static func isDelivering() async -> Bool? {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        switch settings.authorizationStatus {
+        case .notDetermined: return nil
+        case .denied: return false
+        // `.disabled` is the only value that proves nothing will appear;
+        // `.notSupported` says the setting doesn't apply, which is not evidence
+        // against delivery.
+        case .authorized,
+             .provisional,
+             .ephemeral: return settings.alertSetting != .disabled
+        @unknown default: return nil
+        }
+    }
+
     /// Register the pane-notification category. `.customDismissAction` is what
     /// makes the system deliver a *dismissal* to `didReceive` at all — without
     /// it only taps arrive, and `responseRoute` never sees the dismiss case.

--- a/Macterm/App/NotificationHandler.swift
+++ b/Macterm/App/NotificationHandler.swift
@@ -41,10 +41,64 @@ final class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
     private var panesWithNotifications: Set<UUID> = []
 
     func requestAuthorization() {
-        UNUserNotificationCenter.current().requestAuthorization(options: Self.authorizationOptions) { granted, _ in
-            if !granted {
-                logger.notice("Macterm notification authorization denied")
+        UNUserNotificationCenter.current().requestAuthorization(options: Self.authorizationOptions) { _, error in
+            // Ghostty logs this error; swallowing it (as this did) makes a
+            // failed request indistinguishable from a refused one.
+            if let error {
+                logger.error("Notification authorization request failed: \(error.localizedDescription, privacy: .public)")
             }
+            Self.logNotificationSettings()
+        }
+    }
+
+    /// Report what the system actually holds for us, because `granted` alone
+    /// answers none of the questions a silent app raises. The system prompts
+    /// **once per app, ever**: after that a request returns the standing answer
+    /// without showing anything, so a denied app looks identical to one that
+    /// was never asked, and only System Settings can undo it. `soundSetting` is
+    /// the other half — an install that granted permission back when Macterm
+    /// requested `[.alert]` alone can be authorized and still mute, which is
+    /// exactly the upgrade path #298 introduced.
+    ///
+    /// Logged at `.notice` only when something is off, so a healthy launch
+    /// stays quiet and a broken one leaves the answer in `mise run logs`.
+    nonisolated private static func logNotificationSettings() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            let status = describe(settings.authorizationStatus)
+            let alert = describe(settings.alertSetting)
+            let sound = describe(settings.soundSetting)
+            guard settings.authorizationStatus != .authorized
+                || settings.alertSetting != .enabled
+                || settings.soundSetting != .enabled
+            else {
+                logger.info("Notifications ready (authorization=\(status, privacy: .public))")
+                return
+            }
+            logger.notice("""
+            Notifications degraded: authorization=\(status, privacy: .public) \
+            alert=\(alert, privacy: .public) sound=\(sound, privacy: .public). \
+            Fix in System Settings > Notifications > \(appDisplayName, privacy: .public).
+            """)
+        }
+    }
+
+    nonisolated private static func describe(_ status: UNAuthorizationStatus) -> String {
+        switch status {
+        case .notDetermined: "not-determined"
+        case .denied: "denied"
+        case .authorized: "authorized"
+        case .provisional: "provisional"
+        case .ephemeral: "ephemeral"
+        @unknown default: "unknown(\(status.rawValue))"
+        }
+    }
+
+    nonisolated private static func describe(_ setting: UNNotificationSetting) -> String {
+        switch setting {
+        case .notSupported: "not-supported"
+        case .disabled: "disabled"
+        case .enabled: "enabled"
+        @unknown default: "unknown(\(setting.rawValue))"
         }
     }
 

--- a/Macterm/App/NotificationHandler.swift
+++ b/Macterm/App/NotificationHandler.swift
@@ -3,6 +3,11 @@ import UserNotifications
 
 private let logger = Logger(subsystem: appBundleID, category: "NotificationHandler")
 
+/// Owns BOTH ends of a pane notification: the content and `userInfo` written by
+/// `post`, and the routing read back in `didReceive`. They are one contract —
+/// splitting the write across another file is how a key rename silently breaks
+/// tap-routing while everything still compiles.
+///
 /// The delegate methods are `nonisolated` (they can be called off-main) and
 /// hand off to the main actor explicitly via a `Task { @MainActor }`, instead
 /// of a `@preconcurrency` conformance that would silently disable isolation
@@ -14,7 +19,26 @@ final class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
     static let shared = NotificationHandler()
     static let authorizationOptions: UNAuthorizationOptions = [.alert, .sound]
     nonisolated static let foregroundPresentationOptions: UNNotificationPresentationOptions = [.banner, .sound]
+
+    /// The one category every pane notification carries. Bundle-ID-scoped so a
+    /// debug build's registration can't collide with the release app's, the
+    /// same split the logger subsystem uses.
+    nonisolated static let categoryIdentifier = "\(appBundleID).userNotification"
+    /// The explicit "Show" button, alongside clicking the banner body.
+    nonisolated static let showActionIdentifier = "\(appBundleID).userNotification.Show"
+
     weak var appState: AppState?
+
+    /// Panes that have posted a notification which may still be sitting in
+    /// Notification Center. Purely a fast path: `clearDelivered` runs on every
+    /// pane focus change, and without this every one of those would spend an
+    /// XPC round-trip to notificationd only to learn there is nothing to
+    /// remove. (Ghostty guards the same call with its per-surface identifier
+    /// set.) Membership is allowed to be stale in the conservative direction —
+    /// a notification the user dismissed, or that aged out on its own, leaves
+    /// the pane listed and costs one wasted lookup — but never in the other,
+    /// because `post` is the only thing that inserts.
+    private var panesWithNotifications: Set<UUID> = []
 
     func requestAuthorization() {
         UNUserNotificationCenter.current().requestAuthorization(options: Self.authorizationOptions) { granted, _ in
@@ -24,17 +48,117 @@ final class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
+    /// Register the pane-notification category. `.customDismissAction` is what
+    /// makes the system deliver a *dismissal* to `didReceive` at all — without
+    /// it only taps arrive, and `responseRoute` never sees the dismiss case.
+    func registerCategories() {
+        UNUserNotificationCenter.current().setNotificationCategories([
+            UNNotificationCategory(
+                identifier: Self.categoryIdentifier,
+                actions: [UNNotificationAction(identifier: Self.showActionIdentifier, title: "Show")],
+                intentIdentifiers: [],
+                options: [.customDismissAction]
+            ),
+        ])
+    }
+
+    // MARK: - Posting
+
+    /// Post a notification for `pane` — the single path, so the desktop-
+    /// notification and command-finished callers can't drift.
+    func post(pane: Pane, title: String, body: String) {
+        let request = UNNotificationRequest(
+            identifier: Self.identifier(paneID: pane.id),
+            content: Self.makeContent(
+                title: title,
+                subtitle: pane.displayTitle,
+                body: body,
+                userInfo: Self.userInfo(for: pane)
+            ),
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request)
+        panesWithNotifications.insert(pane.id)
+    }
+
+    /// The routing-critical `userInfo` contract, read back by `didReceive`.
+    static func userInfo(for pane: Pane) -> [AnyHashable: Any] {
+        [
+            "paneID": pane.id.uuidString,
+            "projectID": pane.projectID.uuidString,
+            "isQuickTerminal": pane.projectID == QuickTerminalService.ephemeralProjectID,
+        ]
+    }
+
     static func makeContent(
         title: String,
+        subtitle: String,
         body: String,
         userInfo: [AnyHashable: Any]
     ) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = title
+        // Which pane fired this — the same name its sidebar row shows, so the
+        // notification and the row the user goes looking for agree (including
+        // the static fallback when auto-naming is off).
+        content.subtitle = subtitle
         content.body = body
         content.sound = .default
+        content.categoryIdentifier = categoryIdentifier
         content.userInfo = userInfo
         return content
+    }
+
+    // MARK: - Identifiers
+
+    /// Every identifier is `macterm-<paneID>-<unique>`, which makes a pane's
+    /// delivered notifications findable by prefix. Ghostty instead keeps the
+    /// live identifiers themselves in a per-surface `Set<String>`; deriving the
+    /// lookup from the pane id means the set above can be a lossy hint rather
+    /// than the source of truth, so a stale entry costs one wasted lookup
+    /// instead of stranding a banner nothing can remove. The UUID suffix keeps
+    /// each post distinct — a reused identifier would REPLACE the delivered
+    /// notification rather than add one.
+    nonisolated static func identifierPrefix(paneID: UUID) -> String {
+        "macterm-\(paneID.uuidString)-"
+    }
+
+    nonisolated static func identifier(paneID: UUID) -> String {
+        identifierPrefix(paneID: paneID) + UUID().uuidString
+    }
+
+    /// Drop this pane's already-delivered notifications from Notification
+    /// Center. Called when the pane takes focus (the user has now seen it, so a
+    /// "Command Finished" banner for it is stale) and when its surface is
+    /// destroyed — both are what Ghostty does in `focusDidChange` and on
+    /// surface removal.
+    func clearDelivered(paneID: UUID) {
+        guard panesWithNotifications.remove(paneID) != nil else { return }
+        let prefix = Self.identifierPrefix(paneID: paneID)
+        UNUserNotificationCenter.current().getDeliveredNotifications { delivered in
+            let stale = delivered.map(\.request.identifier).filter { $0.hasPrefix(prefix) }
+            guard !stale.isEmpty else { return }
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: stale)
+        }
+    }
+
+    // MARK: - Delegate
+
+    /// What a notification response should do. A dismissal must NOT navigate —
+    /// registering `.customDismissAction` is what starts delivering those here,
+    /// and treating every response as a tap would yank the user to a pane
+    /// because they swiped a banner away.
+    enum ResponseRoute: Equatable {
+        case navigate
+        case ignore
+    }
+
+    nonisolated static func responseRoute(for actionIdentifier: String) -> ResponseRoute {
+        switch actionIdentifier {
+        case UNNotificationDefaultActionIdentifier,
+             showActionIdentifier: .navigate
+        default: .ignore
+        }
     }
 
     nonisolated func userNotificationCenter(
@@ -49,11 +173,13 @@ final class NotificationHandler: NSObject, UNUserNotificationCenterDelegate {
         // actor. This keeps isolation checking ON instead of papering over the
         // off-main delivery with a `@preconcurrency` conformance.
         let userInfo = response.notification.request.content.userInfo
+        let route = Self.responseRoute(for: response.actionIdentifier)
         let paneIDString = userInfo["paneID"] as? String
         let projectIDString = userInfo["projectID"] as? String
         let isQuickTerminal = userInfo["isQuickTerminal"] as? Bool ?? false
         completionHandler()
 
+        guard case .navigate = route else { return }
         guard let paneIDString, let paneID = UUID(uuidString: paneIDString),
               let projectIDString, let projectID = UUID(uuidString: projectIDString)
         else { return }

--- a/Macterm/Config/GhosttyConfigText.swift
+++ b/Macterm/Config/GhosttyConfigText.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Reads a single key out of raw ghostty config text.
+///
+/// Raw text, not the loaded C config, for the reason `ShellIntegrationFeatures`
+/// spells out: some consumers need the value the user *stated*, and the C API
+/// cannot distinguish "explicitly set to the default" from "never mentioned".
+/// A value set in a recursively loaded `config-file` include is not seen —
+/// libghostty resolves those at load time and this only scans the root files.
+enum GhosttyConfigText {
+    /// The effective value of `key`, mirroring libghostty's own semantics:
+    /// the last occurrence wins, and an **empty** value resets the key to its
+    /// default rather than setting it to the empty string. Comments and blank
+    /// lines are skipped, and one matched pair of surrounding double quotes is
+    /// stripped. nil when the key is never set (or only reset).
+    static func lastValue(of key: String, inConfigText text: String) -> String? {
+        var result: String?
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            let lineKey = line[line.startIndex ..< eq].trimmingCharacters(in: .whitespaces)
+            guard lineKey == key else { continue }
+            var value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            if value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") {
+                value = String(value.dropFirst().dropLast())
+            }
+            result = value.isEmpty ? nil : value
+        }
+        return result
+    }
+
+    /// The bool literals ghostty's `parseBool` accepts (`src/cli/args.zig`).
+    static let trueLiterals: Set<String> = ["1", "t", "T", "true"]
+    static let falseLiterals: Set<String> = ["0", "f", "F", "false"]
+}

--- a/Macterm/Config/NotificationConfigIntent.swift
+++ b/Macterm/Config/NotificationConfigIntent.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Whether the user's own Ghostty config asks to be notified.
+///
+/// This exists for one question the Settings pane needs to answer: is it worth
+/// telling this user that macOS is dropping Macterm's notifications? Everyone
+/// who has never granted the permission is technically affected — Macterm posts
+/// on a finished command whatever the config says — but a banner shown to every
+/// such user is nagware. Someone who wrote a notification key into their config
+/// has said they care, and is the person for whom silent notifications are a
+/// bug rather than a non-event.
+///
+/// So the predicate is "asked **for** notifications", not "mentioned
+/// notifications". `desktop-notifications = false` and
+/// `notify-on-command-finish = never` are configuration *against* them, and
+/// nagging that person about a permission they don't want is worse than staying
+/// quiet.
+enum NotificationConfigIntent {
+    /// Keys deliberately NOT consulted:
+    ///
+    /// - `app-notifications` — despite the name it governs Ghostty's own in-app
+    ///   toasts (`clipboard-copy`, `config-reload`), which never reach
+    ///   `UNUserNotificationCenter`.
+    /// - `notify-on-command-finish-after` — a threshold. On its own it enables
+    ///   nothing, so it can't carry the intent.
+    /// - `bell-features` — the bell is `NSSound`/dock attention
+    ///   (`GhosttyCallbacks.ringBell`), a separate path that needs no
+    ///   notification permission at all.
+    static func wantsNotifications(inConfigText text: String?) -> Bool {
+        guard let text else { return false }
+
+        // Default `true`, so only an explicit true states the intent — and an
+        // explicit false states the opposite.
+        if let value = GhosttyConfigText.lastValue(of: "desktop-notifications", inConfigText: text),
+           GhosttyConfigText.trueLiterals.contains(value)
+        {
+            return true
+        }
+
+        // Default `never`. Both other values mean "notify me".
+        if let value = GhosttyConfigText.lastValue(of: "notify-on-command-finish", inConfigText: text),
+           ["unfocused", "always"].contains(value.lowercased())
+        {
+            return true
+        }
+
+        if let value = GhosttyConfigText.lastValue(
+            of: "notify-on-command-finish-action",
+            inConfigText: text
+        ), requestsNotifyAction(value) {
+            return true
+        }
+
+        return false
+    }
+
+    /// `notify-on-command-finish-action` is a packed struct (`bell` defaulting
+    /// on, `notify` defaulting off) with the same grammar as
+    /// `shell-integration-features`: comma parts applied left to right, a `no-`
+    /// prefix turning one off, and a bool literal — valid only as the entire
+    /// value — flipping every flag at once. Only `notify` posts a notification;
+    /// `bell` rings the terminal bell, which needs no permission.
+    private static func requestsNotifyAction(_ value: String) -> Bool {
+        if GhosttyConfigText.trueLiterals.contains(value) { return true }
+        if GhosttyConfigText.falseLiterals.contains(value) { return false }
+        var wantsNotify = false
+        for part in value.split(separator: ",") {
+            let flag = part.trimmingCharacters(in: .whitespaces)
+            if flag == "notify" { wantsNotify = true }
+            if flag == "no-notify" { wantsNotify = false }
+        }
+        return wantsNotify
+    }
+}

--- a/Macterm/Config/ShellIntegrationFeatures.swift
+++ b/Macterm/Config/ShellIntegrationFeatures.swift
@@ -27,29 +27,14 @@ enum ShellIntegrationFeatures {
     static let allFeatures = ["cursor", "sudo", "title", "ssh-env", "ssh-terminfo", "path"]
 
     /// The bool literals ghostty's `parseBool` accepts (`src/cli/args.zig`).
-    private static let trueLiterals: Set<String> = ["1", "t", "T", "true"]
-    private static let falseLiterals: Set<String> = ["0", "f", "F", "false"]
+    private static let trueLiterals = GhosttyConfigText.trueLiterals
+    private static let falseLiterals = GhosttyConfigText.falseLiterals
 
     /// The user's effective `shell-integration-features` value in raw ghostty
-    /// config text. Last occurrence wins and an empty value resets the key to
-    /// its defaults ("not set"), mirroring libghostty's own semantics.
-    /// Comments and blank lines are ignored; a matched pair of surrounding
-    /// double quotes is stripped. nil when the key is never set.
+    /// config text. See `GhosttyConfigText.lastValue` for the semantics
+    /// (last occurrence wins, empty resets to the default, comments skipped).
     static func userValue(inConfigText text: String) -> String? {
-        var result: String?
-        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            if line.isEmpty || line.hasPrefix("#") { continue }
-            guard let eq = line.firstIndex(of: "=") else { continue }
-            let key = line[line.startIndex ..< eq].trimmingCharacters(in: .whitespaces)
-            guard key == "shell-integration-features" else { continue }
-            var value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
-            if value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") {
-                value = String(value.dropFirst().dropLast())
-            }
-            result = value.isEmpty ? nil : value
-        }
-        return result
+        GhosttyConfigText.lastValue(of: "shell-integration-features", inConfigText: text)
     }
 
     /// ghostty's own defaults for the features it knows, read off

--- a/Macterm/Model/Pane.swift
+++ b/Macterm/Model/Pane.swift
@@ -755,6 +755,10 @@ final class Pane: Identifiable {
         // Release any secure-input scope this view holds (a pane closed
         // mid-password-prompt must not leave the OS state stuck on).
         view.passwordInput = false
+        // A notification whose pane no longer exists routes nowhere on tap, so
+        // drop any still sitting in Notification Center. Ghostty does the same
+        // when a surface is removed.
+        NotificationHandler.shared.clearDelivered(paneID: id)
         view.destroySurface()
         let scroll = _scrollView
         // Disarm the orphan-healing re-attach BEFORE the removal below —

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -485,10 +485,23 @@ private struct GeneralSettings: View {
     @State
     private var hasFullDiskAccess: Bool? = FullDiskAccess.isGranted()
 
+    /// True only when the user's Ghostty config asks to be notified AND macOS
+    /// is dropping what Macterm posts. Both halves change only outside this
+    /// window — the config in an editor, the permission in System Settings —
+    /// so it's re-read on activation rather than polled. Starts false: the
+    /// permission read is async, and flashing a warning during the first frame
+    /// would be worse than showing it a beat late.
+    @State
+    private var notificationsBlocked: Bool = false
+
     var body: some View {
         Form {
             if hasFullDiskAccess == false {
                 FullDiskAccessBanner()
+            }
+
+            if notificationsBlocked {
+                NotificationPermissionBanner()
             }
 
             Section {
@@ -605,11 +618,27 @@ private struct GeneralSettings: View {
             // Default files are created and deleted in other apps, so
             // discovery can only have changed while we were inactive.
             defaultGhosttyConfigFiles = GhosttyConfigSource.defaultFileLocations()
+            Task { await refreshNotificationBanner() }
         }
+        .task { await refreshNotificationBanner() }
         .onChange(of: isCustomGhosttyConfigFieldFocused) { wasFocused, isFocused in
             guard wasFocused, !isFocused else { return }
             commitCustomGhosttyConfigEdit()
         }
+    }
+
+    /// Cheap half first: an unreadable or notification-free config skips the
+    /// permission round-trip entirely, and — because the config is the gate —
+    /// a user who never asked for notifications is never told about them.
+    private func refreshNotificationBanner() async {
+        guard NotificationConfigIntent.wantsNotifications(
+            inConfigText: MactermConfig.userGhosttyConfigText()
+        )
+        else {
+            notificationsBlocked = false
+            return
+        }
+        notificationsBlocked = await NotificationHandler.isDelivering() == false
     }
 
     /// The discovered default locations are read-only because Ghostty owns
@@ -946,6 +975,41 @@ private struct FullDiskAccessBanner: View {
                     )
                     .settingsCaption()
                     if let url = FullDiskAccess.settingsURL {
+                        Button("Open System Settings…") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                }
+            } icon: {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(MactermTheme.warning)
+            }
+            .padding(.vertical, 2)
+        }
+    }
+}
+
+/// Shown when the Ghostty config asks to be notified but macOS won't deliver.
+///
+/// The permission is one-shot: macOS presents its prompt the first time an app
+/// asks and never again, so once it has been answered — or dismissed — the app
+/// cannot re-raise it, and a denied Macterm is silent with nothing on screen to
+/// explain why. System Settings is the only way back, which is what makes this
+/// worth a banner rather than a log line.
+private struct NotificationPermissionBanner: View {
+    var body: some View {
+        Section {
+            Label {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Notifications are turned off")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(
+                        "Your Ghostty config asks to be notified, but macOS is not "
+                            + "delivering Macterm's notifications. macOS only ever asks "
+                            + "once, so this can only be changed in System Settings."
+                    )
+                    .settingsCaption()
+                    if let url = NotificationHandler.settingsURL {
                         Button("Open System Settings…") {
                             NSWorkspace.shared.open(url)
                         }

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -1001,14 +1001,10 @@ private struct NotificationPermissionBanner: View {
         Section {
             Label {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Notifications are turned off")
+                    Text("Macterm doesn't have notification permission")
                         .font(.system(size: 13, weight: .semibold))
-                    Text(
-                        "Your Ghostty config asks to be notified, but macOS is not "
-                            + "delivering Macterm's notifications. macOS only ever asks "
-                            + "once, so this can only be changed in System Settings."
-                    )
-                    .settingsCaption()
+                    Text("Your Ghostty config is set to deliver notifications.")
+                        .settingsCaption()
                     if let url = NotificationHandler.settingsURL {
                         Button("Open System Settings…") {
                             NSWorkspace.shared.open(url)

--- a/Macterm/Views/TerminalPane.swift
+++ b/Macterm/Views/TerminalPane.swift
@@ -1,6 +1,5 @@
 import AppKit
 import SwiftUI
-import UserNotifications
 
 struct TerminalPane: View {
     let pane: Pane
@@ -232,6 +231,10 @@ private struct TerminalSurface: NSViewRepresentable {
         if focused, !wasFocused {
             AdaptiveTerminalChrome.shared.focusDidChange(to: view)
             view.notifySurfaceFocused()
+            // The user is looking at this pane now, so any banner still sitting
+            // in Notification Center for it is stale. Same point Ghostty clears
+            // a surface's notifications from (`focusDidChange`).
+            NotificationHandler.shared.clearDelivered(paneID: pane.id)
             FocusRestoration.restoreFocus(to: pane.id, finder: { [pane] in pane }, in: view.window)
         } else if !focused, wasFocused {
             view.notifySurfaceUnfocused()
@@ -323,7 +326,7 @@ private struct TerminalSurface: NSViewRepresentable {
         view.onDesktopNotification = { [weak pane, weak view] title, body in
             guard let pane else { return }
             guard !(NSApp.isActive && view?.isFocused == true) else { return }
-            Self.postPaneNotification(pane: pane, title: title, body: body)
+            NotificationHandler.shared.post(pane: pane, title: title, body: body)
         }
         view.onProgressStarted = { [weak pane] in
             guard Preferences.shared.showTabStatusIndicator else { return }
@@ -410,30 +413,8 @@ private struct TerminalSurface: NSViewRepresentable {
             } else {
                 String(format: "Exited with code %d (%@)", exitCode, Self.formatDuration(durationSec))
             }
-            Self.postPaneNotification(pane: pane, title: "Command Finished", body: body)
+            NotificationHandler.shared.post(pane: pane, title: "Command Finished", body: body)
         }
-    }
-
-    /// Post a user notification for a pane, with the single routing-critical
-    /// `userInfo` contract (paneID / projectID / isQuickTerminal) defined ONCE
-    /// so the desktop-notification and command-finished paths can't drift and
-    /// silently break tap-routing for one of them.
-    private static func postPaneNotification(pane: Pane, title: String, body: String) {
-        let content = NotificationHandler.makeContent(
-            title: title,
-            body: body,
-            userInfo: [
-                "paneID": pane.id.uuidString,
-                "projectID": pane.projectID.uuidString,
-                "isQuickTerminal": pane.projectID == QuickTerminalService.ephemeralProjectID,
-            ]
-        )
-        let request = UNNotificationRequest(
-            identifier: "macterm-\(pane.id.uuidString)-\(UUID().uuidString)",
-            content: content,
-            trigger: nil
-        )
-        UNUserNotificationCenter.current().add(request)
     }
 
     private static func formatDuration(_ seconds: Double) -> String {

--- a/MactermTests/App/NotificationHandlerTests.swift
+++ b/MactermTests/App/NotificationHandlerTests.swift
@@ -1,27 +1,125 @@
+import Foundation
 @testable import Macterm
 import Testing
 import UserNotifications
 
+/// Pane notifications are a **contract with the system**, and every half of it
+/// fails silently when it drifts:
+///
+/// - The authorization options decide, at first grant, whether a sound is even
+///   permitted. Dropping `.sound` doesn't error — notifications just go mute.
+/// - The foreground presentation options are the only thing that makes a
+///   banner (and its sound) appear while Macterm is frontmost. Returning `[]`
+///   swallows the notification with no trace.
+/// - The `userInfo` keys are read back in `didReceive` by string. A rename
+///   compiles fine and breaks tap-routing.
+/// - `clearDelivered` finds a pane's notifications by *identifier prefix*
+///   rather than tracking a live set, so the identifier shape is load-bearing.
+///
+/// So these tests pin the literals and the shape. What they deliberately do
+/// NOT do is post anything: the suite runs hosted inside the debug app, where
+/// `UNUserNotificationCenter.add` would deliver a real notification to the
+/// developer's Notification Center. Everything asserted here is reachable
+/// without touching the center.
 @MainActor
 struct NotificationHandlerTests {
+    // MARK: - System contract
+
     @Test
     func requests_the_same_alert_and_sound_permissions_as_ghostty() {
         #expect(NotificationHandler.authorizationOptions == [.alert, .sound])
     }
 
     @Test
-    func notification_content_uses_the_default_system_sound() {
-        let content = NotificationHandler.makeContent(
-            title: "Title",
-            body: "Body",
-            userInfo: [:]
-        )
-
-        #expect(content.sound?.isEqual(UNNotificationSound.default) == true)
+    func foreground_notifications_present_with_a_banner_and_sound() {
+        #expect(NotificationHandler.foregroundPresentationOptions == [.banner, .sound])
     }
 
     @Test
-    func foreground_notifications_present_with_a_banner_and_sound() {
-        #expect(NotificationHandler.foregroundPresentationOptions == [.banner, .sound])
+    func category_and_action_identifiers_are_scoped_to_the_build_flavor() {
+        // Debug and release are separate apps; a shared category identifier
+        // would let one build's registration describe the other's banners.
+        #expect(NotificationHandler.categoryIdentifier.hasPrefix(appBundleID))
+        #expect(NotificationHandler.showActionIdentifier.hasPrefix(appBundleID))
+        #expect(NotificationHandler.categoryIdentifier != NotificationHandler.showActionIdentifier)
+    }
+
+    // MARK: - Content
+
+    @Test
+    func notification_content_carries_the_sound_subtitle_and_category() {
+        let content = NotificationHandler.makeContent(
+            title: "Command Finished",
+            subtitle: "npm",
+            body: "Exited with code 1 (2.0s)",
+            userInfo: ["paneID": "abc"]
+        )
+
+        #expect(content.title == "Command Finished")
+        #expect(content.subtitle == "npm")
+        #expect(content.body == "Exited with code 1 (2.0s)")
+        #expect(content.sound?.isEqual(UNNotificationSound.default) == true)
+        #expect(content.categoryIdentifier == NotificationHandler.categoryIdentifier)
+        #expect(content.userInfo["paneID"] as? String == "abc")
+    }
+
+    @Test
+    func user_info_carries_the_keys_did_receive_reads_back() {
+        let pane = Pane(projectPath: "/tmp", projectID: UUID())
+        let userInfo = NotificationHandler.userInfo(for: pane)
+
+        #expect(userInfo["paneID"] as? String == pane.id.uuidString)
+        #expect(userInfo["projectID"] as? String == pane.projectID.uuidString)
+        #expect(userInfo["isQuickTerminal"] as? Bool == false)
+    }
+
+    @Test
+    func a_quick_terminal_pane_is_flagged_so_taps_route_to_the_panel() {
+        let pane = Pane(projectPath: "/tmp", projectID: QuickTerminalService.ephemeralProjectID)
+
+        #expect(NotificationHandler.userInfo(for: pane)["isQuickTerminal"] as? Bool == true)
+    }
+
+    // MARK: - Identifiers
+
+    @Test
+    func each_post_gets_a_distinct_identifier_under_the_pane_prefix() {
+        let paneID = UUID()
+        let first = NotificationHandler.identifier(paneID: paneID)
+        let second = NotificationHandler.identifier(paneID: paneID)
+
+        // A reused identifier REPLACES the delivered notification instead of
+        // adding one, so two commands finishing would show as one banner.
+        #expect(first != second)
+        #expect(first.hasPrefix(NotificationHandler.identifierPrefix(paneID: paneID)))
+        #expect(second.hasPrefix(NotificationHandler.identifierPrefix(paneID: paneID)))
+    }
+
+    @Test
+    func one_panes_prefix_never_matches_another_panes_identifier() {
+        // This is what makes prefix-based clearing safe: focusing one pane must
+        // not sweep away a sibling's notifications.
+        let mine = UUID()
+        let other = UUID()
+
+        #expect(!NotificationHandler.identifier(paneID: other)
+            .hasPrefix(NotificationHandler.identifierPrefix(paneID: mine)))
+    }
+
+    // MARK: - Response routing
+
+    @Test
+    func tapping_the_banner_or_the_show_action_navigates() {
+        #expect(NotificationHandler.responseRoute(for: UNNotificationDefaultActionIdentifier) == .navigate)
+        #expect(NotificationHandler.responseRoute(for: NotificationHandler.showActionIdentifier) == .navigate)
+    }
+
+    @Test
+    func dismissing_a_notification_never_navigates() {
+        // The category registers `.customDismissAction`, so dismissals reach
+        // `didReceive` too. Treating them as taps would yank the user to a pane
+        // because they swiped a banner away.
+        #expect(NotificationHandler.responseRoute(for: UNNotificationDismissActionIdentifier) == .ignore)
+        #expect(NotificationHandler.responseRoute(for: "com.example.unknown") == .ignore)
     }
 }

--- a/MactermTests/Config/NotificationConfigIntentTests.swift
+++ b/MactermTests/Config/NotificationConfigIntentTests.swift
@@ -1,0 +1,131 @@
+@testable import Macterm
+import Testing
+
+/// The banner these back is a nag if it fires on the wrong config, and useless
+/// if it stays quiet on the right one — and the user only ever sees the verdict,
+/// never the reasoning. So each case here is a config someone plausibly writes.
+///
+/// The asymmetry worth remembering: `desktop-notifications` defaults to **true**
+/// and `notify-on-command-finish` defaults to **never**, so "not mentioned"
+/// means opposite things for the two keys and neither can be read as intent.
+struct NotificationConfigIntentTests {
+    @Test
+    func a_config_that_never_mentions_notifications_states_no_intent() {
+        #expect(NotificationConfigIntent.wantsNotifications(inConfigText: nil) == false)
+        #expect(NotificationConfigIntent.wantsNotifications(inConfigText: "") == false)
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "theme = catppuccin-mocha\nfont-size = 13"
+        ) == false)
+    }
+
+    @Test
+    func asking_for_desktop_notifications_states_intent() {
+        #expect(NotificationConfigIntent.wantsNotifications(inConfigText: "desktop-notifications = true"))
+        #expect(NotificationConfigIntent.wantsNotifications(inConfigText: "desktop-notifications = 1"))
+    }
+
+    @Test
+    func turning_notifications_off_is_not_intent() {
+        // The case that separates "asked for notifications" from "mentioned
+        // notifications". Warning this user about a permission they don't want
+        // is worse than saying nothing.
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "desktop-notifications = false"
+        ) == false)
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "notify-on-command-finish = never"
+        ) == false)
+    }
+
+    @Test
+    func command_finish_notifications_state_intent_unless_never() {
+        #expect(NotificationConfigIntent.wantsNotifications(inConfigText: "notify-on-command-finish = always"))
+        #expect(NotificationConfigIntent.wantsNotifications(inConfigText: "notify-on-command-finish = unfocused"))
+    }
+
+    @Test
+    func the_finish_action_states_intent_only_when_it_names_notify() {
+        // `bell` is the default and rings NSSound — no permission involved.
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "notify-on-command-finish-action = bell"
+        ) == false)
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "notify-on-command-finish-action = bell,notify"
+        ))
+        // Later parts win per flag, same grammar as shell-integration-features.
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "notify-on-command-finish-action = notify,no-notify"
+        ) == false)
+        // A bool literal is valid only as the whole value and flips every flag.
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "notify-on-command-finish-action = true"
+        ))
+    }
+
+    @Test
+    func a_threshold_alone_is_not_intent() {
+        // `notify-on-command-finish-after` tunes a threshold; on its own it
+        // enables nothing, so it can't carry the intent.
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "notify-on-command-finish-after = 10s"
+        ) == false)
+    }
+
+    @Test
+    func app_notifications_is_not_a_desktop_notification_key() {
+        // Despite the name it governs Ghostty's in-app toasts (clipboard-copy,
+        // config-reload), which never reach UNUserNotificationCenter.
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "app-notifications = clipboard-copy,config-reload"
+        ) == false)
+    }
+
+    @Test
+    func the_bell_is_a_separate_path_that_needs_no_permission() {
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "bell-features = system,audio"
+        ) == false)
+    }
+
+    @Test
+    func the_last_occurrence_of_a_key_wins() {
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "desktop-notifications = true\ndesktop-notifications = false"
+        ) == false)
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "desktop-notifications = false\ndesktop-notifications = true"
+        ))
+    }
+
+    @Test
+    func an_empty_value_resets_the_key_rather_than_setting_it() {
+        // libghostty's own semantics: `key =` restores the default, so the
+        // preceding explicit intent is withdrawn, not kept.
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "notify-on-command-finish = always\nnotify-on-command-finish ="
+        ) == false)
+    }
+
+    @Test
+    func commented_out_intent_is_not_intent() {
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "# desktop-notifications = true"
+        ) == false)
+    }
+
+    @Test
+    func quoted_and_padded_values_still_parse() {
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "  notify-on-command-finish   =   \"always\"  "
+        ))
+    }
+
+    @Test
+    func a_longer_key_that_merely_starts_the_same_is_not_a_match() {
+        // `notify-on-command-finish-after` must not be read as
+        // `notify-on-command-finish` — the parser compares whole keys.
+        #expect(NotificationConfigIntent.wantsNotifications(
+            inConfigText: "notify-on-command-finish-after = always"
+        ) == false)
+    }
+}


### PR DESCRIPTION
Follow-up to #298, which matched Ghostty on notification *sound*. These are the
remaining places where Macterm's pane notifications diverged from Ghostty's —
each one only shows up after the banner is gone, which is why none of them ever
got reported.

## What changes

**Notifications say which pane they came from.** Ghostty sets
`content.subtitle = self.title` (the surface title,
`SurfaceView_AppKit.swift:1749`). Macterm set no subtitle at all, so
"Command Finished — Exited with code 1 (12.4s)" with four tabs open told you
nothing about *where*. The subtitle is now `pane.displayTitle`, deliberately the
same string the pane's sidebar row shows — including the static shell/host
fallback when `autoNameTabs` is off — so the banner and the row you go looking
for always agree.

**Notifications clear themselves once you've seen the pane.** Ghostty removes a
surface's delivered notifications when it gains focus (`focusDidChange`) and
when the surface is removed. Macterm never removed anything, so every bell and
every finished command accumulated in Notification Center indefinitely. Both
hooks now exist, off the existing `focused, !wasFocused` edge in
`TerminalSurface.updateNSView` and off `Pane.destroySurface`.

The lookup differs from Ghostty's on purpose. Ghostty keeps the live identifiers
in a per-surface `Set<String>`; Macterm's identifiers were already
`macterm-<paneID>-<unique>`, so the pane's notifications are findable by prefix
and the set can degrade to a *hint* — it only exists so that a pane focus change
doesn't spend an XPC round-trip to notificationd learning there is nothing to
remove. A stale entry costs one wasted lookup; it can't strand a banner that
nothing is able to remove.

**A "Show" action, and dismissals that don't navigate.** Macterm registered no
`UNNotificationCategory`, so there was no Show button and `didReceive` treated
every response as a tap. Registering `.customDismissAction` — which is what
makes the system deliver dismissals to the delegate at all — means routing now
has to tell them apart, or swiping a banner away would yank you to that pane.
`responseRoute(for:)` is the split, and it's pinned by tests.

**Posting moves into `NotificationHandler`.** It already owned the *read* half of
the `paneID`/`projectID`/`isQuickTerminal` routing contract in `didReceive`;
the write half sat in `TerminalPane.swift` behind a comment warning that exactly
this pair must not drift. Both halves now live in one file.

**Silent notifications now say why.** `requestAuthorization` discarded its error
and logged a flat "authorization denied" for any falsy `granted` — which cannot
distinguish a refusal from a failure from a status that was already determined
and so never prompted at all. Ghostty at least logs the error
(`Ghostty.App.swift:1425`); this logs that plus the settings the system actually
holds, including `soundSetting` — the one thing that would report the `[.alert]`
-> `[.alert, .sound]` upgrade path from #298 leaving an authorized install mute.
`.info` on a healthy launch, `.notice` only when something is off.

This was found the hard way while testing this branch: a debug build produced
neither a prompt nor a notification, and the old log line could not say which of
the three cases it was. The new one reads
`authorization=denied alert=enabled sound=enabled` — the master toggle for
"Macterm Debug" was off in System Settings, where a determined status can only
ever be undone.

## Deliberately not done

- **Ghostty's `getNotificationSettings().authorizationStatus == .authorized`
  guard before posting.** Ghostty needs it because it requests authorization
  lazily, inside `showDesktopNotification`, on every notification. Macterm
  requests once at launch, and posting while denied is already a silent no-op —
  the guard would buy nothing but an async hop.
- **Ghostty's "remove after 3s if the surface was focused when posted" timer.**
  That covers a case Macterm structurally doesn't have: Macterm gates at *post*
  time (`guard !(NSApp.isActive && view?.isFocused == true)`), so it never posts
  for a focused pane in the first place.
- **Re-checking focus at delivery time (`shouldPresentNotification`).** Ghostty
  decides presentation when the notification is delivered; Macterm decides when
  it's posted. Closing that millisecond-wide race would mean calling the
  non-Sendable `completionHandler` across an actor hop, which is precisely the
  design `NotificationHandler`'s header comment says it avoided to keep Swift 6
  isolation checking on. The focus-clearing above covers the same ground from
  the other side.

## Notes

The `[.alert]` → `[.alert, .sound]` upgrade path from #298 is still worth a
manual check on an install that granted permission under the old options —
`UNNotificationSettings.soundSetting` is documented as `.notSupported` when the
`.sound` option was never requested, and a second `requestAuthorization` doesn't
re-prompt. Nothing here changes that either way; flagging it so it isn't lost.

## Verification

`mise run format` / `lint` clean. Unit suite green, including 10 tests in
`NotificationHandlerTests` (rewritten with a header explaining what each literal
is pinning, and now covering the identifier-prefix invariant that makes
prefix-clearing safe, the `userInfo` keys `didReceive` reads back, and dismiss
routing — rather than only restating its own constants). `mise run e2e` green
against the real app: 14 passed, 1 skipped (the docker-gated remote reconnect
test), which exercises the launch path the new `registerCategories()` call sits
on.
