### PR TITLE
feat: add directory preferences for new tabs and splits

### DIFF
--- a/Macterm/App/AppCommandActions.swift
+++ b/Macterm/App/AppCommandActions.swift
@@ -115,13 +115,25 @@ extension AppCommand {
             return { ctx.appState.separatePane(paneID, toProject: projectID, destPath: destPath, at: index) }
         case .splitRight:
             guard let projectID else { return nil }
-            return { ctx.appState.splitPane(direction: .horizontal, projectID: projectID) }
+            return {
+                ctx.appState.splitPane(
+                    direction: .horizontal,
+                    projectID: projectID,
+                    projects: ctx.projectStore.projects
+                )
+            }
         case .splitDown:
             guard let projectID else { return nil }
-            return { ctx.appState.splitPane(direction: .vertical, projectID: projectID) }
+            return {
+                ctx.appState.splitPane(
+                    direction: .vertical,
+                    projectID: projectID,
+                    projects: ctx.projectStore.projects
+                )
+            }
         case .splitAuto:
             guard let projectID else { return nil }
-            return { ctx.appState.autoSplitPane(projectID: projectID) }
+            return { ctx.appState.autoSplitPane(projectID: projectID, projects: ctx.projectStore.projects) }
         case .zoomPane:
             guard let projectID else { return nil }
             return { ctx.appState.toggleZoom(projectID: projectID) }

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -1222,10 +1222,12 @@ final class AppState {
             return nil
         }
         let activePaneDirectory = focusedPane(for: projectID)?.liveLocalWorkingDirectory()
+        // A brand-new tab has no source pane to inherit from, so an
+        // unusable active-pane cwd (nil) lands in the project directory.
         let newTabDirectory = Preferences.shared.newTabWorkingDirectory.resolveNewTerminalDirectory(
             projectDirectory: projectDirectory,
             activePaneDirectory: activePaneDirectory
-        )
+        ) ?? projectDirectory
         // The cwd is user-selectable, but zmx session grouping remains project-scoped.
         let projectSessionSlug = (projectDirectory as NSString).lastPathComponent
         return createTab(
@@ -1655,16 +1657,6 @@ final class AppState {
 
     // MARK: - Splits
 
-    /// Low-level split that preserves source-pane cwd inheritance.
-    func splitPane(direction: SplitDirection, projectID: UUID) {
-        guard let tab = workspaces[projectID]?.activeTab,
-              let paneID = tab.focusedPaneID
-        else { return }
-        logger.debug("splitPane: \(String(describing: direction), privacy: .public) pane=\(paneID, privacy: .public)")
-        tab.split(paneID: paneID, direction: direction)
-        saveWorkspaces()
-    }
-
     /// Splits the focused pane using the user's new split directory preference.
     func splitPane(direction: SplitDirection, projectID: UUID, projects: [Project]) {
         guard let tab = workspaces[projectID]?.activeTab,
@@ -1692,10 +1684,14 @@ final class AppState {
               let tab = ws.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil }),
               let pane = tab.splitRoot.findPane(id: paneID)
         else { return nil }
+        // nil = inherit (the source pane's live cwd, else its own
+        // `projectPath`) — never coerced to the project root, which would
+        // turn a remote pane's split into a local shell.
         let newPaneDirectory = Preferences.shared.newSplitWorkingDirectory.resolveNewTerminalDirectory(
             projectDirectory: projectDirectory,
             activePaneDirectory: pane.liveLocalWorkingDirectory()
         )
+        logger.debug("splitPane: \(String(describing: direction), privacy: .public) pane=\(paneID, privacy: .public)")
         return splitPane(
             paneID,
             direction: direction,
@@ -1731,20 +1727,34 @@ final class AppState {
     }
 
     /// Split a pane into an equal `rows`×`columns` grid (see
-    /// `TerminalTab.makeGrid`), spawning `command` in each new pane. Returns
-    /// the new pane IDs.
+    /// `TerminalTab.makeGrid`), spawning `command` in each new pane. Every
+    /// cell honors the new split directory preference, so a grid and a
+    /// `Cmd+D` split off the same pane can't disagree about it. Returns the
+    /// new pane IDs.
     @discardableResult
     func makeGrid(
         _ paneID: UUID,
         rows: Int,
         columns: Int,
         projectID: UUID,
+        projectDirectory: String,
         command: String? = nil
     ) -> [UUID] {
         guard let ws = workspaces[projectID],
-              let tab = ws.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil })
+              let tab = ws.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil }),
+              let pane = tab.splitRoot.findPane(id: paneID)
         else { return [] }
-        let created = tab.makeGrid(paneID: paneID, rows: rows, columns: columns, command: command)
+        let newPaneDirectory = Preferences.shared.newSplitWorkingDirectory.resolveNewTerminalDirectory(
+            projectDirectory: projectDirectory,
+            activePaneDirectory: pane.liveLocalWorkingDirectory()
+        )
+        let created = tab.makeGrid(
+            paneID: paneID,
+            rows: rows,
+            columns: columns,
+            command: command,
+            newPaneWorkingDirectory: newPaneDirectory
+        )
         if !created.isEmpty { saveWorkspaces() }
         return created
     }

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -1200,9 +1200,14 @@ final class AppState {
     /// `run:` semantics). Returns the new tab's ID, nil when the project has
     /// no live workspace.
     @discardableResult
-    func createTab(projectID: UUID, projectPath: String, command: String? = nil) -> UUID? {
+    func createTab(
+        projectID: UUID,
+        projectPath: String,
+        sessionSlug: String? = nil,
+        command: String? = nil
+    ) -> UUID? {
         guard let ws = workspaces[projectID] else { return nil }
-        let tab = ws.createTab(projectPath: projectPath, command: command)
+        let tab = ws.createTab(projectPath: projectPath, sessionSlug: sessionSlug, command: command)
         logger.debug("createTab: project=\(projectID, privacy: .public) tabs=\(ws.tabs.count, privacy: .public)")
         saveWorkspaces()
         return tab.id
@@ -1212,19 +1217,21 @@ final class AppState {
     /// Active pane falls back to the project path when no local cwd is available.
     /// The pinned workspace falls back to home.
     func createTab(projectID: UUID, projects: [Project]) {
-        let projectDirectory: String
-        if projectID == PinnedTabs.projectID {
-            projectDirectory = PinnedTabs.fallbackRoot
-        } else {
-            guard let project = projects.first(where: { $0.id == projectID }) else { return }
-            projectDirectory = project.path
-        }
+        guard let projectDirectory = configuredProjectDirectory(projectID: projectID, projects: projects) else { return }
         let activePaneDirectory = focusedPane(for: projectID)?.liveLocalWorkingDirectory()
-        let newTabDirectory = Preferences.shared.newTabWorkingDirectory.resolveNewTabDirectory(
+        let newTabDirectory = Preferences.shared.newTabWorkingDirectory.resolveNewTerminalDirectory(
             projectDirectory: projectDirectory,
             activePaneDirectory: activePaneDirectory
         )
-        createTab(projectID: projectID, projectPath: newTabDirectory)
+        // The cwd is user-selectable, but zmx session grouping remains project-scoped.
+        let projectSessionSlug = (projectDirectory as NSString).lastPathComponent
+        createTab(projectID: projectID, projectPath: newTabDirectory, sessionSlug: projectSessionSlug)
+    }
+
+    /// Returns the configured project root, including the synthetic pinned workspace fallback.
+    private func configuredProjectDirectory(projectID: UUID, projects: [Project]) -> String? {
+        if projectID == PinnedTabs.projectID { return PinnedTabs.fallbackRoot }
+        return projects.first(where: { $0.id == projectID })?.path
     }
 
     /// The teardown half of `closeTab`, without the workspace save — so a
@@ -1640,6 +1647,9 @@ final class AppState {
 
     // MARK: - Splits
 
+    /// Low-level split that preserves source-pane cwd inheritance.
+    /// Interactive UI callers use the projects overload below so the Project
+    /// preference has the configured project root available.
     func splitPane(direction: SplitDirection, projectID: UUID) {
         guard let tab = workspaces[projectID]?.activeTab,
               let paneID = tab.focusedPaneID
@@ -1647,6 +1657,44 @@ final class AppState {
         logger.debug("splitPane: \(String(describing: direction), privacy: .public) pane=\(paneID, privacy: .public)")
         tab.split(paneID: paneID, direction: direction)
         saveWorkspaces()
+    }
+
+    /// Splits the focused pane using the user's new split directory preference.
+    func splitPane(direction: SplitDirection, projectID: UUID, projects: [Project]) {
+        guard let tab = workspaces[projectID]?.activeTab,
+              let paneID = tab.focusedPaneID,
+              let projectDirectory = configuredProjectDirectory(projectID: projectID, projects: projects)
+        else { return }
+        splitPane(
+            paneID,
+            direction: direction,
+            projectID: projectID,
+            projectDirectory: projectDirectory
+        )
+    }
+
+    /// Splits a specific interactive pane using the user's new split directory preference.
+    @discardableResult
+    func splitPane(
+        _ paneID: UUID,
+        direction: SplitDirection,
+        projectID: UUID,
+        projectDirectory: String
+    ) -> UUID? {
+        guard let ws = workspaces[projectID],
+              let tab = ws.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil }),
+              let pane = tab.splitRoot.findPane(id: paneID)
+        else { return nil }
+        let newPaneDirectory = Preferences.shared.newSplitWorkingDirectory.resolveNewTerminalDirectory(
+            projectDirectory: projectDirectory,
+            activePaneDirectory: pane.liveLocalWorkingDirectory()
+        )
+        return splitPane(
+            paneID,
+            direction: direction,
+            projectID: projectID,
+            newPaneWorkingDirectory: newPaneDirectory
+        )
     }
 
     /// Split a SPECIFIC pane — found in whichever of the project's tabs holds
@@ -1658,12 +1706,18 @@ final class AppState {
         _ paneID: UUID,
         direction: SplitDirection,
         projectID: UUID,
-        command: String? = nil
+        command: String? = nil,
+        newPaneWorkingDirectory: String? = nil
     ) -> UUID? {
         guard let ws = workspaces[projectID],
               let tab = ws.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil })
         else { return nil }
-        let newID = tab.split(paneID: paneID, direction: direction, command: command)
+        let newID = tab.split(
+            paneID: paneID,
+            direction: direction,
+            command: command,
+            newPaneWorkingDirectory: newPaneWorkingDirectory
+        )
         saveWorkspaces()
         return newID
     }
@@ -1689,11 +1743,17 @@ final class AppState {
 
     /// Split the focused pane along its longer on-screen axis (Ghostty's
     /// `new_split` / BSP behavior). Direction is decided by `TerminalTab.autoSplit`.
-    func autoSplitPane(projectID: UUID) {
+    func autoSplitPane(projectID: UUID, projects: [Project]) {
         guard let tab = workspaces[projectID]?.activeTab,
-              let paneID = tab.focusedPaneID
+              let paneID = tab.focusedPaneID,
+              let pane = tab.focusedPane,
+              let projectDirectory = configuredProjectDirectory(projectID: projectID, projects: projects)
         else { return }
-        tab.autoSplit(paneID: paneID)
+        let newPaneDirectory = Preferences.shared.newSplitWorkingDirectory.resolveNewTerminalDirectory(
+            projectDirectory: projectDirectory,
+            activePaneDirectory: pane.liveLocalWorkingDirectory()
+        )
+        tab.autoSplit(paneID: paneID, newPaneWorkingDirectory: newPaneDirectory)
         saveWorkspaces()
     }
 

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -986,9 +986,8 @@ final class AppState {
     /// and wants new tabs / persisted state to start there.
     ///
     /// No-op when there's no active project or no resolvable pwd. We don't
-    /// touch open panes or workspaces — those keep their current cwd; only
-    /// future tabs created via `createTab(projectID:projects:)` (which reads
-    /// `project.path`) will land in the new directory.
+    /// touch open panes or workspaces. They keep their current cwd. Future tabs
+    /// use the new directory when "New tab directory" is set to Project.
     func replaceProjectPathWithCurrentDir(projectStore: ProjectStore) {
         guard let projectID = activeProjectID,
               let project = projectStore.projects.first(where: { $0.id == projectID }),
@@ -1209,18 +1208,23 @@ final class AppState {
         return tab.id
     }
 
-    /// Convenience overload: look up the project's canonical path from the
-    /// given projects list so new tabs always land in the project directory,
-    /// not whatever cwd the last pane drifted to. A new tab in the PINNED
-    /// workspace (no project directory) starts at home; it's pinned from
-    /// birth — `saveWorkspaces` gives it a record.
+    /// Creates an interactive tab in the directory selected in Settings.
+    /// Active pane falls back to the project path when no local cwd is available.
+    /// The pinned workspace falls back to home.
     func createTab(projectID: UUID, projects: [Project]) {
+        let projectDirectory: String
         if projectID == PinnedTabs.projectID {
-            createTab(projectID: projectID, projectPath: PinnedTabs.fallbackRoot)
-            return
+            projectDirectory = PinnedTabs.fallbackRoot
+        } else {
+            guard let project = projects.first(where: { $0.id == projectID }) else { return }
+            projectDirectory = project.path
         }
-        guard let project = projects.first(where: { $0.id == projectID }) else { return }
-        createTab(projectID: projectID, projectPath: project.path)
+        let activePaneDirectory = focusedPane(for: projectID)?.liveLocalWorkingDirectory()
+        let newTabDirectory = Preferences.shared.newTabWorkingDirectory.resolveNewTabDirectory(
+            projectDirectory: projectDirectory,
+            activePaneDirectory: activePaneDirectory
+        )
+        createTab(projectID: projectID, projectPath: newTabDirectory)
     }
 
     /// The teardown half of `closeTab`, without the workspace save — so a

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -1213,11 +1213,14 @@ final class AppState {
         return tab.id
     }
 
-    /// Creates an interactive tab in the directory selected in Settings.
+    /// Creates a tab in the directory selected in Settings.
     /// Active pane falls back to the project path when no local cwd is available.
     /// The pinned workspace falls back to home.
-    func createTab(projectID: UUID, projects: [Project]) {
-        guard let projectDirectory = configuredProjectDirectory(projectID: projectID, projects: projects) else { return }
+    @discardableResult
+    func createTab(projectID: UUID, projects: [Project], command: String? = nil) -> UUID? {
+        guard let projectDirectory = configuredProjectDirectory(projectID: projectID, projects: projects) else {
+            return nil
+        }
         let activePaneDirectory = focusedPane(for: projectID)?.liveLocalWorkingDirectory()
         let newTabDirectory = Preferences.shared.newTabWorkingDirectory.resolveNewTerminalDirectory(
             projectDirectory: projectDirectory,
@@ -1225,7 +1228,12 @@ final class AppState {
         )
         // The cwd is user-selectable, but zmx session grouping remains project-scoped.
         let projectSessionSlug = (projectDirectory as NSString).lastPathComponent
-        createTab(projectID: projectID, projectPath: newTabDirectory, sessionSlug: projectSessionSlug)
+        return createTab(
+            projectID: projectID,
+            projectPath: newTabDirectory,
+            sessionSlug: projectSessionSlug,
+            command: command
+        )
     }
 
     /// Returns the configured project root, including the synthetic pinned workspace fallback.
@@ -1648,8 +1656,6 @@ final class AppState {
     // MARK: - Splits
 
     /// Low-level split that preserves source-pane cwd inheritance.
-    /// Interactive UI callers use the projects overload below so the Project
-    /// preference has the configured project root available.
     func splitPane(direction: SplitDirection, projectID: UUID) {
         guard let tab = workspaces[projectID]?.activeTab,
               let paneID = tab.focusedPaneID
@@ -1673,13 +1679,14 @@ final class AppState {
         )
     }
 
-    /// Splits a specific interactive pane using the user's new split directory preference.
+    /// Splits a specific pane using the user's new split directory preference.
     @discardableResult
     func splitPane(
         _ paneID: UUID,
         direction: SplitDirection,
         projectID: UUID,
-        projectDirectory: String
+        projectDirectory: String,
+        command: String? = nil
     ) -> UUID? {
         guard let ws = workspaces[projectID],
               let tab = ws.tabs.first(where: { $0.splitRoot.findPane(id: paneID) != nil }),
@@ -1693,6 +1700,7 @@ final class AppState {
             paneID,
             direction: direction,
             projectID: projectID,
+            command: command,
             newPaneWorkingDirectory: newPaneDirectory
         )
     }

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -16,12 +16,19 @@ enum NewTerminalWorkingDirectory: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Uses the active pane cwd when selected and available. Otherwise, uses the project directory.
-    func resolveNewTerminalDirectory(projectDirectory: String, activePaneDirectory: String?) -> String {
-        guard self == .activePaneDirectory,
-              let activePaneDirectory,
-              !activePaneDirectory.isEmpty
-        else { return projectDirectory }
+    /// The directory a new terminal must start in, or nil for "keep the
+    /// caller's own inheritance". Nil is only ever "Active pane" with no
+    /// usable LOCAL cwd — every remote pane, and any pane whose surface
+    /// isn't up yet — and coercing that case to the project root would be
+    /// wrong: `TerminalTab.split` inherits a remote pane's scp-style
+    /// `projectPath` verbatim, so overriding it spawns a LOCAL shell at the
+    /// project root instead of a remote sibling (and a pinned pane, whose
+    /// own `projectPath` IS its cwd, would land at home). Callers with
+    /// nothing to inherit from (a brand-new tab) coalesce to the project
+    /// directory themselves.
+    func resolveNewTerminalDirectory(projectDirectory: String, activePaneDirectory: String?) -> String? {
+        guard self == .activePaneDirectory else { return projectDirectory }
+        guard let activePaneDirectory, !activePaneDirectory.isEmpty else { return nil }
         return activePaneDirectory
     }
 }

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -2,8 +2,8 @@ import AppKit
 import Foundation
 import Observation
 
-/// Determines whether a new tab starts in the project directory or the focused pane's cwd.
-enum NewTabWorkingDirectory: String, CaseIterable, Identifiable {
+/// Determines whether a new terminal starts in the project directory or the focused pane's cwd.
+enum NewTerminalWorkingDirectory: String, CaseIterable, Identifiable {
     case projectDirectory = "project"
     case activePaneDirectory = "active_pane"
 
@@ -16,8 +16,8 @@ enum NewTabWorkingDirectory: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Uses the active pane cwd when selected and nonempty. Otherwise, uses the project directory.
-    func resolveNewTabDirectory(projectDirectory: String, activePaneDirectory: String?) -> String {
+    /// Uses the active pane cwd when selected and available. Otherwise, uses the project directory.
+    func resolveNewTerminalDirectory(projectDirectory: String, activePaneDirectory: String?) -> String {
         guard self == .activePaneDirectory,
               let activePaneDirectory,
               !activePaneDirectory.isEmpty
@@ -239,8 +239,13 @@ final class Preferences {
     }
 
     /// Selection shown by "New tab directory" in Settings.
-    var newTabWorkingDirectory: NewTabWorkingDirectory {
+    var newTabWorkingDirectory: NewTerminalWorkingDirectory {
         didSet { defaults.set(newTabWorkingDirectory.rawValue, forKey: Keys.newTabWorkingDirectory) }
+    }
+
+    /// Selection shown by "New split directory" in Settings.
+    var newSplitWorkingDirectory: NewTerminalWorkingDirectory {
+        didSet { defaults.set(newSplitWorkingDirectory.rawValue, forKey: Keys.newSplitWorkingDirectory) }
     }
 
     /// Presentation used by `peekSidebarWhenHidden`. The pinned sidebar is
@@ -719,8 +724,12 @@ final class Preferences {
         self.defaults = defaults
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
         terminalScrollSpeed = Self.clampScrollSpeed(defaults.double(forKey: Keys.terminalScrollSpeed), fallback: 1.0)
+        // Defaults preserve the behavior from before these preferences existed:
+        // new tabs started at the project root; splits inherited the active pane cwd.
         newTabWorkingDirectory = (defaults.string(forKey: Keys.newTabWorkingDirectory))
-            .flatMap(NewTabWorkingDirectory.init(rawValue:)) ?? .projectDirectory
+            .flatMap(NewTerminalWorkingDirectory.init(rawValue:)) ?? .projectDirectory
+        newSplitWorkingDirectory = (defaults.string(forKey: Keys.newSplitWorkingDirectory))
+            .flatMap(NewTerminalWorkingDirectory.init(rawValue:)) ?? .activePaneDirectory
         sidebarPeekStyle = (defaults.string(forKey: Keys.sidebarPeekStyle))
             .flatMap(SidebarPeekStyle.init(rawValue:)) ?? .resizeTerminal
         windowOpacity = (defaults.object(forKey: Keys.windowOpacity) as? Double) ?? 1.0
@@ -867,6 +876,7 @@ final class Preferences {
         static let autoTiling = "macterm.autoTiling.enabled"
         static let terminalScrollSpeed = "macterm.terminal.scrollSpeed"
         static let newTabWorkingDirectory = "macterm.tabs.newTabWorkingDirectory"
+        static let newSplitWorkingDirectory = "macterm.panes.newSplitWorkingDirectory"
         static let sidebarPeekStyle = "macterm.sidebar.presentation"
         static let windowOpacity = "macterm.window.opacity"
         static let windowBlurRadius = "macterm.window.blurRadius"

--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -2,6 +2,30 @@ import AppKit
 import Foundation
 import Observation
 
+/// Determines whether a new tab starts in the project directory or the focused pane's cwd.
+enum NewTabWorkingDirectory: String, CaseIterable, Identifiable {
+    case projectDirectory = "project"
+    case activePaneDirectory = "active_pane"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .projectDirectory: "Project"
+        case .activePaneDirectory: "Active pane"
+        }
+    }
+
+    /// Uses the active pane cwd when selected and nonempty. Otherwise, uses the project directory.
+    func resolveNewTabDirectory(projectDirectory: String, activePaneDirectory: String?) -> String {
+        guard self == .activePaneDirectory,
+              let activePaneDirectory,
+              !activePaneDirectory.isEmpty
+        else { return projectDirectory }
+        return activePaneDirectory
+    }
+}
+
 /// When the numbered tab switcher in the title bar is shown.
 enum TabSwitcherVisibility: String, CaseIterable, Identifiable {
     case always
@@ -212,6 +236,11 @@ final class Preferences {
     /// Multiplier applied to terminal scroll wheel / trackpad row deltas.
     var terminalScrollSpeed: Double {
         didSet { defaults.set(terminalScrollSpeed, forKey: Keys.terminalScrollSpeed) }
+    }
+
+    /// Selection shown by "New tab directory" in Settings.
+    var newTabWorkingDirectory: NewTabWorkingDirectory {
+        didSet { defaults.set(newTabWorkingDirectory.rawValue, forKey: Keys.newTabWorkingDirectory) }
     }
 
     /// Presentation used by `peekSidebarWhenHidden`. The pinned sidebar is
@@ -690,6 +719,8 @@ final class Preferences {
         self.defaults = defaults
         autoTilingEnabled = defaults.bool(forKey: Keys.autoTiling)
         terminalScrollSpeed = Self.clampScrollSpeed(defaults.double(forKey: Keys.terminalScrollSpeed), fallback: 1.0)
+        newTabWorkingDirectory = (defaults.string(forKey: Keys.newTabWorkingDirectory))
+            .flatMap(NewTabWorkingDirectory.init(rawValue:)) ?? .projectDirectory
         sidebarPeekStyle = (defaults.string(forKey: Keys.sidebarPeekStyle))
             .flatMap(SidebarPeekStyle.init(rawValue:)) ?? .resizeTerminal
         windowOpacity = (defaults.object(forKey: Keys.windowOpacity) as? Double) ?? 1.0
@@ -835,6 +866,7 @@ final class Preferences {
     enum Keys {
         static let autoTiling = "macterm.autoTiling.enabled"
         static let terminalScrollSpeed = "macterm.terminal.scrollSpeed"
+        static let newTabWorkingDirectory = "macterm.tabs.newTabWorkingDirectory"
         static let sidebarPeekStyle = "macterm.sidebar.presentation"
         static let windowOpacity = "macterm.window.opacity"
         static let windowBlurRadius = "macterm.window.blurRadius"

--- a/Macterm/App/Responders.swift
+++ b/Macterm/App/Responders.swift
@@ -226,19 +226,27 @@ final class MainAppResponder: KeyResponder {
 
         if HotkeyRegistry.matches(event, action: .splitRight) {
             guard let projectID = appState.activeProjectID else { return .passThrough }
-            appState.splitPane(direction: .horizontal, projectID: projectID)
+            appState.splitPane(
+                direction: .horizontal,
+                projectID: projectID,
+                projects: projectStore.projects
+            )
             return .handled
         }
 
         if HotkeyRegistry.matches(event, action: .splitDown) {
             guard let projectID = appState.activeProjectID else { return .passThrough }
-            appState.splitPane(direction: .vertical, projectID: projectID)
+            appState.splitPane(
+                direction: .vertical,
+                projectID: projectID,
+                projects: projectStore.projects
+            )
             return .handled
         }
 
         if HotkeyRegistry.matches(event, action: .splitAuto) {
             guard let projectID = appState.activeProjectID else { return .passThrough }
-            appState.autoSplitPane(projectID: projectID)
+            appState.autoSplitPane(projectID: projectID, projects: projectStore.projects)
             return .handled
         }
 

--- a/Macterm/Control/ControlHandler.swift
+++ b/Macterm/Control/ControlHandler.swift
@@ -420,8 +420,12 @@ final class ControlHandler {
 
     private func tabNew(_ args: ControlArgs) throws -> ControlData {
         let (project, workspace) = try resolveWorkspace(args)
-        guard let tabID = appState.createTab(projectID: project.id, projectPath: project.path, command: args.run),
-              let index = workspace.tabs.firstIndex(where: { $0.id == tabID })
+        guard let tabID = appState.createTab(
+            projectID: project.id,
+            projects: projectStore.projects,
+            command: args.run
+        ),
+            let index = workspace.tabs.firstIndex(where: { $0.id == tabID })
         else {
             throw ControlError(code: .internalError, message: "tab creation failed")
         }
@@ -547,7 +551,11 @@ final class ControlHandler {
             throw ControlError(code: .badRequest, message: "direction must be right, down, or auto")
         }
         guard let newID = appState.splitPane(
-            target.pane.id, direction: direction, projectID: project.id, command: args.run
+            target.pane.id,
+            direction: direction,
+            projectID: project.id,
+            projectDirectory: project.path,
+            command: args.run
         ), let newPane = target.tab.splitRoot.findPane(id: newID)
         else {
             throw ControlError(code: .internalError, message: "split failed")

--- a/Macterm/Control/ControlHandler.swift
+++ b/Macterm/Control/ControlHandler.swift
@@ -840,7 +840,12 @@ final class ControlHandler {
         let (project, workspace) = try resolveWorkspace(args)
         let target = try resolvePane(args, in: workspace)
         let created = appState.makeGrid(
-            target.pane.id, rows: rows, columns: cols, projectID: project.id, command: args.run
+            target.pane.id,
+            rows: rows,
+            columns: cols,
+            projectID: project.id,
+            projectDirectory: project.path,
+            command: args.run
         )
         guard !created.isEmpty else {
             throw ControlError(code: .internalError, message: "grid produced no panes")

--- a/Macterm/Model/Pane.swift
+++ b/Macterm/Model/Pane.swift
@@ -145,6 +145,12 @@ final class Pane: Identifiable {
         surfaceReattachTick &+= 1
     }
 
+    /// Returns a local pane's cwd. Remote cwd values omit the host, so remote panes return nil.
+    func liveLocalWorkingDirectory() -> String? {
+        guard !isRemote else { return nil }
+        return nsView?.currentPwd ?? ProcessInspector.foregroundWorkingDirectory(forPane: self)
+    }
+
     var executionState: TerminalExecutionState = .idle {
         didSet {
             guard executionState != oldValue else { return }

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -145,7 +145,11 @@ final class TerminalTab: Identifiable {
         // REMOTE pane, `currentPwd` is a remote-filesystem path with no host
         // prefix — inheriting it would spawn the sibling as a LOCAL shell in a
         // bogus dir instead of a remote zmx session — so skip the live cwd and
-        // inherit the scp-style `projectPath` verbatim.
+        // inherit the scp-style `projectPath` verbatim. An explicit
+        // `newPaneWorkingDirectory` (the "Project" split preference) wins over
+        // the whole chain; the preference resolver passes nil rather than the
+        // project root whenever it has no usable LOCAL cwd, precisely so the
+        // remote/unattached cases keep falling through to it.
         let livePwd = pane.liveLocalWorkingDirectory()
         let sourcePath = newPaneWorkingDirectory ?? livePwd ?? pane.projectPath
         let sourceProjectID = pane.projectID
@@ -169,9 +173,17 @@ final class TerminalTab: Identifiable {
     /// optionally spawning `command` in every NEW pane. The source pane
     /// becomes the top-left cell and keeps its running shell — a command
     /// can only be injected at spawn (`initial_input`), so the caller runs
-    /// text into it separately if needed. Returns the new pane IDs.
+    /// text into it separately if needed. `newPaneWorkingDirectory` overrides
+    /// cwd inheritance for every new cell, exactly as in `split`. Returns the
+    /// new pane IDs.
     @discardableResult
-    func makeGrid(paneID: UUID, rows: Int, columns: Int, command: String? = nil) -> [UUID] {
+    func makeGrid(
+        paneID: UUID,
+        rows: Int,
+        columns: Int,
+        command: String? = nil,
+        newPaneWorkingDirectory: String? = nil
+    ) -> [UUID] {
         guard rows >= 1, columns >= 1, rows * columns > 1,
               splitRoot.findPane(id: paneID) != nil
         else { return [] }
@@ -181,7 +193,12 @@ final class TerminalTab: Identifiable {
         var rowHeads = [paneID]
         for _ in 1 ..< rows {
             guard let previous = rowHeads.last,
-                  let newID = split(paneID: previous, direction: .vertical, command: command)
+                  let newID = split(
+                      paneID: previous,
+                      direction: .vertical,
+                      command: command,
+                      newPaneWorkingDirectory: newPaneWorkingDirectory
+                  )
             else { break }
             rowHeads.append(newID)
             created.append(newID)
@@ -189,7 +206,13 @@ final class TerminalTab: Identifiable {
         for head in rowHeads {
             var current = head
             for _ in 1 ..< columns {
-                guard let newID = split(paneID: current, direction: .horizontal, command: command) else { break }
+                guard let newID = split(
+                    paneID: current,
+                    direction: .horizontal,
+                    command: command,
+                    newPaneWorkingDirectory: newPaneWorkingDirectory
+                )
+                else { break }
                 created.append(newID)
                 current = newID
             }

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -139,9 +139,7 @@ final class TerminalTab: Identifiable {
         // prefix — inheriting it would spawn the sibling as a LOCAL shell in a
         // bogus dir instead of a remote zmx session — so skip the live cwd and
         // inherit the scp-style `projectPath` verbatim.
-        let livePwd = pane.isRemote
-            ? nil
-            : (pane.nsView?.currentPwd ?? ProcessInspector.foregroundWorkingDirectory(forPane: pane))
+        let livePwd = pane.liveLocalWorkingDirectory()
         let sourcePath = livePwd ?? pane.projectPath
         let sourceProjectID = pane.projectID
         let (newRoot, newID) = splitRoot.splitting(

--- a/Macterm/Model/Workspace.swift
+++ b/Macterm/Model/Workspace.swift
@@ -125,8 +125,15 @@ final class TerminalTab: Identifiable {
     /// new pane in the `.second` position. Returns the new pane ID if created.
     /// A `command` spawns in the new pane via libghostty's `initial_input`
     /// (the layout `run:` path — typed into the fresh shell verbatim).
+    /// `newPaneWorkingDirectory` overrides cwd inheritance without changing
+    /// the source pane's project-scoped session slug.
     @discardableResult
-    func split(paneID: UUID, direction: SplitDirection, command: String? = nil) -> UUID? {
+    func split(
+        paneID: UUID,
+        direction: SplitDirection,
+        command: String? = nil,
+        newPaneWorkingDirectory: String? = nil
+    ) -> UUID? {
         // Bail before any side effect if the pane isn't in this tab — otherwise
         // an unknown ID would clear the user's zoom and rebalance ratios for a
         // split that never happens (mirrors toggleZoom/makeGrid's guard).
@@ -140,7 +147,7 @@ final class TerminalTab: Identifiable {
         // bogus dir instead of a remote zmx session — so skip the live cwd and
         // inherit the scp-style `projectPath` verbatim.
         let livePwd = pane.liveLocalWorkingDirectory()
-        let sourcePath = livePwd ?? pane.projectPath
+        let sourcePath = newPaneWorkingDirectory ?? livePwd ?? pane.projectPath
         let sourceProjectID = pane.projectID
         let (newRoot, newID) = splitRoot.splitting(
             paneID: paneID,
@@ -199,10 +206,14 @@ final class TerminalTab: Identifiable {
     /// splits top/bottom. Falls back to a horizontal split when the focused
     /// pane's NSView isn't attached yet and has no measurable bounds.
     @discardableResult
-    func autoSplit(paneID: UUID) -> UUID? {
+    func autoSplit(paneID: UUID, newPaneWorkingDirectory: String? = nil) -> UUID? {
         let bounds = splitRoot.findPane(id: paneID)?.nsView?.bounds.size ?? .zero
         let direction: SplitDirection = bounds.height > bounds.width ? .vertical : .horizontal
-        return split(paneID: paneID, direction: direction)
+        return split(
+            paneID: paneID,
+            direction: direction,
+            newPaneWorkingDirectory: newPaneWorkingDirectory
+        )
     }
 
     /// Adjust the nearest matching-axis split ratio around the focused pane.
@@ -379,8 +390,13 @@ final class Workspace: Identifiable {
     }
 
     @discardableResult
-    func createTab(projectPath: String, command: String? = nil) -> TerminalTab {
-        let tab = TerminalTab(projectPath: projectPath, projectID: projectID, command: command)
+    func createTab(projectPath: String, sessionSlug: String? = nil, command: String? = nil) -> TerminalTab {
+        let tab = TerminalTab(
+            projectPath: projectPath,
+            projectID: projectID,
+            sessionSlug: sessionSlug,
+            command: command
+        )
         tabs.append(tab)
         if let current = activeTabID { tabHistory.push(current) }
         activeTabID = tab.id

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -445,7 +445,8 @@ private struct GeneralSettings: View {
     @State private var autoTilingEnabled: Bool = Preferences.shared.autoTilingEnabled
     @State private var backgroundSSHConnections: Bool = Preferences.shared.backgroundSSHConnections
     @State private var reconnectRemotePanes: Bool = Preferences.shared.reconnectRemotePanes
-    @State private var newTabWorkingDirectory: NewTabWorkingDirectory = Preferences.shared.newTabWorkingDirectory
+    @State private var newTabWorkingDirectory: NewTerminalWorkingDirectory = Preferences.shared.newTabWorkingDirectory
+    @State private var newSplitWorkingDirectory: NewTerminalWorkingDirectory = Preferences.shared.newSplitWorkingDirectory
 
     /// Why session persistence is inactive, when it is. Missing binary is a
     /// dev-build state; an over-budget socket path is an environment problem
@@ -548,12 +549,21 @@ private struct GeneralSettings: View {
 
             Section("Terminal") {
                 Picker("New tab directory", selection: $newTabWorkingDirectory) {
-                    ForEach(NewTabWorkingDirectory.allCases) { directory in
+                    ForEach(NewTerminalWorkingDirectory.allCases) { directory in
                         Text(directory.displayName).tag(directory)
                     }
                 }
                 .onChange(of: newTabWorkingDirectory) { _, directory in
                     Preferences.shared.newTabWorkingDirectory = directory
+                }
+
+                Picker("New split directory", selection: $newSplitWorkingDirectory) {
+                    ForEach(NewTerminalWorkingDirectory.allCases) { directory in
+                        Text(directory.displayName).tag(directory)
+                    }
+                }
+                .onChange(of: newSplitWorkingDirectory) { _, directory in
+                    Preferences.shared.newSplitWorkingDirectory = directory
                 }
 
                 SettingsSlider(

--- a/Macterm/Settings/SettingsView.swift
+++ b/Macterm/Settings/SettingsView.swift
@@ -445,6 +445,7 @@ private struct GeneralSettings: View {
     @State private var autoTilingEnabled: Bool = Preferences.shared.autoTilingEnabled
     @State private var backgroundSSHConnections: Bool = Preferences.shared.backgroundSSHConnections
     @State private var reconnectRemotePanes: Bool = Preferences.shared.reconnectRemotePanes
+    @State private var newTabWorkingDirectory: NewTabWorkingDirectory = Preferences.shared.newTabWorkingDirectory
 
     /// Why session persistence is inactive, when it is. Missing binary is a
     /// dev-build state; an over-budget socket path is an environment problem
@@ -546,6 +547,15 @@ private struct GeneralSettings: View {
             }
 
             Section("Terminal") {
+                Picker("New tab directory", selection: $newTabWorkingDirectory) {
+                    ForEach(NewTabWorkingDirectory.allCases) { directory in
+                        Text(directory.displayName).tag(directory)
+                    }
+                }
+                .onChange(of: newTabWorkingDirectory) { _, directory in
+                    Preferences.shared.newTabWorkingDirectory = directory
+                }
+
                 SettingsSlider(
                     label: "Scroll speed",
                     value: $terminalScrollSpeed,

--- a/Macterm/Views/MainWindow.swift
+++ b/Macterm/Views/MainWindow.swift
@@ -886,8 +886,12 @@ struct WorkspaceView: View {
                 projectID: project.id,
                 onFocusPane: { appState.focusPane($0, projectID: project.id) },
                 onSplit: { paneID, dir in
-                    tab.split(paneID: paneID, direction: dir)
-                    appState.saveWorkspaces()
+                    appState.splitPane(
+                        paneID,
+                        direction: dir,
+                        projectID: project.id,
+                        projectDirectory: project.path
+                    )
                 },
                 // This closure is the PROCESS-EXIT path only (SplitTreeView
                 // wires it to the surface's onProcessExit; the user's Cmd+W

--- a/Macterm/Views/Sidebar.swift
+++ b/Macterm/Views/Sidebar.swift
@@ -727,7 +727,7 @@ struct SidebarContent: View {
     private func projectMenu(_ project: Project) -> some View {
         Button("New Tab") {
             appState.selectProject(project)
-            appState.createTab(projectID: project.id, projectPath: project.path)
+            appState.createTab(projectID: project.id, projects: projectStore.projects)
             presentation.expandedProjects.insert(project.id)
         }
         Button("Copy Path") {

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -39,7 +39,7 @@ struct AppStateTests {
     // MARK: - Tabs
 
     @Test
-    func createTab_uses_active_local_cwd_and_remote_project_fallback() throws {
+    func createTab_uses_selected_directory_and_preserves_project_session_slug() throws {
         let prior = Preferences.shared.newTabWorkingDirectory
         defer { Preferences.shared.newTabWorkingDirectory = prior }
         Preferences.shared.newTabWorkingDirectory = .activePaneDirectory
@@ -53,11 +53,29 @@ struct AppStateTests {
         state.createTab(projectID: localProject.id, projects: [localProject])
 
         #expect(localWorkspace.activeTab?.focusedPane?.projectPath == "/project/src")
+        #expect(localWorkspace.activeTab?.focusedPane?.sessionSlug == "project")
 
-        let remoteProject = seedProject(state, name: "remote", path: "devbox:~/repo")
+        let inheritedPane = try #require(localWorkspace.activeTab?.focusedPane)
+        inheritedPane.ensureNSView().currentPwd = "/project/src/deep"
+        Preferences.shared.newTabWorkingDirectory = .projectDirectory
+
+        state.createTab(projectID: localProject.id, projects: [localProject])
+
+        #expect(localWorkspace.activeTab?.focusedPane?.projectPath == localProject.path)
+        #expect(localWorkspace.activeTab?.focusedPane?.sessionSlug == "project")
+    }
+
+    @Test
+    func createTab_remote_active_pane_falls_back_to_project_directory() throws {
+        let prior = Preferences.shared.newTabWorkingDirectory
+        defer { Preferences.shared.newTabWorkingDirectory = prior }
+        Preferences.shared.newTabWorkingDirectory = .activePaneDirectory
+
+        let state = makeAppState()
+        let remoteProject = seedProject(state, path: "devbox:~/repo")
         let remoteWorkspace = try #require(state.workspaces[remoteProject.id])
 
-        state.createTab(projectID: remoteProject.id, projects: [localProject, remoteProject])
+        state.createTab(projectID: remoteProject.id, projects: [remoteProject])
 
         #expect(remoteWorkspace.activeTab?.focusedPane?.projectPath == remoteProject.path)
     }
@@ -73,6 +91,31 @@ struct AppStateTests {
         state.splitPane(direction: .horizontal, projectID: p.id)
         #expect(tab.splitRoot.allPanes().count == 2)
         #expect(tab.focusedPaneID != before)
+    }
+
+    @Test
+    func splitPane_uses_selected_directory() throws {
+        let prior = Preferences.shared.newSplitWorkingDirectory
+        defer { Preferences.shared.newSplitWorkingDirectory = prior }
+        Preferences.shared.newSplitWorkingDirectory = .activePaneDirectory
+
+        let state = makeAppState()
+        let project = seedProject(state, path: "/project")
+        let tab = try #require(state.workspaces[project.id]?.activeTab)
+        let activePane = try #require(tab.focusedPane)
+        activePane.ensureNSView().currentPwd = "/project/src"
+
+        state.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
+
+        #expect(tab.focusedPane?.projectPath == "/project/src")
+
+        let inheritedPane = try #require(tab.focusedPane)
+        inheritedPane.ensureNSView().currentPwd = "/project/src/deep"
+        Preferences.shared.newSplitWorkingDirectory = .projectDirectory
+
+        state.splitPane(direction: .vertical, projectID: project.id, projects: [project])
+
+        #expect(tab.focusedPane?.projectPath == project.path)
     }
 
     @Test

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -36,6 +36,32 @@ struct AppStateTests {
         return p
     }
 
+    // MARK: - Tabs
+
+    @Test
+    func createTab_uses_active_local_cwd_and_remote_project_fallback() throws {
+        let prior = Preferences.shared.newTabWorkingDirectory
+        defer { Preferences.shared.newTabWorkingDirectory = prior }
+        Preferences.shared.newTabWorkingDirectory = .activePaneDirectory
+
+        let state = makeAppState()
+        let localProject = seedProject(state, path: "/project")
+        let localWorkspace = try #require(state.workspaces[localProject.id])
+        let activePane = try #require(localWorkspace.activeTab?.focusedPane)
+        activePane.ensureNSView().currentPwd = "/project/src"
+
+        state.createTab(projectID: localProject.id, projects: [localProject])
+
+        #expect(localWorkspace.activeTab?.focusedPane?.projectPath == "/project/src")
+
+        let remoteProject = seedProject(state, name: "remote", path: "devbox:~/repo")
+        let remoteWorkspace = try #require(state.workspaces[remoteProject.id])
+
+        state.createTab(projectID: remoteProject.id, projects: [localProject, remoteProject])
+
+        #expect(remoteWorkspace.activeTab?.focusedPane?.projectPath == remoteProject.path)
+    }
+
     // MARK: - Splits
 
     @Test

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -88,7 +88,7 @@ struct AppStateTests {
         let p = seedProject(state)
         let tab = try #require(state.workspaces[p.id]?.activeTab)
         let before = tab.focusedPaneID
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         #expect(tab.splitRoot.allPanes().count == 2)
         #expect(tab.focusedPaneID != before)
     }
@@ -118,13 +118,64 @@ struct AppStateTests {
         #expect(tab.focusedPane?.projectPath == project.path)
     }
 
+    /// "Active pane" with no usable LOCAL cwd must fall through to the source
+    /// pane's own `projectPath`, NOT to the project root: a remote pane
+    /// coerced to the project directory loses its declared subdirectory, and
+    /// one whose tab was moved into a local project would spawn a LOCAL shell
+    /// instead of a remote zmx sibling.
+    @Test
+    func splitPane_remote_source_inherits_its_own_path_not_the_project_root() throws {
+        let prior = Preferences.shared.newSplitWorkingDirectory
+        defer { Preferences.shared.newSplitWorkingDirectory = prior }
+        Preferences.shared.newSplitWorkingDirectory = .activePaneDirectory
+
+        let state = makeAppState()
+        let project = seedProject(state, path: "devbox:~/repo")
+        state.createTab(projectID: project.id, projectPath: "devbox:~/repo/sub")
+        let tab = try #require(state.workspaces[project.id]?.activeTab)
+        #expect(tab.focusedPane?.projectPath == "devbox:~/repo/sub")
+
+        state.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
+
+        #expect(tab.focusedPane?.projectPath == "devbox:~/repo/sub")
+        #expect(tab.focusedPane?.isRemote == true)
+    }
+
+    /// A grid honors the split directory preference, so `macterm grid` and a
+    /// `Cmd+D` split off the same pane can't disagree about it.
+    @Test
+    func makeGrid_uses_selected_directory() throws {
+        let prior = Preferences.shared.newSplitWorkingDirectory
+        defer { Preferences.shared.newSplitWorkingDirectory = prior }
+        Preferences.shared.newSplitWorkingDirectory = .projectDirectory
+
+        let state = makeAppState()
+        let project = seedProject(state, path: "/project")
+        let tab = try #require(state.workspaces[project.id]?.activeTab)
+        let source = try #require(tab.focusedPane)
+        source.ensureNSView().currentPwd = "/project/src"
+
+        let created = state.makeGrid(
+            source.id,
+            rows: 2,
+            columns: 2,
+            projectID: project.id,
+            projectDirectory: project.path
+        )
+
+        #expect(created.count == 3)
+        for id in created {
+            #expect(tab.splitRoot.findPane(id: id)?.projectPath == "/project")
+        }
+    }
+
     @Test
     func splitPane_no_focused_pane_is_noop() throws {
         let state = makeAppState()
         let p = seedProject(state)
         let tab = try #require(state.workspaces[p.id]?.activeTab)
         tab.focusedPaneID = nil
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         #expect(tab.splitRoot.allPanes().count == 1)
     }
 
@@ -175,7 +226,7 @@ struct AppStateTests {
         let state = makeAppState()
         let p = seedProject(state)
         let tab = try #require(state.workspaces[p.id]?.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         #expect(tab.splitRoot.allPanes().count == 2)
         let target = try #require(tab.focusedPaneID)
         state.closePane(target, projectID: p.id)
@@ -208,7 +259,7 @@ struct AppStateTests {
         let p = seedProject(state)
         let ws = try #require(state.workspaces[p.id])
         let originalTab = try #require(ws.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let targetInOriginal = try #require(originalTab.focusedPaneID)
 
         // Switch to a new tab, then close a pane on the (now non-active) original.
@@ -323,7 +374,7 @@ struct AppStateTests {
         let p = seedProject(state)
         let ws = try #require(state.workspaces[p.id])
         let destTab = try #require(ws.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let sourceTab = ws.createTab(projectPath: p.path)
         ws.selectTab(destTab.id)
 
@@ -356,8 +407,8 @@ struct AppStateTests {
         let p = seedProject(state)
         let ws = try #require(state.workspaces[p.id])
         let tab = try #require(ws.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
-        state.splitPane(direction: .vertical, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
+        state.splitPane(direction: .vertical, projectID: p.id, projects: [p])
         let panes = tab.splitRoot.allPanes().map(\.id)
         #expect(panes.count == 3)
 
@@ -392,7 +443,7 @@ struct AppStateTests {
         let ws = try #require(state.workspaces[p.id])
         let tab = try #require(ws.activeTab)
         let original = try #require(tab.focusedPaneID)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let dragged = try #require(tab.focusedPaneID)
         tab.zoomedPaneID = dragged
 
@@ -416,7 +467,7 @@ struct AppStateTests {
         let p = seedProject(state)
         let ws = try #require(state.workspaces[p.id])
         let tab = try #require(ws.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let dragged = try #require(tab.focusedPaneID)
 
         state.separatePane(dragged, toProject: p.id, destPath: p.path, at: 0)
@@ -434,7 +485,7 @@ struct AppStateTests {
         let ws1 = try #require(state.workspaces[p1.id])
         let ws2 = try #require(state.workspaces[p2.id])
         state.selectProject(p1)
-        state.splitPane(direction: .horizontal, projectID: p1.id)
+        state.splitPane(direction: .horizontal, projectID: p1.id, projects: [p1])
         let sourceTab = try #require(ws1.activeTab)
         let dragged = try #require(sourceTab.focusedPaneID)
         let ws2TabsBefore = ws2.tabs.count
@@ -764,7 +815,7 @@ struct AppStateTests {
         let state = makeAppState()
         let p = seedProject(state)
         let ws = try #require(state.workspaces[p.id])
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         ws.createTab(projectPath: "/tmp")
         ws.tabs[1].customTitle = "build"
         let beforePaneIDs = Set(ws.tabs.flatMap { $0.splitRoot.allPanes().map(\.id) })
@@ -977,7 +1028,7 @@ struct AppStateTests {
         let state = makeAppState()
         let p = seedProject(state)
         let tab = try #require(state.workspaces[p.id]?.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let target = try #require(tab.focusedPaneID)
         // No GhosttyTerminalNSView is ever created in tests, so needsConfirmQuit is false.
         state.requestClosePane(target, projectID: p.id)
@@ -1644,7 +1695,7 @@ struct AppStateTests {
         state.zmx = recordingZmx(into: killed)
         let p = seedProject(state)
         let tab = try #require(state.workspaces[p.id]?.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let names = Set(tab.splitRoot.allPanes().map(\.sessionName))
         #expect(names.count == 2)
 
@@ -1666,7 +1717,7 @@ struct AppStateTests {
         state.zmx = recordingZmx(into: killed, remoteInto: remoteKilled)
         let p = seedProject(state, name: "remote", path: "devbox:~/dev/api")
         let tab = try #require(state.workspaces[p.id]?.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let target = try #require(tab.focusedPaneID)
         let targetName = try #require(tab.splitRoot.findPane(id: target)?.sessionName)
 
@@ -1704,7 +1755,7 @@ struct AppStateTests {
         let state = makeAppState()
         state.zmx = recordingZmx(into: killed)
         let p = seedProject(state)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let tab = try #require(state.workspaces[p.id]?.activeTab)
         let target = try #require(tab.focusedPaneID)
         let name = try #require(tab.splitRoot.findPane(id: target)?.sessionName)
@@ -1853,7 +1904,7 @@ struct AppStateTests {
         state.zmx = recordingZmx(into: killed)
         let p = seedProject(state)
         let tab = try #require(state.workspaces[p.id]?.activeTab)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let target = try #require(tab.focusedPaneID)
         let targetName = try #require(tab.splitRoot.findPane(id: target)?.sessionName)
 
@@ -1869,7 +1920,7 @@ struct AppStateTests {
         let state = makeAppState()
         state.zmx = recordingZmx(into: killed)
         let p = seedProject(state)
-        state.splitPane(direction: .horizontal, projectID: p.id)
+        state.splitPane(direction: .horizontal, projectID: p.id, projects: [p])
         let names = try Set(
             #require(state.workspaces[p.id]).tabs
                 .flatMap { $0.splitRoot.allPanes() }
@@ -1910,7 +1961,7 @@ struct AppStateTests {
         let p2 = seedProject(state, name: "p2", path: "/tmp2")
         let tab = try #require(state.workspaces[p1.id]?.activeTab)
         // Split so the moved tab carries more than one pane to restamp.
-        state.splitPane(direction: .horizontal, projectID: p1.id)
+        state.splitPane(direction: .horizontal, projectID: p1.id, projects: [p1])
         let panes = tab.splitRoot.allPanes()
         #expect(panes.count == 2)
         let originalSessionNames = Set(panes.map(\.sessionName))

--- a/MactermTests/Control/ControlHandlerTests.swift
+++ b/MactermTests/Control/ControlHandlerTests.swift
@@ -189,7 +189,7 @@ struct ControlHandlerTests {
     func pane_list_walks_splits_and_marks_focus() async {
         let (handler, appState, projectStore) = makeHandler()
         let project = seedProject(appState, projectStore)
-        appState.splitPane(direction: .horizontal, projectID: project.id)
+        appState.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
         let response = await handler.handle(request("pane.list"))
         let panes = response.data?.panes
         #expect(panes?.count == 2)
@@ -225,7 +225,7 @@ struct ControlHandlerTests {
         let (handler, appState, projectStore) = makeHandler()
         let project = seedProject(appState, projectStore)
         appState.createTab(projectID: project.id, projectPath: project.path)
-        appState.splitPane(direction: .vertical, projectID: project.id)
+        appState.splitPane(direction: .vertical, projectID: project.id, projects: [project])
 
         let all = await handler.handle(request("pane.list"))
         #expect(all.data?.panes?.count == 3)
@@ -724,7 +724,7 @@ struct ControlHandlerTests {
         let tab = try #require(appState.workspaces[project.id]?.activeTab)
         let source = try #require(tab.splitRoot.allPanes().first)
         source.ensureNSView().currentPwd = "/project/source"
-        appState.splitPane(direction: .horizontal, projectID: project.id)
+        appState.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
         let focusedPane = try #require(tab.focusedPane)
         focusedPane.ensureNSView().currentPwd = "/project/focused"
 
@@ -800,7 +800,7 @@ struct ControlHandlerTests {
         let project = seedProject(appState, projectStore)
         let tab = try #require(appState.workspaces[project.id]?.activeTab)
         let left = try #require(tab.splitRoot.allPanes().first)
-        appState.splitPane(direction: .horizontal, projectID: project.id)
+        appState.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
         let panes = tab.splitRoot.allPanes()
         #expect(panes.count == 2)
         let right = try #require(panes.last)
@@ -836,7 +836,7 @@ struct ControlHandlerTests {
         let (handler, appState, projectStore) = makeHandler()
         let project = seedProject(appState, projectStore)
         let tab = try #require(appState.workspaces[project.id]?.activeTab)
-        appState.splitPane(direction: .horizontal, projectID: project.id)
+        appState.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
         #expect(tab.splitRoot.allPanes().count == 2)
 
         let bare = await handler.handle(request("pane.close"))
@@ -964,7 +964,7 @@ struct ControlHandlerTests {
         let (handler, appState, projectStore) = makeHandler()
         let project = seedProject(appState, projectStore)
         // A horizontal split gives a horizontal-axis branch at the root.
-        appState.splitPane(direction: .horizontal, projectID: project.id)
+        appState.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
         let tab = try #require(appState.workspaces[project.id]?.activeTab)
         let focused = try #require(tab.focusedPaneID)
 
@@ -983,7 +983,7 @@ struct ControlHandlerTests {
     func pane_resize_split_validates_axis_and_ratio() async throws {
         let (handler, appState, projectStore) = makeHandler()
         let project = seedProject(appState, projectStore)
-        appState.splitPane(direction: .horizontal, projectID: project.id)
+        appState.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
         let tab = try #require(appState.workspaces[project.id]?.activeTab)
         let focused = try #require(tab.focusedPaneID).uuidString
 
@@ -1009,7 +1009,7 @@ struct ControlHandlerTests {
         let project = seedProject(appState, projectStore)
         // Only a horizontal split exists; asking to resize a vertical split
         // around the pane finds no matching branch.
-        appState.splitPane(direction: .horizontal, projectID: project.id)
+        appState.splitPane(direction: .horizontal, projectID: project.id, projects: [project])
         let tab = try #require(appState.workspaces[project.id]?.activeTab)
         let focused = try #require(tab.focusedPaneID).uuidString
 

--- a/MactermTests/Control/ControlHandlerTests.swift
+++ b/MactermTests/Control/ControlHandlerTests.swift
@@ -482,18 +482,34 @@ struct ControlHandlerTests {
 
     @Test
     func tab_new_creates_selects_and_reports() async throws {
+        let prior = Preferences.shared.newTabWorkingDirectory
+        defer { Preferences.shared.newTabWorkingDirectory = prior }
+        Preferences.shared.newTabWorkingDirectory = .activePaneDirectory
+
         let (handler, appState, projectStore) = makeHandler()
-        let project = seedProject(appState, projectStore)
-        let response = await handler.handle(request("tab.new", args: ControlArgs(run: "btop")))
+        let project = seedProject(appState, projectStore, name: "target", path: "/target-project")
+        let targetPane = try #require(appState.workspaces[project.id]?.activeTab?.focusedPane)
+        targetPane.ensureNSView().currentPwd = "/target-project/src"
+        let activeProject = seedProject(appState, projectStore, name: "active", path: "/active-project")
+        let activePane = try #require(appState.workspaces[activeProject.id]?.activeTab?.focusedPane)
+        activePane.ensureNSView().currentPwd = "/active-project/elsewhere"
+
+        let response = await handler.handle(request(
+            "tab.new",
+            args: ControlArgs(project: project.id.uuidString, run: "btop")
+        ))
         #expect(response.ok)
         let info = try #require(response.data?.tabs?.first)
         #expect(info.index == 2)
         #expect(info.active == true)
         let workspace = try #require(appState.workspaces[project.id])
         #expect(workspace.tabs.count == 2)
+        let newPane = try #require(workspace.tabs.last?.focusedPane)
+        #expect(newPane.projectPath == "/target-project/src")
+        #expect(newPane.sessionSlug == "target-project")
         // The declared command reaches the new tab's pane (spawns via
         // initial_input when the surface is created).
-        #expect(workspace.tabs.last?.splitRoot.allPanes().first?.command == "btop")
+        #expect(newPane.command == "btop")
     }
 
     @Test
@@ -699,16 +715,29 @@ struct ControlHandlerTests {
 
     @Test
     func pane_split_targets_session_selector() async throws {
+        let prior = Preferences.shared.newSplitWorkingDirectory
+        defer { Preferences.shared.newSplitWorkingDirectory = prior }
+        Preferences.shared.newSplitWorkingDirectory = .activePaneDirectory
+
         let (handler, appState, projectStore) = makeHandler()
-        let project = seedProject(appState, projectStore)
+        let project = seedProject(appState, projectStore, path: "/project")
         let tab = try #require(appState.workspaces[project.id]?.activeTab)
         let source = try #require(tab.splitRoot.allPanes().first)
+        source.ensureNSView().currentPwd = "/project/source"
+        appState.splitPane(direction: .horizontal, projectID: project.id)
+        let focusedPane = try #require(tab.focusedPane)
+        focusedPane.ensureNSView().currentPwd = "/project/focused"
 
         let response = await handler.handle(request(
             "pane.split", args: ControlArgs(session: source.sessionName, direction: "down")
         ))
         #expect(response.ok)
-        #expect(tab.splitRoot.allPanes().count == 2)
+        let newInfo = try #require(response.data?.panes?.first)
+        let newID = try #require(UUID(uuidString: newInfo.id))
+        let newPane = try #require(tab.splitRoot.findPane(id: newID))
+        #expect(newPane.projectPath == "/project/source")
+        #expect(newPane.sessionSlug == source.sessionSlug)
+        #expect(tab.splitRoot.allPanes().count == 3)
 
         let both = await handler.handle(request(
             "pane.split", args: ControlArgs(pane: "pane:1", session: source.sessionName, direction: "down")
@@ -719,6 +748,28 @@ struct ControlHandlerTests {
             "pane.split", args: ControlArgs(session: "macterm-nope-000000000000", direction: "down")
         ))
         #expect(unknown.error?.code == .notFound)
+    }
+
+    @Test
+    func pane_split_remote_source_falls_back_to_project_directory() async throws {
+        let prior = Preferences.shared.newSplitWorkingDirectory
+        defer { Preferences.shared.newSplitWorkingDirectory = prior }
+        Preferences.shared.newSplitWorkingDirectory = .activePaneDirectory
+
+        let (handler, appState, projectStore) = makeHandler()
+        let project = seedProject(appState, projectStore, path: "devbox:~/repo")
+        let tab = try #require(appState.workspaces[project.id]?.activeTab)
+        let source = try #require(tab.focusedPane)
+        source.ensureNSView().currentPwd = "/repo/src"
+
+        let response = await handler.handle(request("pane.split", args: ControlArgs(direction: "right")))
+
+        #expect(response.ok)
+        let newInfo = try #require(response.data?.panes?.first)
+        let newID = try #require(UUID(uuidString: newInfo.id))
+        let newPane = try #require(tab.splitRoot.findPane(id: newID))
+        #expect(newPane.projectPath == project.path)
+        #expect(newPane.sessionSlug == source.sessionSlug)
     }
 
     @Test


### PR DESCRIPTION
## What

Adds separate `New tab directory` and `New split directory` settings. Both offer `Project` and `Active pane`.

Tabs still default to `Project`. Splits still default to `Active pane`, so existing behavior does not change. All existing UI entry points and the `macterm tab new` and `macterm pane split` commands use these settings.

## Why

`Cmd+T` always returned to the project root, even when the active shell had moved into a nested directory. This makes active-pane inheritance configurable without changing the existing defaults for tabs or splits.

Closes #334

## How

- `AppState` resolves the new terminal directory before creating a tab or pane.
- The selected cwd does not change the project-scoped zmx session slug.
- CLI tab creation reads the target workspace's focused pane. CLI splits read the selected source pane and fall back to the focused pane when no selector is given.
- Remote panes fall back to the configured `host:path`.

## Verified

- [x] `mise run format --verbose`, `mise run lint --verbose`, and `mise run test --verbose` pass
- [x] Built and ran the Debug app and confirmed both settings in the UI
- [x] Added behavior tests for tabs, splits, zmx session identity, and remote fallback
- [x] `mise run e2e --verbose` passes locally. The opt-in Docker remote reconnect test was skipped

The bundled CLI was also exercised against an isolated Debug app. This covered nested tab cwd inheritance, explicit-source splits, Project-mode splits, and remote fallback.

## Notes for reviewers

Quick Terminal is intentionally unchanged. It has no project workspace, starts at `$HOME`, and uses the dedicated `quick` zmx slug. Its splits continue to inherit the source pane cwd.

Codex assisted with implementation and test execution under direct human direction.