### PR TITLE
ci: pin the Xcode every compiling job builds with

### DIFF
--- a/.github/actions/select-xcode/action.yml
+++ b/.github/actions/select-xcode/action.yml
@@ -1,0 +1,51 @@
+name: Select Xcode
+description: >
+  Point the job at a pinned Xcode rather than whatever the runner image
+  currently defaults to, and expose the version so build-product caches can key
+  on it.
+
+# The pin exists because the runner image's default moves on its own. CI ran
+# unpinned until macterm#340: `MactermApp.body` failed to type-check on Xcode
+# 26.3 while compiling fine on the 26.6 that `macos-26` happened to default to,
+# so nothing here could see it. Pinning doesn't by itself test the older Xcode
+# a contributor may have — CONTRIBUTING.md asks only for "Xcode 26" — but it
+# does mean a green run names a toolchain, and that a future image bump is a
+# reviewable one-line change instead of a silent one.
+
+inputs:
+  version:
+    description: >
+      Xcode version to select, spelled as it appears in
+      /Applications/Xcode_<version>.app on the runner image.
+    required: false
+    default: "26.6"
+
+outputs:
+  version:
+    description: The selected Xcode version. Feed it to any build-product cache key.
+    value: ${{ inputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Select Xcode ${{ inputs.version }}
+      shell: bash
+      env:
+        XCODE_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        DEV_DIR="/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer"
+
+        # Hard-fail rather than fall through to the default. Runner images drop
+        # older Xcodes as they age, so this WILL fire one day — and a silent
+        # fallback to whatever is default is exactly the unpinned behaviour the
+        # action exists to remove. The failure should read as "bump the pin",
+        # not as a mystery compile error somewhere downstream.
+        if [[ ! -d "$DEV_DIR" ]]; then
+          echo "::error::Xcode ${XCODE_VERSION} is not on this runner ($DEV_DIR). Bump the default in .github/actions/select-xcode/action.yml to one of the versions below."
+          ls -d /Applications/Xcode*.app || true
+          exit 1
+        fi
+
+        echo "DEVELOPER_DIR=$DEV_DIR" >> "$GITHUB_ENV"
+        "$DEV_DIR/usr/bin/xcodebuild" -version

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,6 +40,8 @@ jobs:
               - "mise.toml"
               - "scripts/**"
               - ".github/workflows/benchmark.yml"
+              # The Xcode pin lives here; a bump must re-measure against it.
+              - ".github/actions/select-xcode/**"
 
   # Fetch the latest main baseline in parallel with the build+sample job. It's
   # pure GitHub API + a download with no dependency on the build, so keeping it
@@ -113,6 +115,13 @@ jobs:
 
       - uses: jdx/mise-action@v4.3.0
 
+      # Pin the toolchain: `macos-26` defaults to whatever Xcode the image
+      # currently ships, which is how macterm#340's type-check failure stayed
+      # invisible here. See the action for the full rationale.
+      - name: Select Xcode
+        id: xcode
+        uses: ./.github/actions/select-xcode
+
       # ISO week (YYYY-Www) — makes the GhosttyKit cache self-refresh weekly.
       - name: Cache epoch
         id: epoch
@@ -161,10 +170,10 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: build/DerivedData
-          key: derived-release-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-${{ github.run_id }}
+          key: derived-release-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-${{ github.run_id }}
           restore-keys: |
-            derived-release-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-
-            derived-release-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-
+            derived-release-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-
+            derived-release-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-
 
       - name: Build and benchmark
         run: mise run bench --verbose

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -195,6 +195,13 @@ jobs:
 
       - uses: jdx/mise-action@v4.3.0
 
+      # Pin the toolchain: `macos-26` defaults to whatever Xcode the image
+      # currently ships, which is how macterm#340's type-check failure stayed
+      # invisible here. See the action for the full rationale.
+      - name: Select Xcode
+        id: xcode
+        uses: ./.github/actions/select-xcode
+
       # ISO week (YYYY-Www) — makes the GhosttyKit cache self-refresh weekly.
       - name: Cache epoch
         id: epoch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,14 @@ jobs:
 
       - uses: jdx/mise-action@v4.3.0
 
+      # Pin the toolchain: `macos-26` defaults to whatever Xcode the image
+      # currently ships, which is how macterm#340's type-check failure stayed
+      # invisible here. See the action for the full rationale. Only this job
+      # compiles — `release` and `bump-cask` never invoke xcodebuild.
+      - name: Select Xcode
+        id: xcode
+        uses: ./.github/actions/select-xcode
+
       # ISO week (YYYY-Www) — makes the GhosttyKit cache self-refresh weekly.
       - name: Cache epoch
         id: epoch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
               - "scripts/**"
               - "e2e/**"
               - ".github/workflows/test.yml"
+              # The Xcode pin lives here; a bump must rebuild what it governs.
+              - ".github/actions/select-xcode/**"
               - "Macterm/Info.plist"
               - "Macterm/Macterm.entitlements"
 
@@ -44,6 +46,13 @@ jobs:
         uses: actions/checkout@v7
 
       - uses: jdx/mise-action@v4.3.0
+
+      # Pin the toolchain: `macos-26` defaults to whatever Xcode the image
+      # currently ships, which is how macterm#340's type-check failure stayed
+      # invisible here. See the action for the full rationale.
+      - name: Select Xcode
+        id: xcode
+        uses: ./.github/actions/select-xcode
 
       # ISO week (YYYY-Www) — makes the GhosttyKit cache self-refresh weekly.
       - name: Cache epoch
@@ -124,15 +133,24 @@ jobs:
       # hashing the per-slice static archives would add hundreds of MB of
       # hashing to every job to catch a stale *relink* — which xcodebuild
       # already handles, tracking the archives as link inputs.
+
+      # The Xcode version leads the key for the same reason the framework hash
+      # is in it: .swiftmodule/.pcm products record the compiler that wrote
+      # them, so restoring products built by a different Swift across a pin
+      # bump is the "module file was built by a different version" flavour of
+      # the incident above. The pin makes that version knowable, and having it
+      # in the key is what keeps a bump from silently inheriting the old
+      # toolchain's output. Bumping it starts one cold build, which is fine —
+      # a cold cache only costs time; a stale one breaks the build.
       - name: Restore DerivedData (Debug)
         id: derived
         uses: actions/cache/restore@v6
         with:
           path: build/DerivedData
-          key: derived-debug-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-${{ github.run_id }}
+          key: derived-debug-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-${{ github.run_id }}
           restore-keys: |
-            derived-debug-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-
-            derived-debug-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-
+            derived-debug-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-
+            derived-debug-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-
 
       - name: Test
         run: mise run test --verbose
@@ -166,6 +184,13 @@ jobs:
         uses: actions/checkout@v7
 
       - uses: jdx/mise-action@v4.3.0
+
+      # Pin the toolchain: `macos-26` defaults to whatever Xcode the image
+      # currently ships, which is how macterm#340's type-check failure stayed
+      # invisible here. See the action for the full rationale.
+      - name: Select Xcode
+        id: xcode
+        uses: ./.github/actions/select-xcode
 
       # ISO week (YYYY-Www) — makes the GhosttyKit cache self-refresh weekly.
       - name: Cache epoch
@@ -201,10 +226,10 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: build/DerivedData
-          key: derived-debug-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-${{ github.run_id }}
+          key: derived-debug-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-${{ github.run_id }}
           restore-keys: |
-            derived-debug-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-
-            derived-debug-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-
+            derived-debug-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-${{ hashFiles('**/*.swift', 'project.yml') }}-
+            derived-debug-xcode${{ steps.xcode.outputs.version }}-${{ hashFiles('GhosttyKit.xcframework/*/Headers/ghostty.h') }}-
 
       - name: End-to-end tests
         run: mise run e2e --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Thanks for your interest in contributing! Macterm is a macOS terminal emulator b
 
 Building requires macOS 26+ and a full install of Xcode 26 (the Command Line Tools alone aren't enough — `xcodebuild` needs the Xcode app to build the macOS app target, and the code compiles against macOS 26 SDK APIs behind `#available` checks). The shipped app itself runs on macOS 14+.
 
+CI compiles on one pinned Xcode (`.github/actions/select-xcode`), so a green run names a toolchain rather than whatever the runner image defaulted to that week. Any Xcode 26 is still fine locally — but note that CI therefore won't catch a failure specific to an older 26.x than the pin, which is how [#340](https://github.com/thdxg/macterm/pull/340) reached main.
+
 ```bash
 mise install
 ```


### PR DESCRIPTION
## What

Adds a `select-xcode` composite action and calls it from the five jobs that invoke the compiler — `test.yml` (Unit, End-to-end), `benchmark.yml`, `release.yml`, `release-tip.yml`. It sets `DEVELOPER_DIR` from one pinned version and exposes that version for cache keys.

Follow-up to #340.

## Why

Nothing in CI selects an Xcode today. `macos-26` ships 26.0.1, 26.1.1, 26.2, 26.3, 26.4.1, 26.5 and 26.6, and every job silently takes the image default. That is how #340 stayed invisible: `MactermApp.body` failed to type-check on 26.3 while compiling fine on the 26.6 the runner happened to pick, so CI had nothing to say about it — and a green run never recorded which toolchain produced it.

I measured the underlying problem while reviewing #340, building both versions with `-Xfrontend -warn-long-function-bodies=200`:

| | `MactermApp.body` getter |
|---|---|
| before #340 | **3295 ms** |
| after #340 | **477 ms** |

The next-slowest view body in the app is `Sidebar.swift:220` at 370 ms, so that expression was a ~9× outlier rather than something broadly true of the codebase. Nothing else is near the cliff.

## What this does and doesn't buy

It freezes image drift and makes a toolchain bump a reviewable one-line change instead of a silent rollout.

**It does not test an older 26.x than the pin**, so a #340-class failure on 26.3 still wouldn't surface here. Catching that needs a job compiling against the floor of the supported range, which is a separate call about runner minutes and how far back "Xcode 26" is meant to reach. `CONTRIBUTING.md` now states the gap rather than leaving "a full install of Xcode 26" to imply coverage it doesn't have.

## Details worth a look

- **Absence hard-fails.** Runner images drop older Xcodes as they age, so the pin will eventually name one that isn't there. It errors with the installed list and a pointer to the default, instead of falling through to whatever is current — a silent fallback is precisely the unpinned behaviour being removed.
- **The version leads the `derived-debug-*` / `derived-release-*` cache keys**, for the same reason the GhosttyKit header hash is already in them: `.swiftmodule`/`.pcm` products record the compiler that wrote them, so a bump must not restore products built by a different Swift. This is the "module file was built by a different version" flavour of the incident already documented in `test.yml`. Merging invalidates those caches once — a cold cache costs time, a stale one breaks the build.
- **The action is in both paths filters.** Otherwise a pin bump touches only `.github/actions/**` and skips the very jobs it governs.
- **Format and Lint are deliberately unpinned.** They run swiftformat/swiftlint, which parse Swift themselves and never invoke `xcodebuild`; `release`/`bump-cask` don't compile either. Adding the step there would be noise.

## Verified

All ten workflows and the action parse. Both branches of the action's script exercised locally — the missing-Xcode path errors with the installed list and exits 1, the success path writes `DEVELOPER_DIR` and prints the version. Cross-checked every job in every workflow: the five that compile all select Xcode, and no job that selects it fails to compile.