### PR TITLE
Let people size the sidebar's project and tab icons down

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -44,6 +44,41 @@ enum UpdateChannel: String, CaseIterable, Identifiable {
     }
 }
 
+/// How large the leading glyph on a sidebar project/tab row draws, relative to
+/// the row's text. `medium` is the system default: the SF Symbols take
+/// whatever size the row's ambient font gives them, exactly as they did before
+/// this preference existed, so it is the one case that applies no sizing at
+/// all. The raw values are persisted.
+enum SidebarIconSize: String, CaseIterable, Identifiable {
+    case small
+    case medium
+    case large
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .small: "Small"
+        case .medium: "Medium"
+        case .large: "Large"
+        }
+    }
+
+    /// Multiplier for the sidebar glyphs sized by hand rather than by SwiftUI's
+    /// `imageScale` — the agent logo's frame, the plain-digit number glyph, the
+    /// running spinner, the completion dot. Taken from AppKit rather than
+    /// guessed so those glyphs track the SF Symbols beside them instead of
+    /// drifting: `NSImage.SymbolConfiguration` renders a 13pt symbol 12/14/18pt
+    /// tall at small/medium/large.
+    var glyphScale: CGFloat {
+        switch self {
+        case .small: 12.0 / 14.0
+        case .medium: 1
+        case .large: 18.0 / 14.0
+        }
+    }
+}
+
 /// Whether a quick-terminal geometry axis (position or size) comes from the
 /// Settings sliders (`fixed`) or is remembered from the user's own
 /// manipulation of the panel — dragging the grab handle, resizing from the
@@ -140,6 +175,11 @@ final class Preferences {
 
     var tabIconSymbol: String {
         didSet { defaults.set(tabIconSymbol, forKey: Keys.tabIconSymbol) }
+    }
+
+    /// How large the leading glyph on project and tab rows draws.
+    var sidebarIconSize: SidebarIconSize {
+        didSet { defaults.set(sidebarIconSize.rawValue, forKey: Keys.sidebarIconSize) }
     }
 
     /// Replace a tab's icon with the running AI agent's logo (Claude Code,
@@ -614,6 +654,8 @@ final class Preferences {
         activeProjectID = (defaults.string(forKey: Keys.activeProjectID)).flatMap(UUID.init)
         projectIconSymbol = defaults.string(forKey: Keys.projectIconSymbol) ?? "folder"
         tabIconSymbol = defaults.string(forKey: Keys.tabIconSymbol) ?? "terminal"
+        sidebarIconSize = (defaults.string(forKey: Keys.sidebarIconSize))
+            .flatMap(SidebarIconSize.init(rawValue:)) ?? .medium
         showAgentIcons = defaults.object(forKey: Keys.showAgentIcons) as? Bool ?? true
         showTabStatusIndicator = defaults.object(forKey: Keys.showTabStatusIndicator) as? Bool ?? false
         showSpinnerOverAgentIcons = defaults.object(forKey: Keys.showSpinnerOverAgentIcons) as? Bool ?? true
@@ -737,6 +779,7 @@ final class Preferences {
         static let activeProjectID = "macterm.activeProjectID"
         static let projectIconSymbol = "macterm.sidebar.projectIcon"
         static let tabIconSymbol = "macterm.sidebar.tabIcon"
+        static let sidebarIconSize = "macterm.sidebar.iconSize"
         static let showAgentIcons = "macterm.sidebar.showAgentIcons"
         static let showTabStatusIndicator = "macterm.sidebar.showTabStatusIndicator"
         static let showSpinnerOverAgentIcons = "macterm.sidebar.showSpinnerOverAgentIcons"

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -1027,6 +1027,7 @@ private struct AppearanceSettings: View {
     // not `@AppStorage`, which would bind to the banned `UserDefaults.standard`.
     @State private var projectIconSymbol: String = Preferences.shared.projectIconSymbol
     @State private var tabIconSymbol: String = Preferences.shared.tabIconSymbol
+    @State private var sidebarIconSize: String = Preferences.shared.sidebarIconSize.rawValue
     @State private var showAgentIcons: Bool = Preferences.shared.showAgentIcons
     @State private var showTabStatusIndicator: Bool = Preferences.shared.showTabStatusIndicator
     @State private var showSpinnerOverAgentIcons: Bool = Preferences.shared.showSpinnerOverAgentIcons
@@ -1137,6 +1138,15 @@ private struct AppearanceSettings: View {
                     }
                 }
                 .onChange(of: tabIconSymbol) { _, v in Preferences.shared.tabIconSymbol = v }
+
+                Picker("Icon size", selection: $sidebarIconSize) {
+                    ForEach(SidebarIconSize.allCases) { option in
+                        Text(option.displayName).tag(option.rawValue)
+                    }
+                }
+                .onChange(of: sidebarIconSize) { _, v in
+                    Preferences.shared.sidebarIconSize = SidebarIconSize(rawValue: v) ?? .medium
+                }
 
                 Toggle("Auto-name tabs", isOn: $autoNameTabs)
                     .onChange(of: autoNameTabs) { _, v in

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -1070,6 +1070,20 @@ private struct TabStatusGlyph: View {
     let index: Int
     var agent: AgentIcon?
     var spinnerOverAgent = true
+    @AppStorage(Preferences.Keys.sidebarIconSize)
+    private var iconSizeRaw = SidebarIconSize.medium.rawValue
+
+    private var size: SidebarIconSize {
+        SidebarIconSize(rawValue: iconSizeRaw) ?? .medium
+    }
+
+    /// The spinner is a control, so it steps between AppKit's control sizes
+    /// rather than scaling continuously with the icons. `.mini` (12pt) matches
+    /// a small symbol closely; `.regular` is 32pt, far past even a large one,
+    /// so large stays on `.small` and only its frame grows.
+    private var spinnerControlSize: ControlSize {
+        size == .small ? .mini : .small
+    }
 
     var body: some View {
         switch state {
@@ -1079,11 +1093,12 @@ private struct TabStatusGlyph: View {
                     .foregroundStyle(.secondary)
                     .help("Running")
             } else {
+                let side = 16 * size.glyphScale
                 ProgressView()
-                    .controlSize(.small)
+                    .controlSize(spinnerControlSize)
                     .tint(.secondary)
                     .help("Running")
-                    .frame(width: 16, height: 16)
+                    .frame(width: side, height: side)
             }
         case .done:
             SidebarRowIcon(symbol: symbol, index: index, agent: agent)
@@ -1091,16 +1106,18 @@ private struct TabStatusGlyph: View {
                 .overlay(alignment: .bottomTrailing) {
                     // Opaque (not translucent) so it reads clearly over the
                     // icon and the sidebar background. Nested in a background
-                    // ring so it stays legible over any icon color.
+                    // ring so it stays legible over any icon color. Sized off
+                    // the icon so the dot keeps hugging its corner at every
+                    // icon size instead of floating away from a smaller glyph.
                     Circle()
                         .fill(.background)
-                        .frame(width: 7, height: 7)
+                        .frame(width: 7 * size.glyphScale, height: 7 * size.glyphScale)
                         .overlay(
                             Circle()
                                 .fill(MactermTheme.success)
-                                .frame(width: 5, height: 5)
+                                .frame(width: 5 * size.glyphScale, height: 5 * size.glyphScale)
                         )
-                        .offset(x: 2.5, y: 2.5)
+                        .offset(x: 2.5 * size.glyphScale, y: 2.5 * size.glyphScale)
                 }
                 .help("Done")
         case .idle:
@@ -1134,26 +1151,48 @@ private struct SidebarRowIcon: View {
     let symbol: String
     let index: Int
     var agent: AgentIcon?
+    @AppStorage(Preferences.Keys.sidebarIconSize)
+    private var iconSizeRaw = SidebarIconSize.medium.rawValue
     /// Scales with the user's text size like the sibling SF Symbols do; a
     /// fixed 15pt would stay small next to enlarged row text.
     @ScaledMetric(relativeTo: .body)
     private var agentIconSize: CGFloat = 15
+
+    private var size: SidebarIconSize {
+        SidebarIconSize(rawValue: iconSizeRaw) ?? .medium
+    }
 
     var body: some View {
         if let agent {
             // A live AI agent in the tab overrides the user's chosen icon —
             // the logo is a status signal, tinted with the agent's brand color
             // (overriding the row's .secondary tint).
+            let side = agentIconSize * size.glyphScale
             Image(agent.rawValue)
                 .renderingMode(.template)
                 .resizable()
                 .scaledToFit()
-                .frame(width: agentIconSize, height: agentIconSize)
+                .frame(width: side, height: side)
                 .foregroundStyle(agent.brandColor)
         } else if Preferences.numberIconChoices.contains(symbol) {
-            NumberGlyph(index: index, variant: symbol)
+            NumberGlyph(index: index, variant: symbol, size: size)
         } else {
             Image(systemName: symbol)
+                .imageScale(size.imageScale)
+        }
+    }
+}
+
+private extension SidebarIconSize {
+    /// SwiftUI's own symbol scaling, which sizes a symbol against whatever font
+    /// the row hands it. `medium` is the default, so the middle case leaves an
+    /// icon exactly the size it was before this preference existed rather than
+    /// pinning it to a point size of our own.
+    var imageScale: Image.Scale {
+        switch self {
+        case .small: .small
+        case .medium: .medium
+        case .large: .large
         }
     }
 }
@@ -1161,18 +1200,29 @@ private struct SidebarRowIcon: View {
 private struct NumberGlyph: View {
     let index: Int
     let variant: String
+    var size: SidebarIconSize = .medium
+    /// The `.body` point size, as a metric so the digits keep tracking the
+    /// user's text size once `glyphScale` has been applied — `imageScale` is
+    /// no help here, since these variants draw text rather than a symbol.
+    @ScaledMetric(relativeTo: .body)
+    private var bodyFontSize: CGFloat = 13
+
+    private var digitFont: Font {
+        .system(size: bodyFontSize * size.glyphScale).monospacedDigit()
+    }
 
     var body: some View {
         if variant == Preferences.numberIconPlain {
             Text("\(index)")
-                .font(.body.monospacedDigit())
+                .font(digitFont)
         } else if let suffix = shapeSuffix, (1 ... 50).contains(index) {
             // SF Symbols ships `1.<shape>` through `50.<shape>`; beyond that,
             // fall back to plain digits so we don't render a missing glyph.
             Image(systemName: "\(index).\(suffix)")
+                .imageScale(size.imageScale)
         } else {
             Text("\(index)")
-                .font(.body.monospacedDigit())
+                .font(digitFont)
         }
     }
 


### PR DESCRIPTION
The sidebar's project and tab icons had no size of their own — they took whatever the List row's ambient font gave them, so anyone who wanted them less prominent next to the tab names had no way to say so.

Adds **Settings → Appearance → Sidebar → Icon size**, a Small/Medium/Large dropdown under the existing Project icon / Tab icon pickers. Medium is the default and is the current appearance unchanged.

## What changed

- New `SidebarIconSize` enum + `Preferences.sidebarIconSize` (persisted at `macterm.sidebar.iconSize`), following the same shape as `TabSwitcherVisibility` / `UpdateChannel`.
- `SidebarRowIcon`, `NumberGlyph`, and `TabStatusGlyph` read it and scale.
- A picker in the Appearance pane's Sidebar section.

## Notes for a reviewer

**`medium` is a true no-op, deliberately.** The SF Symbols go through SwiftUI's own `.imageScale`, whose `.medium` *is* the default — so the middle case applies no sizing and the icon keeps whatever the row's font gives it. Pinning it to a point size of ours instead would risk shifting the default appearance for a preference nobody touched.

**The multiplier is measured, not guessed.** Four glyphs are sized by hand and `imageScale` can't reach them: the agent logo's frame, the plain-digit number glyph (it's `Text`, not an `Image`), the running spinner's frame, and the completion dot plus its offset, which has to keep hugging the icon's corner. `glyphScale` covers those, taken from AppKit so they track the symbols beside them — `NSImage.SymbolConfiguration` renders a 13pt symbol 12/14/18pt tall at small/medium/large, hence `12/14` and `18/14`.

**One compromise: the spinner.** It's a control, so it steps between AppKit's control sizes rather than scaling smoothly. Small drops it to `.mini` (12pt, a close match); large stays on `.small` because the next step up, `.regular`, is 32pt — far past even a large icon. So at Large only its frame grows, leaving the spinner ~2pt under the symbols. Visible if you look for it side by side; I don't think it reads as wrong, but it's the one place the sizes don't track exactly.

**No test added**, matching convention — `tabSwitcherVisibility` and the icon-symbol pickers have none either. Enum-backed UI preferences aren't unit-tested here; `UpdaterChannelTests` is the exception only because that raw value is a wire contract with `publish-appcast.sh`.

## Verification

`mise run test`, `format`, and `lint` all clean. Beyond that I launched the debug app hermetically at each size and captured the sidebar, including a pass with number icons, a running command, and a finished one to exercise the four hand-scaled glyphs. The title column doesn't shift between sizes, so rows never reflow.
