### PR TITLE
chore(deps): bump GhosttyKit to build-2026-08-31

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -22,7 +22,7 @@ XCFRAMEWORK_DIR="GhosttyKit.xcframework"
 # including the nightly sync — deletes and recreates it with different bytes,
 # the exact asset-swap-under-a-pin hazard documented in AGENTS.md. The next
 # ordinary bump (a past-day daily tag, immutable by then) retires this one.
-GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-pinned-2026-08-26}"
+GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-31}"
 # Which tag the on-disk fork artifacts actually came from. Without this the
 # presence checks below would keep a stale copy forever after a pin bump — the
 # same silent-staleness trap that makes symlinking these artifacts a bad idea.


### PR DESCRIPTION
Moves the pinned `thdxg/ghostty` release (`GHOSTTYKIT_TAG` in `scripts/setup.sh`) from `pinned-2026-08-26` to `build-2026-08-31`.

**CI on this PR is the gate.** Editing `scripts/setup.sh` changes the GhosttyKit cache key, so this run downloads the new pin from scratch and exercises it through Unit, End-to-end, and the benchmark — rather than a release being the first thing to try it.

Compare upstream: [`pinned-2026-08-26...build-2026-08-31`](https://github.com/thdxg/ghostty/compare/pinned-2026-08-26...build-2026-08-31)

---

### GhosttyKit API review — `pinned-2026-08-26` → `build-2026-08-31`

Filtered to the **170** `ghostty_*`/`GHOSTTY_*` symbols Macterm's own sources reference and the header defines.

#### ✅ No symbol we use was removed

#### No changed hunk touches a symbol we use

<sub>0 changed header lines total; 0 hunk(s) touch symbols we use. A green CI run means it builds and the suites pass — not that no behaviour moved.</sub>
