### PR TITLE
Drive the unfocused-split dim from the user's ghostty config

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -161,12 +161,6 @@ final class Preferences {
         didSet { defaults.set(terminalScrollSpeed, forKey: Keys.terminalScrollSpeed) }
     }
 
-    /// How dark the overlay on an unfocused split pane gets (0–0.8, 0 = no dimming).
-    /// Capped below 1 so an unfocused pane is never fully black.
-    var paneDimOpacity: Double {
-        didSet { defaults.set(paneDimOpacity, forKey: Keys.paneDimOpacity) }
-    }
-
     // MARK: - Sidebar icons
 
     var projectIconSymbol: String {
@@ -345,9 +339,6 @@ final class Preferences {
         numberIconSquare,
         numberIconPlain,
     ]
-
-    /// Upper bound for `paneDimOpacity` — a fully black overlay reads as broken, not dim.
-    static let maxPaneDimOpacity: Double = 0.8
 
     /// Curated SF Symbols offered in Settings — keeps users from typing invalid names.
     static let projectIconChoices: [String] = [
@@ -611,9 +602,6 @@ final class Preferences {
         self.defaults = defaults
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
         terminalScrollSpeed = Self.clampScrollSpeed(defaults.double(forKey: Keys.terminalScrollSpeed), fallback: 1.0)
-        paneDimOpacity = Self.clampPaneDimOpacity(
-            (defaults.object(forKey: Keys.paneDimOpacity) as? Double) ?? 0.2
-        )
         windowOpacity = (defaults.object(forKey: Keys.windowOpacity) as? Double) ?? 1.0
         windowBlurRadius = defaults.integer(forKey: Keys.windowBlurRadius)
         windowGlassEnabled = defaults.object(forKey: Keys.windowGlassEnabled) as? Bool ?? false
@@ -695,10 +683,6 @@ final class Preferences {
         return min(max(v, sidebarWidthRange.lowerBound), sidebarWidthRange.upperBound)
     }
 
-    private static func clampPaneDimOpacity(_ v: Double) -> Double {
-        max(0.0, min(maxPaneDimOpacity, v))
-    }
-
     private static func clampScrollSpeed(_ v: Double, fallback: Double) -> Double {
         guard v > 0 else { return fallback }
         return max(0.25, min(3.0, v))
@@ -725,6 +709,13 @@ final class Preferences {
             defaults.removeObject(forKey: "macterm.eagerlyStartProjectTabs.enabled")
             defaults.removeObject(forKey: "macterm.session.terminateOnQuit")
             defaults.set(true, forKey: Keys.migrationRetiredToggleKeys)
+        }
+        // The unfocused-split dim is now driven by the user's ghostty config
+        // (`unfocused-split-opacity` / `unfocused-split-fill`), so the
+        // Macterm-side slider key is dead.
+        if !defaults.bool(forKey: Keys.migrationRetiredPaneDimKey) {
+            defaults.removeObject(forKey: "macterm.pane.dimOpacity")
+            defaults.set(true, forKey: Keys.migrationRetiredPaneDimKey)
         }
     }
 
@@ -754,7 +745,6 @@ final class Preferences {
     enum Keys {
         static let autoTiling = "macterm.autoTiling.enabled"
         static let terminalScrollSpeed = "macterm.terminal.scrollSpeed"
-        static let paneDimOpacity = "macterm.pane.dimOpacity"
         static let windowOpacity = "macterm.window.opacity"
         static let windowBlurRadius = "macterm.window.blurRadius"
         static let windowGlassEnabled = "macterm.window.glassEnabled"
@@ -795,5 +785,6 @@ final class Preferences {
         static let tabSwitcherPosition = "macterm.toolbar.tabSwitcherPosition"
         static let migrationV2GhosttyConfigOwned = "macterm.migration.v2_ghostty_config_owned"
         static let migrationRetiredToggleKeys = "macterm.migration.retired_toggle_keys"
+        static let migrationRetiredPaneDimKey = "macterm.migration.retired_pane_dim_key"
     }
 }

--- a/Macterm/Ghostty/GhosttyApp.swift
+++ b/Macterm/Ghostty/GhosttyApp.swift
@@ -322,6 +322,27 @@ final class GhosttyApp {
         return NSColor(srgbRed: CGFloat(c.r) / 255, green: CGFloat(c.g) / 255, blue: CGFloat(c.b) / 255, alpha: 1)
     }
 
+    /// The alpha of the overlay that dims an unfocused split pane, derived
+    /// from the user's `unfocused-split-opacity`. Ghostty defines that key as
+    /// the unfocused *pane's* opacity (1 = no dimming; libghostty clamps it to
+    /// 0.15…1 at load), so the overlay draws at its complement — the same
+    /// reading Ghostty.app applies.
+    var unfocusedSplitDimOpacity: Double {
+        guard let config else { return 0 }
+        var opacity = 1.0
+        let key = "unfocused-split-opacity"
+        guard ghostty_config_get(config, &opacity, key, UInt(key.utf8.count)) else { return 0 }
+        return 1 - opacity
+    }
+
+    /// The color of that overlay (`unfocused-split-fill`). The key is unset by
+    /// default and Ghostty falls back to the theme background, so the dim
+    /// reads as the pane fading toward the background — correct on light and
+    /// dark themes alike.
+    var unfocusedSplitFill: NSColor {
+        configColor("unfocused-split-fill") ?? backgroundColor
+    }
+
     private func configColor(_ key: String) -> NSColor? {
         guard let config else { return nil }
         var color = ghostty_config_color_s()

--- a/Macterm/Ghostty/Theme.swift
+++ b/Macterm/Ghostty/Theme.swift
@@ -64,14 +64,15 @@ enum MactermTheme {
         NSColor(srgbRed: CGFloat(rgb.r) / 255, green: CGFloat(rgb.g) / 255, blue: CGFloat(rgb.b) / 255, alpha: 1)
     }
 
-    /// A translucent overlay that dims an unfocused pane, at the user-configured
-    /// `opacity` (#156). Derived from the theme rather than a fixed black so it
-    /// reads correctly on light themes too: on a light theme, dimming toward the
-    /// (dark) foreground reduces contrast the way black does on a dark theme;
-    /// on a dark theme, black is correct.
+    /// The translucent overlay that dims an unfocused split pane, honoring the
+    /// user's ghostty `unfocused-split-opacity` / `unfocused-split-fill` with
+    /// Ghostty.app's exact semantics. The fill defaults to the theme
+    /// background, so the pane fades toward the background — which reads
+    /// correctly on light themes too, where dimming toward black would not.
     @MainActor
-    static func dimOverlay(opacity: Double) -> Color {
-        colorScheme == .light ? fgAlpha(opacity) : Color.black.opacity(opacity)
+    static var dimOverlay: Color {
+        let app = GhosttyApp.shared
+        return Color(nsColor: app.unfocusedSplitFill.withAlphaComponent(app.unfocusedSplitDimOpacity))
     }
 
     /// Scene-level light/dark scheme. Follows ONLY the resolved config theme,

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -1045,8 +1045,6 @@ private struct AppearanceSettings: View {
     @State
     private var liquidGlassStyle: WindowGlassStyle = Preferences.shared.windowGlassStyle
     @State
-    private var paneDimOpacity: Double = Preferences.shared.paneDimOpacity
-    @State
     private var adaptiveTerminalChrome: Bool = Preferences.shared.adaptiveTerminalChromeEnabled
     /// Inverted view of `Preferences.hideTitleBar`: the control reads as
     /// "Show toolbar" (on by default), the preference stores the hide.
@@ -1107,21 +1105,6 @@ private struct AppearanceSettings: View {
                 Text("Matches the whole window for a single pane; in a split, only each full-screen app's pane changes color.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            }
-
-            Section("Split Panes") {
-                SettingsSlider(
-                    label: "Unfocused dimming",
-                    value: $paneDimOpacity,
-                    range: 0.0 ... Preferences.maxPaneDimOpacity,
-                    step: nil,
-                    display: { "\(Int(($0 / Preferences.maxPaneDimOpacity * 100).rounded()))%" }
-                )
-                .onChange(of: paneDimOpacity) { _, v in
-                    Preferences.shared.paneDimOpacity = v
-                }
-                Text("How dark unfocused panes get in a split layout.")
-                    .settingsCaption()
             }
 
             Section("Sidebar") {

--- a/Macterm/Views/SplitTreeView.swift
+++ b/Macterm/Views/SplitTreeView.swift
@@ -137,11 +137,11 @@ private struct SplitLeafView: View {
         )
         .overlay {
             if !isFocused, isSplit, pane.adaptiveBackgroundColor == nil {
-                // Theme-derived dim (not fixed black) so an unfocused pane
-                // dims correctly on light themes too, at the user-configured
-                // opacity (#156). A pane whose TUI supplies its own adaptive
-                // background stays color-accurate even while unfocused.
-                MactermTheme.dimOverlay(opacity: Preferences.shared.paneDimOpacity)
+                // Driven by the user's ghostty `unfocused-split-opacity` /
+                // `unfocused-split-fill`, same as Ghostty.app's split dim. A
+                // pane whose TUI supplies its own adaptive background stays
+                // color-accurate even while unfocused.
+                MactermTheme.dimOverlay
                     .allowsHitTesting(false)
             }
         }


### PR DESCRIPTION
## What

Removes Macterm's own **Unfocused dimming** setting (Settings → Appearance → Split Panes) and drives the unfocused-split overlay from the user's ghostty config instead: `unfocused-split-opacity` and `unfocused-split-fill`, with Ghostty.app's exact semantics.

## Why

The two settings duplicated each other — and the ghostty keys were silently inert in Macterm. ghostty applies `unfocused-split-opacity` purely in its frontends (Ghostty.app's SwiftUI overlay, the GTK apprt); libghostty's renderer never touches it, so a user setting it in their ghostty config saw nothing happen while Macterm dimmed from its own `paneDimOpacity` preference. Same knob in two places, one a no-op. Ghostty-shaped settings belong in the user's ghostty config, so the Macterm preference loses.

## How

- `GhosttyApp` gains `unfocusedSplitDimOpacity` / `unfocusedSplitFill`, reading the live config through `ghostty_config_get` exactly as Ghostty.app does (verified against the pinned fork at `build-2026-08-23`): the overlay alpha is the complement of `unfocused-split-opacity` (libghostty clamps the key to 0.15–1 at load, so 1 = no dim), and the fill defaults to the theme background.
- `MactermTheme.dimOverlay` now returns that fill at that alpha. The old scheme-dependent color logic (#156: black on dark themes, fg on light) is gone — fading toward the background is what ghostty documents, and it reads correctly on light themes by construction.
- The overlay's gates in `SplitTreeView` are unchanged (split + unfocused + no adaptive TUI background). `GhosttyApp` is `@Observable`, so a config reload re-renders the dim live.
- `Preferences.paneDimOpacity`, its clamp, `maxPaneDimOpacity`, and the Settings slider are removed; the stored key is dropped via the existing one-time-migration sweep.

**Behavior change:** a previously tuned slider value is not carried over — everyone lands on ghostty's default (`0.7` → a 30% fade toward the background) until they set `unfocused-split-opacity` in their ghostty config.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app and confirmed the behavior
- [ ] Added or updated tests for new model / persistence / palette / hotkey logic

Live end-to-end proof: launched a hermetic debug instance (throwaway HOME/ZMX_DIR, relocated app data, `XDG_CONFIG_HOME` pointing at a config with `background = #113311`, `unfocused-split-opacity = 0.5`, `unfocused-split-fill = #ff0000`), split a pane over the control CLI, and screenshotted: the focused pane stayed pure green, the unfocused pane tinted 50% red — both keys flow user config → libghostty → overlay.

## Notes for reviewers

- No new unit tests: the accessors are libghostty bindings and the overlay is UI, both outside the suite's coverage targets by convention.
- Verification detour worth knowing: benchmark mode (`MACTERM_BENCHMARK=1`) force-disables the user-config layer in `loadConfig`, so the e2e/bench harness can't exercise these keys — the live proof above launches without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)