### PR TITLE
Split the persistence and multiplexing feature claims apart

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ _The command palette (⌘P) jumps to a project, switches tabs, or runs any actio
 
 ## Features
 
-- **Persistent multiplexing** \
-  Projects, tabs, and split panes are saved and restored on relaunch. Quitting detaches your shells; relaunching brings them back with scrollback and running processes intact.
+- **Session persistence** \
+  Quitting detaches your shells instead of killing them; relaunching brings them back with scrollback and running processes intact.
+- **Multiplexing** \
+  Drag a pane onto another to join them, or separate one into its own tab — by drag or by keybind. Projects, tabs, and split layouts are saved and restored on relaunch.
 - **Remote projects** \
   Open a directory on another machine over SSH. Your shells keep running there, surviving quits, dropped connections, and even a local reboot.
 - **Vertical project sidebar** \

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -109,56 +109,61 @@
     <section class="mx-auto" style="max-width:1180px;padding:clamp(88px,12vw,140px) var(--site-gutter) 48px">
       <div class="flex justify-between items-baseline mb-6">
         <h2 class="text-[22px] font-medium m-0">Features</h2>
-        <span class="font-mono text-[12px] text-meta">ten of them</span>
+        <span class="font-mono text-[12px] text-meta">eleven of them</span>
       </div>
       <div>
         <div data-reveal class="feature-row">
           <span class="font-mono text-[13px] text-meta">01</span>
-          <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Persistent multiplexing</h3>
-          <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Projects, tabs, and panes are saved and restored on relaunch. Quit the app; your whole workspace comes back — scrollback and running processes intact.</p>
+          <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Session persistence</h3>
+          <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Quitting detaches your shells instead of killing them. Relaunch; they come back — scrollback and running processes intact.</p>
         </div>
         <div data-reveal class="feature-row">
           <span class="font-mono text-[13px] text-meta">02</span>
+          <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Multiplexing</h3>
+          <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Drag a pane onto another to join them, or separate one into its own tab — by drag or by keybind. Projects, tabs, and split layouts are saved and restored on relaunch.</p>
+        </div>
+        <div data-reveal class="feature-row">
+          <span class="font-mono text-[13px] text-meta">03</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Remote projects</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Open a directory on another machine over SSH. Panes persist <em>on the host</em>, surviving quits, dropped connections, even a local reboot.</p>
         </div>
         <div data-reveal class="feature-row">
-          <span class="font-mono text-[13px] text-meta">03</span>
+          <span class="font-mono text-[13px] text-meta">04</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Vertical project sidebar</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Organize projects and their tabs in a native macOS sidebar, stacked vertically where there's actually room to read them.</p>
         </div>
         <div data-reveal class="feature-row">
-          <span class="font-mono text-[13px] text-meta">04</span>
+          <span class="font-mono text-[13px] text-meta">05</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Pinned tabs</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Pin a tab above your projects to keep it running — it starts on every launch, and restores itself with its command if the session dies.</p>
         </div>
         <div data-reveal class="feature-row">
-          <span class="font-mono text-[13px] text-meta">05</span>
+          <span class="font-mono text-[13px] text-meta">06</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Command palette</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Press <kbd class="font-mono bg-chip border border-[rgba(23,21,15,0.16)] rounded-[5px]" style="font-size:.8em;padding:.1em .4em">⌘P</kbd> to split panes, switch projects, or open a directory — every action a keystroke away.</p>
         </div>
         <div data-reveal class="feature-row">
-          <span class="font-mono text-[13px] text-meta">06</span>
+          <span class="font-mono text-[13px] text-meta">07</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Declarative layouts</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Describe a project's tabs, splits, and per-pane commands in <code class="font-mono" style="font-size:.85em">~/.config/macterm/projects/</code>. Open it; the workspace builds itself.</p>
         </div>
         <div data-reveal class="feature-row">
-          <span class="font-mono text-[13px] text-meta">07</span>
+          <span class="font-mono text-[13px] text-meta">08</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Control CLI</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">A bundled <code class="font-mono" style="font-size:.85em">macterm</code> command drives the running app over a socket — so scripts and AI agents can spawn panes and run commands.</p>
         </div>
         <div data-reveal class="feature-row">
-          <span class="font-mono text-[13px] text-meta">08</span>
+          <span class="font-mono text-[13px] text-meta">09</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Quick terminal</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">A global terminal that drops down from anywhere with a hotkey, then gets out of your way when you're done.</p>
         </div>
         <div data-reveal class="feature-row">
-          <span class="font-mono text-[13px] text-meta">09</span>
+          <span class="font-mono text-[13px] text-meta">10</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Adaptive background</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">The window picks up the background color the running program paints. A full-screen TUI tints the whole window to match; in a split, each pane takes its own.</p>
         </div>
         <div data-reveal class="feature-row">
-          <span class="font-mono text-[13px] text-meta">10</span>
+          <span class="font-mono text-[13px] text-meta">11</span>
           <h3 class="font-sans font-medium leading-[1.02] tracking-[-0.02em] m-0" style="font-size:clamp(24px,3.4vw,40px)">Ghostty compatibility</h3>
           <p class="text-[16px] leading-[1.5] text-body m-0" style="max-width:46ch">Reads your existing <code class="font-mono" style="font-size:.85em">ghostty/config</code>. Theme, font, keybinds — all of it just works.</p>
         </div>


### PR DESCRIPTION
## What

Splits the "Persistent multiplexing" feature row into two — **Session persistence** and **Multiplexing** — in the README and on the website's features section.

## Why

The old row bundled two independent selling points into one, and the multiplexing half went effectively unsaid: nothing in the features list mentioned that panes and tabs can be joined or separated at all. Session persistence deserves to stand alone as *the* process-preserving claim, and multiplexing deserves to name the rearranging it actually does.

## How

- **Session persistence** — detach-on-quit, scrollback and running processes intact.
- **Multiplexing** — drag a pane onto another to join them, or separate one into its own tab, by drag or by keybind; projects, tabs, and split layouts are saved and restored.

The keybind half is accurate against the app: `separateCurrentPane` / `separateAllPanes` are real `AppCommand`s (palette-invokable and rebindable, unbound by default). Joining is drag-only — `AppState.mergeTab` / `Workspace.movePane` have no command or keybind — which is why the copy names drag first and doesn't promise a keybind for that direction.

On the website the two rows take slots 01/02, the remaining nine renumbered 03–11, and the section caption went from "ten of them" to "eleven of them".

The hero, `og:`/`twitter:` descriptions, and the JSON-LD blurb still say "session persistence, smart multiplexing" / "persistent multiplexing" — left alone deliberately, since they're taglines rather than the list this PR is about.

## Verified

Copy-only change (Markdown + static HTML); no Swift touched, so the Swift gates don't apply. Reviewed the rendered diff and confirmed the renumbering is contiguous 01–11 with no duplicates.