### PR TITLE
Rename tabs by double-clicking their sidebar title

### DIFF
--- a/Macterm/App/FocusRestoration.swift
+++ b/Macterm/App/FocusRestoration.swift
@@ -15,6 +15,21 @@ enum FocusRestoration {
     private static let maxAttempts = 40
     private static let retryInterval: TimeInterval = 0.05
 
+    /// Set while a sidebar row's inline rename field is open (see
+    /// `SidebarPresentationState.beginRename`).
+    ///
+    /// Restoration is a *retry loop*, so it can land long after the call that
+    /// started it. Double-clicking an inactive tab's title both switches tabs
+    /// and opens the rename field in one gesture: the newly activated pane
+    /// transitions to focused, `TerminalSurface.updateNSView` asks for
+    /// restoration, and — when that pane's view isn't in the window yet (an
+    /// unloaded project, a pinned tab rebuilt from its declaration) — the
+    /// retry resolves several ticks later and takes first responder back off
+    /// the caret. The field stays on screen while the keystrokes go to the
+    /// shell. Rename commit and cancel both call `restoreFocusToActivePane()`,
+    /// so the terminal gets focus the moment editing ends.
+    static var isEditingInlineName = false
+
     /// Restore first responder to the pane's NSView inside `window`. If the
     /// view isn't in `window` yet (tree reshape, split tear-down), retry on the
     /// main run loop until it is or we hit the attempt cap. Safe to call from
@@ -35,6 +50,13 @@ enum FocusRestoration {
         in window: NSWindow,
         attempt: Int
     ) {
+        // Paired conditions on purpose: the flag alone would wedge terminal
+        // focus app-wide if a rename ever ended without clearing it (its row
+        // closing mid-edit, say), and the field-editor check alone would break
+        // the search bar, which restores focus *out* of its own text field.
+        if isEditingInlineName, (window.firstResponder as? NSTextView)?.isFieldEditor == true {
+            return
+        }
         if let pane = finder(), let view = pane.nsView, view.window === window {
             window.makeFirstResponder(view)
             view.notifySurfaceFocused()

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -397,6 +397,7 @@ struct SidebarContent: View {
                     tab: tab,
                     index: index + 1,
                     iconSymbolOverride: "pin",
+                    selectionItem: .tab(projectID: PinnedTabs.projectID, tabID: record.id),
                     presentation: presentation,
                     isInteractive: isInteractive,
                     onRename: { newName in
@@ -494,6 +495,7 @@ struct SidebarContent: View {
         SidebarTabRow(
             tab: tab,
             index: tabIndex + 1,
+            selectionItem: .tab(projectID: project.id, tabID: tab.id),
             presentation: presentation,
             isInteractive: isInteractive,
             // An unloaded project keeps its tabs as a layout with no shells
@@ -985,6 +987,7 @@ private struct SidebarTabRow: View {
     /// Fixed icon overriding the user's `tabIconSymbol` preference — the
     /// pinned rows pass "pin" so the icon itself marks the row's kind.
     var iconSymbolOverride: String?
+    let selectionItem: SidebarItem
     @Bindable
     var presentation: SidebarPresentationState
     let isInteractive: Bool
@@ -1019,10 +1022,11 @@ private struct SidebarTabRow: View {
                 .onAppear { focused = true }
         } else {
             TabRowTitle(tab: tab)
-                // Keep the List's native single-click selection (including
-                // modifier-click multi-selection) alive alongside rename.
-                // A plain `onTapGesture(count: 2)` owns the title's whole tap
-                // sequence and prevents the row seeing its first click.
+                // A title-level double-click gesture owns the tap sequence,
+                // so the List row never sees clicks landing on the text. Give
+                // the title the same selection path explicitly, while keeping
+                // rename simultaneous so the first click selects immediately.
+                .onTapGesture { select() }
                 .simultaneousGesture(TapGesture(count: 2).onEnded { beginRename() })
         }
     }
@@ -1101,6 +1105,22 @@ private struct SidebarTabRow: View {
             originalCustomTitle: tab.customTitle
         )
         appState.renamingTabID = nil
+    }
+
+    private func select() {
+        guard isInteractive else { return }
+        let modifiers = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if modifiers.contains(.command) {
+            if presentation.selection.contains(selectionItem) {
+                presentation.selection.remove(selectionItem)
+            } else {
+                presentation.selection.insert(selectionItem)
+            }
+        } else if modifiers.contains(.shift) {
+            presentation.selection.insert(selectionItem)
+        } else {
+            presentation.selection = [selectionItem]
+        }
     }
 
     private func commit() {

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -1019,6 +1019,7 @@ private struct SidebarTabRow: View {
                 .onAppear { focused = true }
         } else {
             TabRowTitle(tab: tab)
+                .onTapGesture(count: 2) { beginRename() }
         }
     }
 

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -1019,7 +1019,11 @@ private struct SidebarTabRow: View {
                 .onAppear { focused = true }
         } else {
             TabRowTitle(tab: tab)
-                .onTapGesture(count: 2) { beginRename() }
+                // Keep the List's native single-click selection (including
+                // modifier-click multi-selection) alive alongside rename.
+                // A plain `onTapGesture(count: 2)` owns the title's whole tap
+                // sequence and prevents the row seeing its first click.
+                .simultaneousGesture(TapGesture(count: 2).onEnded { beginRename() })
         }
     }
 

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -339,7 +339,16 @@ struct SidebarContent: View {
             // puts the ink an equal ~20.5pt off both the left and bottom edges.
             .padding(.bottom, 20)
         }
+        .onChange(of: orderedItems, initial: true) { _, items in
+            presentation.orderedItems = items
+        }
         .onChange(of: presentation.selection) { _, items in
+            // Whatever collapses the sidebar to a single row becomes the row a
+            // later shift-click extends from — a native click on a row's icon
+            // or padding, a title click, or `syncSelection` after a tab switch.
+            // Watching the selection rather than writing the anchor at each
+            // click site is what keeps ours and AppKit's the same row.
+            if items.count == 1 { presentation.selectionAnchor = items.first }
             // Navigation follows a single selection only. A multi-selection is
             // for bulk actions (delete), so it must not yank the active project
             // or tab around as rows are added to the selection.
@@ -575,6 +584,25 @@ struct SidebarContent: View {
             // drop stays on target.
             if targeted { presentation.expandedProjects.insert(project.id) }
         }
+    }
+
+    /// Every visible row in visual order, mirroring the `List` body: the
+    /// pinned records, then each project's header followed by its tabs while
+    /// that project is expanded. Published to `presentation` so a shift-click
+    /// on a row title can resolve the range between two rows — the List keeps
+    /// its own copy of this order for the clicks it still handles itself.
+    private var orderedItems: [SidebarItem] {
+        var items: [SidebarItem] = appState.pinnedRecords.map {
+            .tab(projectID: PinnedTabs.projectID, tabID: $0.id)
+        }
+        for project in projectStore.projects {
+            items.append(.project(project.id))
+            guard presentation.expandedProjects.contains(project.id) else { continue }
+            items.append(contentsOf: (appState.workspaces[project.id]?.tabs ?? []).map {
+                .tab(projectID: project.id, tabID: $0.id)
+            })
+        }
+        return items
     }
 
     private var activeTabID: UUID? {
@@ -1107,18 +1135,37 @@ private struct SidebarTabRow: View {
         appState.renamingTabID = nil
     }
 
+    /// Stand in for the List's own click handling, which never sees a press
+    /// that lands on the title (see `titleContent`).
+    ///
+    /// Shift has to extend the range between the anchor and this row, not just
+    /// add this row: the selection drives the bulk "Close N Tabs" / "Remove N
+    /// Projects" actions, so inserting one row means clicking 1 and
+    /// shift-clicking 5 closes 2 tabs instead of 5.
     private func select() {
         guard isInteractive else { return }
-        let modifiers = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        // The event being handled, not the keyboard's state whenever the
+        // gesture happens to resolve — a Command released with the mouse
+        // button would otherwise read as a plain click and collapse an
+        // in-progress multi-selection down to this one row.
+        let current = NSApp.currentEvent?.modifierFlags ?? NSEvent.modifierFlags
+        let modifiers = current.intersection(.deviceIndependentFlagsMask)
         if modifiers.contains(.command) {
             if presentation.selection.contains(selectionItem) {
                 presentation.selection.remove(selectionItem)
             } else {
                 presentation.selection.insert(selectionItem)
             }
-        } else if modifiers.contains(.shift) {
-            presentation.selection.insert(selectionItem)
+        } else if modifiers.contains(.shift),
+                  let anchor = presentation.selectionAnchor,
+                  anchor != selectionItem,
+                  let range = presentation.itemRange(from: anchor, to: selectionItem)
+        {
+            presentation.selection = Set(range)
         } else {
+            // Includes a shift-click with no usable anchor (nothing selected
+            // yet, or the anchor's row has since gone): AppKit selects just the
+            // clicked row there too.
             presentation.selection = [selectionItem]
         }
     }

--- a/Macterm/Views/SidebarPresentationState.swift
+++ b/Macterm/Views/SidebarPresentationState.swift
@@ -36,6 +36,10 @@ final class SidebarPresentationState {
         renameTarget = target
         renameText = text
         self.originalCustomTitle = originalCustomTitle
+        // A rename opened by double-clicking an inactive row also switches to
+        // it, and the pane that becomes focused asks for first responder on a
+        // retry loop that can outlive this gesture. See the flag's own notes.
+        FocusRestoration.isEditingInlineName = true
     }
 
     func isRenaming(_ target: SidebarRenameTarget) -> Bool {
@@ -66,5 +70,6 @@ final class SidebarPresentationState {
         renameTarget = nil
         renameText = ""
         originalCustomTitle = nil
+        FocusRestoration.isEditingInlineName = false
     }
 }

--- a/Macterm/Views/SidebarPresentationState.swift
+++ b/Macterm/Views/SidebarPresentationState.swift
@@ -25,6 +25,20 @@ final class SidebarPresentationState {
     var scrollPosition: SidebarItem?
     var renameText = ""
 
+    /// Every row the sidebar is currently showing, in visual order (pinned
+    /// records, then each project's header followed by its tabs while it is
+    /// expanded). `SidebarContent` publishes it because it is the view that
+    /// builds that order; it exists so a shift-click can resolve the range
+    /// between two rows. Empty until the first publish.
+    var orderedItems: [SidebarItem] = []
+
+    /// The row a shift-click extends *from* — the last row that ended up as
+    /// the whole selection, however it got there (a native click on a row's
+    /// icon or padding, a title click, or `syncSelection` following a tab
+    /// switch). AppKit keeps the same anchor for the List's own rows, so
+    /// tracking single-selection is what keeps the two in step.
+    var selectionAnchor: SidebarItem?
+
     private(set) var renameTarget: SidebarRenameTarget?
     private(set) var originalCustomTitle: String?
 
@@ -40,6 +54,17 @@ final class SidebarPresentationState {
         // it, and the pane that becomes focused asks for first responder on a
         // retry loop that can outlive this gesture. See the flag's own notes.
         FocusRestoration.isEditingInlineName = true
+    }
+
+    /// The inclusive run of visible rows between two items, in visual order —
+    /// the selection a shift-click produces. Nil when either row has since
+    /// gone (a closed tab, a collapsed project), so the caller can fall back
+    /// to selecting the clicked row alone.
+    func itemRange(from anchor: SidebarItem, to item: SidebarItem) -> [SidebarItem]? {
+        guard let start = orderedItems.firstIndex(of: anchor),
+              let end = orderedItems.firstIndex(of: item)
+        else { return nil }
+        return Array(orderedItems[min(start, end) ... max(start, end)])
     }
 
     func isRenaming(_ target: SidebarRenameTarget) -> Bool {

--- a/MactermTests/Views/SidebarPresentationStateTests.swift
+++ b/MactermTests/Views/SidebarPresentationStateTests.swift
@@ -56,6 +56,52 @@ struct SidebarPresentationStateTests {
         #expect(state.scrollPosition == .tab(projectID: projectID, tabID: tabID))
     }
 
+    @Test
+    func a_shift_click_range_spans_every_row_between_the_two_ends() {
+        let state = SidebarPresentationState()
+        let projectID = UUID()
+        let tabs = (0 ..< 5).map { _ in UUID() }
+        state.orderedItems = [.project(projectID)]
+            + tabs.map { .tab(projectID: projectID, tabID: $0) }
+
+        let range = state.itemRange(
+            from: .tab(projectID: projectID, tabID: tabs[0]),
+            to: .tab(projectID: projectID, tabID: tabs[3])
+        )
+
+        #expect(range == tabs[0 ... 3].map { .tab(projectID: projectID, tabID: $0) })
+    }
+
+    @Test
+    func a_shift_click_range_reads_the_same_dragged_upward() {
+        let state = SidebarPresentationState()
+        let projectID = UUID()
+        let tabs = (0 ..< 3).map { _ in UUID() }
+        state.orderedItems = tabs.map { .tab(projectID: projectID, tabID: $0) }
+
+        let up = state.itemRange(
+            from: .tab(projectID: projectID, tabID: tabs[2]),
+            to: .tab(projectID: projectID, tabID: tabs[0])
+        )
+
+        #expect(up == state.orderedItems)
+    }
+
+    @Test
+    func a_range_off_a_vanished_row_is_nil_rather_than_a_wrong_span() {
+        let state = SidebarPresentationState()
+        let projectID = UUID()
+        let tabID = UUID()
+        state.orderedItems = [.tab(projectID: projectID, tabID: tabID)]
+
+        // The anchor's tab was closed (or its project collapsed) since the
+        // click that set it — the caller selects just the clicked row.
+        #expect(state.itemRange(
+            from: .tab(projectID: projectID, tabID: UUID()),
+            to: .tab(projectID: projectID, tabID: tabID)
+        ) == nil)
+    }
+
     /// The flag is one process-wide value (it gates a global retry loop), so
     /// these two set it from a known state and hand it back — a sibling test
     /// that leaves a rename open must not decide whether they pass.

--- a/MactermTests/Views/SidebarPresentationStateTests.swift
+++ b/MactermTests/Views/SidebarPresentationStateTests.swift
@@ -55,4 +55,34 @@ struct SidebarPresentationStateTests {
         #expect(state.selection == [.tab(projectID: projectID, tabID: tabID)])
         #expect(state.scrollPosition == .tab(projectID: projectID, tabID: tabID))
     }
+
+    /// The flag is one process-wide value (it gates a global retry loop), so
+    /// these two set it from a known state and hand it back — a sibling test
+    /// that leaves a rename open must not decide whether they pass.
+    @Test
+    func an_open_rename_holds_focus_restoration_off_until_it_ends() {
+        FocusRestoration.isEditingInlineName = false
+        defer { FocusRestoration.isEditingInlineName = false }
+        let state = SidebarPresentationState()
+        let tabID = UUID()
+
+        state.beginRename(.tab(tabID), text: "draft")
+        #expect(FocusRestoration.isEditingInlineName)
+
+        _ = state.completeRename(.tab(tabID))
+        #expect(!FocusRestoration.isEditingInlineName)
+    }
+
+    @Test
+    func cancelling_a_rename_also_releases_focus_restoration() {
+        FocusRestoration.isEditingInlineName = false
+        defer { FocusRestoration.isEditingInlineName = false }
+        let state = SidebarPresentationState()
+        let tabID = UUID()
+
+        state.beginRename(.tab(tabID), text: "draft")
+        #expect(state.cancelRename(.tab(tabID)))
+
+        #expect(!FocusRestoration.isEditingInlineName)
+    }
 }


### PR DESCRIPTION
## What

Double-clicking a tab name in the sidebar now opens the existing inline rename field.

## Why

Renaming currently sits behind the context menu. The tab name is already the obvious place to edit it.

## How

The title uses the same selection binding as the rest of the row, so its first click selects the tab immediately. A second click opens the existing rename field. Context menu and keyboard behaviour stay unchanged.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior

The end-to-end suite passes: 15 tests passed and the Docker-only remote fixture was skipped.

## Notes for reviewers

The screenshot uses temporary local projects. “Design system” is in the inline editor after double-clicking its title.

<img width="1200" height="800" alt="Sidebar tab in edit mode after a double-click" src="https://github.com/user-attachments/assets/03c59a38-b61d-44f3-9df4-714724c5f1a9" />