### PR TITLE
Name the tip release just "Tip"

### DIFF
--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -329,7 +329,7 @@ jobs:
             # its URL, its download counts, and — because --prerelease is
             # re-asserted every time — can never silently become "Latest".
             gh release edit "$TAG" \
-              --title 'Macterm tip ("continuous")' \
+              --title 'Tip' \
               --notes-file "$NOTES_FILE" \
               --prerelease --draft=false --latest=false
           else
@@ -337,7 +337,7 @@ jobs:
             # `gh release create` would otherwise cut it at the default branch's
             # current HEAD rather than the commit we just built.
             gh release create "$TAG" \
-              --title 'Macterm tip ("continuous")' \
+              --title 'Tip' \
               --notes-file "$NOTES_FILE" \
               --target "$SHA" \
               --prerelease --latest=false


### PR DESCRIPTION
## What

Renames the rolling tip prerelease from `Macterm tip ("continuous")` to just `Tip`.

## Why

On the releases page the repo name is redundant next to every other release, and the parenthetical quoted alias was inherited from ghostty (`Ghostty Tip ("Nightly")`) without earning its place here. Stable releases are already named after nothing but their tag, so `Tip` matches them.

## How

Both `--title` call sites change together. The workflow re-asserts the title on every publish, so editing only `create` or only `edit` would let the name flip back depending on whether the release already existed.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass — n/a, no Swift changed; workflow YAML re-parsed and every `run:` body re-checked with `bash -n`

## Notes for reviewers

Because the title is re-asserted on each publish, the live release keeps its old name until a tip build runs with this merged. I renamed the existing release in place so it doesn't sit stale in the meantime; the next build sets the same name from the workflow.
