### PR TITLE
feat: reach tabs past 9 with multi-digit Cmd+digit

### DIFF
--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -1609,8 +1609,17 @@ final class AppState {
         }
     }
 
+    /// Tab slots addressable by Cmd+digit — sidebar ROWS in the pinned
+    /// workspace (records, unloaded included) and live tabs elsewhere, the
+    /// same two sources `selectTabByIndex` selects from. It is what bounds
+    /// digit accumulation, so the two must keep counting the same things.
+    func selectableTabCount(projectID: UUID) -> Int {
+        if projectID == PinnedTabs.projectID { return pinnedRecords.count }
+        return workspaces[projectID]?.tabs.count ?? 0
+    }
+
     func selectTabByIndex(_ index: Int, projectID: UUID) {
-        // Cmd+1…9 in the pinned workspace counts SIDEBAR rows (records,
+        // Cmd+digit in the pinned workspace counts SIDEBAR rows (records,
         // unloaded included), matching what the user sees.
         if projectID == PinnedTabs.projectID {
             guard pinnedRecords.indices.contains(index) else { return }

--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -683,10 +683,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mainResponder.mainWindow = mainWindow
         mainAppResponder = mainResponder
         KeyRouter.shared.register(mainResponder)
-        // Tab-cycle commit on Ctrl-release.
-        KeyRouter.shared.registerFlagsHandler { [weak appState] event in
-            guard let appState, appState.isTabCycling else { return }
+        // Tab-cycle commit on Ctrl-release, and Cmd+digit run end on
+        // Cmd-release (so the next digit addresses a tab rather than
+        // extending the number the last one built).
+        KeyRouter.shared.registerFlagsHandler { [weak appState, weak mainResponder] event in
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if !flags.contains(.command) { mainResponder?.endTabIndexChord() }
+            guard let appState, appState.isTabCycling else { return }
             if !flags.contains(.control),
                let projectID = appState.activeProjectID
             {

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -471,7 +471,7 @@ final class Preferences {
     /// switcher, update button), the title text, and — a side effect of
     /// SwiftUI removing the window toolbar — the traffic lights. The sidebar
     /// and terminal surface extend to the window's top edge. Tab switching
-    /// stays available via the sidebar and Cmd+1…9; close/minimize/zoom stay
+    /// stays available via the sidebar and Cmd+digit; close/minimize/zoom stay
     /// available from the Window menu. No AppKit private API involved: the
     /// window keeps its normal style mask, so edge-resizing still works.
     var hideTitleBar: Bool {

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -109,13 +109,14 @@ final class QuickTerminalResponder: KeyResponder {
 }
 
 /// App-level hotkeys for the main window: split, close, focus, resize, tab
-/// cycling, project navigation, new tab, new project, Cmd+1-9 tab selection,
-/// etc. Runs after the palette and quick-terminal responders.
+/// cycling, project navigation, new tab, new project, Cmd+digit tab
+/// selection, etc. Runs after the palette and quick-terminal responders.
 @MainActor
 final class MainAppResponder: KeyResponder {
     private let appState: AppState
     private let projectStore: ProjectStore
     weak var mainWindow: NSWindow?
+    private var tabIndexChord = TabIndexChord()
 
     private static let focusActions: [(HotkeyAction, PaneFocusDirection)] = [
         (.focusPaneLeft, .left),
@@ -361,18 +362,39 @@ final class MainAppResponder: KeyResponder {
             return .handled
         }
 
-        // Cmd+1-9 tab selection. Must check after the configurable hotkeys
+        // Cmd+digit tab selection. Must check after the configurable hotkeys
         // so user bindings take precedence over digits.
+        //
+        // Digits accumulate into a multi-digit number while Command stays
+        // down (see TabIndexChord), so a workspace with more than nine tabs
+        // is fully reachable. Every digit 1-9 is still swallowed even when it
+        // addresses nothing, matching the old single-digit binding; a `0` that
+        // isn't a valid continuation passes through, since on its own it is
+        // ghostty's reset-font-size chord, not ours.
         if flags == .command {
             let key = (event.charactersIgnoringModifiers ?? "").lowercased()
-            if let idx = Int(key), (1 ... 9).contains(idx),
+            if key.count == 1, let digit = Int(key), (0 ... 9).contains(digit),
                let projectID = appState.activeProjectID
             {
-                appState.selectTabByIndex(idx - 1, projectID: projectID)
-                return .handled
+                // Auto-repeat must not accumulate: holding Cmd+1 down is one
+                // request for tab 1, not a walk through 1, 11, 111.
+                guard !event.isARepeat else { return .handled }
+                let tabCount = appState.selectableTabCount(projectID: projectID)
+                if let number = tabIndexChord.press(digit: digit, tabCount: tabCount) {
+                    appState.selectTabByIndex(number - 1, projectID: projectID)
+                    return .handled
+                }
+                return digit == 0 ? .passThrough : .handled
             }
         }
 
         return .passThrough
+    }
+
+    /// Ends an in-flight Cmd+digit run, so the next digit starts a fresh
+    /// number instead of extending the last one. Driven by the flags monitor
+    /// on Command release.
+    func endTabIndexChord() {
+        tabIndexChord.reset()
     }
 }

--- a/Macterm/App/TabIndexChord.swift
+++ b/Macterm/App/TabIndexChord.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Accumulates Cmd+digit presses into a multi-digit tab number, so a
+/// workspace with more than nine tabs is still fully reachable from the
+/// keyboard (Cmd+1 then 2 → tab 12, Cmd+1 then 0 → tab 10).
+///
+/// Selection stays EAGER: the first digit switches immediately, exactly as
+/// the single-digit binding always did, and a following digit re-selects the
+/// wider number. Deferring the switch until the number is known would be the
+/// obvious alternative, but it puts a timeout's worth of latency on Cmd+1 —
+/// the overwhelmingly common press — to serve the rare two-digit one.
+///
+/// A run ends when Command is released (`reset`, driven by the flags monitor)
+/// or when `window` passes between digits, so a Cmd+1 now and a Cmd+2 later
+/// can never join into 12.
+struct TabIndexChord {
+    /// Idle gap after which the next digit starts a new number. Backstop for
+    /// the Command-release reset — a Command held across unrelated work must
+    /// not keep an ancient digit alive.
+    static let window: TimeInterval = 1.0
+
+    private var digits: String = ""
+    private var lastPress: Date?
+
+    /// Records a digit press and returns the 1-based tab number it addresses,
+    /// or nil when no tab can be addressed (a bare `0`, or a digit past the
+    /// end of a workspace too small for it).
+    ///
+    /// A digit that can't extend the current number restarts the run rather
+    /// than being dropped — with 5 tabs, Cmd+1 then Cmd+2 selects tab 2 (12
+    /// doesn't exist), which is what the single-digit binding did.
+    mutating func press(digit: Int, tabCount: Int, now: Date = Date()) -> Int? {
+        let isStale = lastPress.map { now.timeIntervalSince($0) > Self.window } ?? true
+        if isStale { digits = "" }
+
+        if let extended = Int(digits + String(digit)), extended >= 1, extended <= tabCount {
+            digits += String(digit)
+            lastPress = now
+            return extended
+        }
+        guard digit >= 1, digit <= tabCount else {
+            reset()
+            return nil
+        }
+        digits = String(digit)
+        lastPress = now
+        return digit
+    }
+
+    /// Ends the current run — the next digit starts a fresh number.
+    mutating func reset() {
+        digits = ""
+        lastPress = nil
+    }
+}

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -1178,7 +1178,7 @@ private struct AppearanceSettings: View {
                     .onChange(of: showToolbar) { _, v in
                         Preferences.shared.hideTitleBar = !v
                     }
-                Text("Hiding it removes the title bar, window buttons, and drag area; switch tabs via the sidebar or ⌘1–9.")
+                Text("Hiding it removes the title bar, window buttons, and drag area; switch tabs via the sidebar or ⌘ and the tab number.")
                     .settingsCaption()
 
                 Group {

--- a/Macterm/Views/TabSwitcherToolbarItem.swift
+++ b/Macterm/Views/TabSwitcherToolbarItem.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 /// Numbered segmented control in the window title bar that mirrors a fixed
 /// 5-tab sliding window of the active project's tabs. Each segment shows
-/// the tab's 1-based index; Cmd+1…Cmd+9 in `Responders.swift` selects by
-/// that same index.
+/// the tab's 1-based index; Cmd+digit in `Responders.swift` selects by
+/// that same index (multi-digit numbers accumulate while Cmd is held).
 ///
 /// The window centers the active tab when at least two tabs sit on either
 /// side; otherwise it clamps to the start or end of the workspace. The
@@ -13,7 +13,7 @@ import SwiftUI
 /// When tabs sit off either end of the visible window, the first/last
 /// segment is relabelled `…` — a quiet affordance that more tabs exist in
 /// that direction. The segment still selects its underlying tab when
-/// clicked. Cmd+1…Cmd+9 keeps using real tab indices via the keyboard
+/// clicked. Cmd+digit keeps using real tab indices via the keyboard
 /// handler in `Responders.swift`, so shortcuts aren't affected.
 struct TabSwitcherToolbarItem: View {
     @Environment(AppState.self)
@@ -80,7 +80,7 @@ struct TabSwitcherToolbarItem: View {
             // Keyed on the labels rather than `windowTabs.count`: a digit
             // flipping to `⋯` changes the ideal width at a constant count.
             .id(labels.joined(separator: "\u{1F}"))
-            .help("Cmd+1…\(min(9, tabs.count)) to switch tabs")
+            .help("Cmd+1…\(tabs.count) to switch tabs")
         }
     }
 

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -858,7 +858,11 @@ final class GhosttyTerminalNSView: NSView {
         let key = (event.charactersIgnoringModifiers ?? "").lowercased()
         // Always let system Cmd shortcuts through
         if flags == .command, Self.systemKeys.contains(key) { return true }
-        // Cmd+1-9 for tab selection
+        // Cmd+1-9 for tab selection. A backstop only: KeyRouter's monitor
+        // sees these first and swallows them. Cmd+0 is deliberately absent —
+        // it addresses a tab only as the second digit of a multi-digit run
+        // (TabIndexChord), which the monitor has already handled; on its own
+        // it belongs to ghostty as reset-font-size.
         if flags == .command, let n = Int(key), (1 ... 9).contains(n) { return true }
         // A binding the user flagged for passthrough is NOT an app shortcut
         // while a program owns this pane's keyboard — otherwise the key would

--- a/MactermTests/App/TabIndexChordTests.swift
+++ b/MactermTests/App/TabIndexChordTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+@testable import Macterm
+import Testing
+
+struct TabIndexChordTests {
+    @Test
+    func a_single_digit_selects_that_tab() {
+        var chord = TabIndexChord()
+        #expect(chord.press(digit: 3, tabCount: 5) == 3)
+    }
+
+    @Test
+    func a_second_digit_extends_the_number() {
+        var chord = TabIndexChord()
+        #expect(chord.press(digit: 1, tabCount: 12) == 1)
+        #expect(chord.press(digit: 2, tabCount: 12) == 12)
+    }
+
+    @Test
+    func zero_is_reachable_only_as_a_continuation() {
+        var chord = TabIndexChord()
+        #expect(chord.press(digit: 0, tabCount: 12) == nil)
+        #expect(chord.press(digit: 1, tabCount: 12) == 1)
+        #expect(chord.press(digit: 0, tabCount: 12) == 10)
+    }
+
+    @Test
+    func three_digits_accumulate() {
+        var chord = TabIndexChord()
+        #expect(chord.press(digit: 1, tabCount: 120) == 1)
+        #expect(chord.press(digit: 0, tabCount: 120) == 10)
+        #expect(chord.press(digit: 5, tabCount: 120) == 105)
+    }
+
+    /// The old single-digit binding's behaviour, preserved: with too few tabs
+    /// to hold the extended number, the digit starts a new one.
+    @Test
+    func a_digit_that_cannot_extend_restarts_the_number() {
+        var chord = TabIndexChord()
+        #expect(chord.press(digit: 1, tabCount: 5) == 1)
+        #expect(chord.press(digit: 2, tabCount: 5) == 2)
+        #expect(chord.press(digit: 3, tabCount: 5) == 3)
+    }
+
+    @Test
+    func a_digit_past_the_end_addresses_nothing() {
+        var chord = TabIndexChord()
+        #expect(chord.press(digit: 7, tabCount: 3) == nil)
+        #expect(chord.press(digit: 8, tabCount: 0) == nil)
+    }
+
+    /// A failed press must not leave the run open — the digit after it starts
+    /// clean rather than extending a number the user never saw selected.
+    @Test
+    func a_failed_press_ends_the_run() {
+        var chord = TabIndexChord()
+        #expect(chord.press(digit: 1, tabCount: 12) == 1)
+        #expect(chord.press(digit: 9, tabCount: 12) == 9) // 19 doesn't exist
+        #expect(chord.press(digit: 0, tabCount: 12) == nil) // 90 doesn't either
+        #expect(chord.press(digit: 2, tabCount: 12) == 2)
+    }
+
+    @Test
+    func releasing_command_ends_the_run() {
+        var chord = TabIndexChord()
+        #expect(chord.press(digit: 1, tabCount: 12) == 1)
+        chord.reset()
+        #expect(chord.press(digit: 2, tabCount: 12) == 2)
+    }
+
+    @Test
+    func an_idle_gap_ends_the_run() {
+        var chord = TabIndexChord()
+        let start = Date()
+        #expect(chord.press(digit: 1, tabCount: 12, now: start) == 1)
+        let later = start.addingTimeInterval(TabIndexChord.window + 0.5)
+        #expect(chord.press(digit: 2, tabCount: 12, now: later) == 2)
+    }
+
+    @Test
+    func digits_inside_the_window_still_join() {
+        var chord = TabIndexChord()
+        let start = Date()
+        #expect(chord.press(digit: 1, tabCount: 12, now: start) == 1)
+        let soon = start.addingTimeInterval(TabIndexChord.window / 2)
+        #expect(chord.press(digit: 2, tabCount: 12, now: soon) == 12)
+    }
+}


### PR DESCRIPTION
`Cmd+<number>` could only ever address nine tabs — a workspace with more than nine was unreachable from the keyboard past tab 9, since the binding read a single digit and stopped.

Digits now accumulate into a multi-digit number while Command stays down.

## Behaviour

- `⌘1` → tab 1, instantly, exactly as before.
- `⌘1` then `2` (Command still held) → tab 12. `⌘1` then `0` → tab 10. Three digits work too.
- A run ends when Command is released, or after a 1s idle gap between digits — so a `⌘1` now and a `⌘2` a moment later can never join into 12.
- A digit that can't extend restarts the number: with 5 tabs, `⌘1` then `⌘2` selects tab 2, which is what the single-digit binding did.
- Auto-repeat doesn't accumulate — holding `⌘1` is one request for tab 1, not a walk through 1, 11, 111.
- Bare `⌘0` still passes through to ghostty as reset-font-size; `0` addresses a tab only as a continuation digit.

## Why eager selection

The first digit switches immediately and a following digit re-selects the wider number. Deferring the switch until the number is known is the obvious alternative, but it puts a timeout's worth of latency on `⌘1` — the overwhelmingly common press — to serve the rare two-digit one. The cost of the choice is one transient switch to the single-digit tab in a workspace with ten or more tabs.

## What changed

- **`Macterm/App/TabIndexChord.swift`** (new) — the accumulator: digits, validity against the tab count, expiry. Pure and AppKit-free, so it's fully unit-testable.
- **`Responders.swift`** — the `Cmd+1-9` branch runs digits `0…9` through the chord. Digits 1-9 are still swallowed even when they address nothing, matching the old binding.
- **`MactermApp.swift`** — the flags monitor that already commits tab cycling on Ctrl release now also ends the digit run on Cmd release.
- **`AppState.swift`** — `selectableTabCount(projectID:)` bounds the accumulation, counting the same two sources `selectTabByIndex` selects from (sidebar rows in the pinned workspace, live tabs elsewhere) so the two can't disagree.
- Help text and comments that said "⌘1–9": the tab-switcher tooltip now reads `Cmd+1…<tab count>`, plus the hide-title-bar setting caption and two code comments.

## Reviewer notes

- **Not verified by hand in the running app.** Driving real modifier+digit keystrokes needs an Accessibility grant the harness doesn't have, and the control CLI bypasses `keyDown` entirely, so the keyboard route can only be exercised by a person. Worth a manual pass with ten or more tabs open.
- `GhosttyTerminalNSView.isAppShortcut` keeps its `1...9` check and deliberately does **not** gain `0`. It's a backstop only — `KeyRouter`'s monitor sees these first — and on its own `⌘0` belongs to ghostty.
- `TabIndexChordTests` covers extension, three digits, zero-only-as-continuation, restart-on-overflow, a failed press ending the run, the Command-release reset, and the timeout on both sides.
