### PR TITLE
Stop macOS stealing key repeat with the press-and-hold accent overlay

### DIFF
--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -29,7 +29,20 @@ struct MactermApp: App {
         // It must run THIS early: the tooltip machinery can initialize with
         // the first window, which precedes applicationDidFinishLaunching on
         // some launches (see the didBecomeMain note on AppDelegate).
-        UserDefaults.standard.register(defaults: ["NSInitialToolTipDelay": 350])
+        // Hold a key down in a terminal and macOS's press-and-hold accent
+        // overlay ("é è ê…") steals the repeat, which is wrong in every TUI
+        // that binds a held key to motion — hjkl in helix/vim being the case
+        // that gets reported. Terminals want key repeat, not diacritics.
+        // Ghostty registers exactly this key, which is why the same ghostty
+        // config behaves differently there: the knob is an AppKit default in
+        // OUR process, not anything the config pipeline can carry.
+        // Registration domain again (see above): a user who genuinely wants
+        // the overlay keeps it via `defaults write -g ApplePressAndHoldEnabled
+        // true`, since NSGlobalDomain is searched ahead of registration.
+        UserDefaults.standard.register(defaults: [
+            "NSInitialToolTipDelay": 350,
+            "ApplePressAndHoldEnabled": false,
+        ])
     }
 
     var body: some Scene {


### PR DESCRIPTION
Holding a character key in a pane popped macOS's press-and-hold accent overlay ("é è ê…") instead of repeating the key. That breaks any TUI binding a held key to motion — holding `j` in helix is how it got reported.


## Why the same ghostty config behaves differently in Ghostty

This is not a ghostty setting, which is the whole reason it looked so confusing: the two apps were reading the *same* config file and behaving differently.

`ApplePressAndHoldEnabled` is an AppKit default, read per-process by `NSTextInputContext`. Nothing in Macterm's config pipeline could carry it either way. Ghostty registers the key itself at launch — its binary has two hits for it in `__TEXT`, and it is *absent* from the persisted `com.mitchellh.ghostty` domain, so it is going into the volatile registration domain. Macterm simply never did, so AppKit's own default (overlay on) stood.

## The change

One line, on the seam already there for `NSInitialToolTipDelay`:

- **Registration domain, not a write.** Nothing is persisted, so this doesn't breach the "never `UserDefaults.standard` in app code" rule — same justification the existing tooltip line carries.
- **`NSGlobalDomain` is searched ahead of registration**, so anyone who actually wants the overlay keeps it with `defaults write -g ApplePressAndHoldEnabled true`. No new preference: Ghostty hardcodes this with no config option, and that escape hatch already covers dissent.
- **It stays in `init()`**, not `applicationDidFinishLaunching`, for the reason the neighbouring comment gives — input machinery can initialize with the first window, which on some launches precedes the delegate callback.

## Notes for review

- **Dead keys are untouched.** `⌥e` then `e` composes through marked text, a different mechanism from press-and-hold; this knob doesn't reach it. The Option-key translation path in `GhosttyTerminalNSView` (the `interpretKeyEvents` comment about `∫`) is likewise unaffected.
- **No test.** The behaviour lives in AppKit's input stack and needs a real held key to observe — driving key repeat synthetically needs an Accessibility grant, which is exactly why the benchmark harness uses Darwin notifications rather than synthetic keys. Verified instead by confirming both keys compile into `Macterm.debug.dylib` (debug builds put the code there, not in the 41KB stub executable) and holding a key in that build.

`mise run format`, `lint`, and `test` all pass.
