### PR TITLE
Lead the README features with what they do, not how they work

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@
 
 ## Features
 
-- **Persistent multiplexing** — projects, tabs, and split panes are saved and restored on relaunch. Shells run under a bundled [zmx](https://github.com/neurosnap/zmx) session, so quitting detaches and relaunching reattaches every pane with its scrollback and running processes intact.
-- **Remote projects** — open a directory on another machine over SSH. Each pane is a persistent session *on the host*, so your shells survive quits, dropped connections, and even a local reboot.
+- **Persistent multiplexing** — projects, tabs, and split panes are saved and restored on relaunch. Quitting detaches your shells; relaunching brings them back with scrollback and running processes intact.
+- **Remote projects** — open a directory on another machine over SSH. Your shells keep running there, surviving quits, dropped connections, and even a local reboot.
 - **Vertical project sidebar** — organize projects and their tabs in a native macOS sidebar, stacked vertically where there's room to read them.
-- **Pinned tabs** — pin a tab above your projects to keep it running: it starts on every launch, closing only stops it (the row and its layout stay), and if its session dies it restores itself, re-running the command it was pinned with. The pinned set lives in an editable `pinned.yaml`.
+- **Pinned tabs** — pin a tab above your projects to keep it running: it starts on every launch, and restores itself with its command if the session dies.
 - **Command palette** — press <kbd>⌘P</kbd> to split panes, switch projects, or open a directory. Every action is a keystroke away, and each row shows its keybind.
 - **Declarative layouts** — describe a project's tabs, splits, and per-pane commands in YAML; Macterm builds the workspace from it on open.
-- **Control CLI** — a bundled `macterm` command drives the running app over a local socket, so scripts and AI agents can spawn panes, run commands, and script layouts.
+- **Control CLI** — a bundled `macterm` command drives the running app, so scripts and AI agents can spawn panes, run commands, and script layouts.
 - **Quick terminal** — a global drop-down terminal on a hotkey (<kbd>⌃`</kbd>), for scratch work from anywhere.
-- **Ghostty compatibility:** loads and merges Ghostty's standard XDG and macOS Application Support config files in its native order, including the legacy `config` filename, with optional Macterm-specific files layered on top. Theme, font, keybinds: all of it just works.
+- **Ghostty compatibility** — reads your existing Ghostty config. Theme, font, keybinds: all of it just works.
 
 ## Install
 


### PR DESCRIPTION
## What

Simplifies the README's Features section: each bullet now leads with the user-facing behavior instead of the implementation behind it.

## Why

The list had drifted into describing internals — the bundled zmx session, host-side persistent sessions, the `pinned.yaml` file, the local control socket, and Ghostty's XDG/Application Support config merge order including the legacy `config` filename. That's reference material for someone already using Macterm, not the pitch for someone deciding whether to. All of it is still covered by the Documentation links further down the page.

## How

Five bullets trimmed; four (sidebar, palette, layouts, quick terminal) were already user-facing and are unchanged.

- **Persistent multiplexing** — dropped the zmx link and the detach/reattach mechanics; kept "scrollback and running processes intact".
- **Remote projects** — dropped "persistent session *on the host*"; kept what survives (quits, dropped connections, a local reboot).
- **Pinned tabs** — dropped the closing-vs-unpinning semantics and the `pinned.yaml` file.
- **Control CLI** — dropped "over a local socket".
- **Ghostty compatibility** — replaced the config-file resolution detail with "reads your existing Ghostty config", and switched its `:` to an em dash so it matches the other eight bullets.

## Verified

Docs-only change — no code touched, so nothing to build or test.