### PR TITLE
Keep the tab switcher's padding uniform at any window shape, and default it on

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -292,8 +292,9 @@ final class Preferences {
     /// Show a transient tab switcher while the Recent Tab shortcut is held
     /// (#344): a glass strip of the recency-ordered tabs with a preview of
     /// each pane, so a several-tab project shows where the next Ctrl+Tab will
-    /// land. Opt-in — off keeps the plain direct-cycling behavior, and the
-    /// pane snapshots are only captured when it's on.
+    /// land. On by default. Off keeps the plain direct-cycling behavior —
+    /// where each press switches tabs for real rather than moving a selection
+    /// — and skips the pane snapshots entirely, so it costs nothing there.
     var showTabSwitcherOverlay: Bool {
         didSet { defaults.set(showTabSwitcherOverlay, forKey: Keys.showTabSwitcherOverlay) }
     }
@@ -810,7 +811,7 @@ final class Preferences {
             .flatMap(SidebarIconSize.init(rawValue:)) ?? .medium
         showAgentIcons = defaults.object(forKey: Keys.showAgentIcons) as? Bool ?? true
         showTabStatusIndicator = defaults.object(forKey: Keys.showTabStatusIndicator) as? Bool ?? false
-        showTabSwitcherOverlay = defaults.object(forKey: Keys.showTabSwitcherOverlay) as? Bool ?? false
+        showTabSwitcherOverlay = defaults.object(forKey: Keys.showTabSwitcherOverlay) as? Bool ?? true
         showSpinnerOverAgentIcons = defaults.object(forKey: Keys.showSpinnerOverAgentIcons) as? Bool ?? true
         autoNameTabs = defaults.object(forKey: Keys.autoNameTabs) as? Bool ?? true
         autoAssignProjectColors = defaults.object(forKey: Keys.autoAssignProjectColors) as? Bool ?? false

--- a/Macterm/Views/TabSwitcherOverlay.swift
+++ b/Macterm/Views/TabSwitcherOverlay.swift
@@ -104,6 +104,13 @@ private struct TabSwitcherStrip: View {
     let onClick: (Int) -> Void
 
     private static let spacing: CGFloat = 10
+    /// Inset from the panel's edge to the cards. The preview inside a card
+    /// carries `TabSwitcherCard.selectionHalo` on top of this, so the gap the
+    /// eye actually reads — panel edge to picture — is the sum, equally on
+    /// every side. Anything that pads one axis and not the other shows up
+    /// immediately here: the card used to carry a stray `.padding(.vertical, 2)`
+    /// (left over from a uniform padding that was removed around it), which
+    /// made the top gap 20 against 18 at the sides.
     private static let insets: CGFloat = 14
     /// Left clear on both sides of the panel, so it reads as floating in the
     /// window rather than spanning it.
@@ -194,51 +201,62 @@ private struct TabSwitcherCard: View {
     let isSelected: Bool
     let paneAspect: CGFloat?
 
-    /// Height of the preview area. Fixed, with the width following the pane
-    /// region's real aspect — the other way round (fixed width, derived
-    /// height) makes a portrait window's card taller than the strip.
-    static let previewHeight: CGFloat = 140
+    /// Height of the preview at a comfortably wide pane region. A narrow
+    /// (portrait) one grows TALLER instead of the card growing wider than its
+    /// picture — see `previewHeight(forPaneAspect:)`.
+    private static let basePreviewHeight: CGFloat = 140
+    /// Ceiling on that growth, so an extremely tall pane region can't turn the
+    /// strip into a wall.
+    private static let maxPreviewHeight: CGFloat = 190
+    /// Width a narrow card is grown toward — enough to carry an icon and some
+    /// title. Reached by making the preview taller, NEVER by padding the card
+    /// wider than its picture: a card with surplus width has to distribute it,
+    /// and centering that surplus is what made the side padding drift away
+    /// from the top padding as the window changed shape.
+    private static let widthTarget: CGFloat = 116
     /// Aspect assumed before anything has been measured. Only reachable for a
     /// workspace whose panes have never been on screen this run.
     static let fallbackAspect: CGFloat = 16.0 / 10.0
-    /// Floor on the card's width, so a very narrow (portrait) pane region
-    /// doesn't produce a card too small to carry an icon and any title at all.
-    /// The preview is centered in it and the title row aligns to the preview,
-    /// not to the card — see `body`.
-    private static let minimumWidth: CGFloat = 110
     private static let cornerRadius: CGFloat = 8
     /// Halo left around the preview for the selection fill to show in. Zero
     /// would hide it: the thumbnail is opaque, so a highlight exactly the
     /// preview's size sits entirely behind it.
     private static let selectionHalo: CGFloat = 4
 
-    /// The card's width for a given pane region — the preview at
-    /// `previewHeight` plus its halo, floored by `minimumWidth`.
-    static func width(forPaneAspect aspect: CGFloat?) -> CGFloat {
-        max(minimumWidth, boxWidth(forPaneAspect: aspect))
+    /// Aspect to lay out at, floored so a degenerate measurement can't divide
+    /// the height into something enormous.
+    private static func safeAspect(_ aspect: CGFloat?) -> CGFloat {
+        max(aspect ?? fallbackAspect, 0.2)
     }
 
-    /// Width of the preview plus the halo around it: the card's real content,
-    /// and what the title row is sized and aligned to.
-    private static func boxWidth(forPaneAspect aspect: CGFloat?) -> CGFloat {
-        (previewHeight * (aspect ?? fallbackAspect)).rounded() + selectionHalo * 2
+    /// Preview height for a pane region: the base, grown toward `widthTarget`
+    /// when the region is narrow, capped.
+    static func previewHeight(forPaneAspect aspect: CGFloat?) -> CGFloat {
+        min(maxPreviewHeight, max(basePreviewHeight, widthTarget / safeAspect(aspect)))
+    }
+
+    /// The card's width — exactly its preview plus the halo, at every aspect.
+    /// Keeping the two equal is what makes the panel's padding uniform by
+    /// construction: there is no surplus for a layout to distribute.
+    static func width(forPaneAspect aspect: CGFloat?) -> CGFloat {
+        (previewHeight(forPaneAspect: aspect) * safeAspect(aspect)).rounded() + selectionHalo * 2
     }
 
     private var cardWidth: CGFloat { Self.width(forPaneAspect: paneAspect) }
 
     var body: some View {
-        let boxWidth = Self.boxWidth(forPaneAspect: paneAspect)
-        // Preview and title share a left edge. The VStack is only as wide as
-        // the preview box, so centering it inside `cardWidth` moves the title
-        // with the picture instead of pinning the title to the card's edge and
-        // leaving it adrift of a narrower preview.
+        // Preview, title row and card are all exactly `cardWidth`: the preview
+        // because the card's width is derived from it, the title row because
+        // it asks for the same. Nothing here is wider than its content, so
+        // there is no surplus to center and the panel's padding reads the same
+        // on every side at every window shape.
         VStack(alignment: .leading, spacing: 6) {
             PaneMosaic(node: tab.splitRoot, focusedPaneID: tab.focusedPaneID)
                 // The mosaic gets the pane region's real proportions, so every
                 // leaf inside it gets its own pane's proportions and the
                 // captured frames drop in uncropped.
-                .aspectRatio(paneAspect ?? Self.fallbackAspect, contentMode: .fit)
-                .frame(height: Self.previewHeight)
+                .aspectRatio(Self.safeAspect(paneAspect), contentMode: .fit)
+                .frame(height: Self.previewHeight(forPaneAspect: paneAspect))
                 // The gaps between leaves are the miniature split dividers, so
                 // they need a color of their own. Left transparent they showed
                 // whatever sat behind the card — the selection fill on the
@@ -291,10 +309,8 @@ private struct TabSwitcherCard: View {
             // Inset by the halo so the icon's leading edge lands on the
             // preview's own edge rather than the highlight's.
             .padding(.horizontal, Self.selectionHalo)
-            .frame(width: boxWidth, alignment: .leading)
+            .frame(width: cardWidth, alignment: .leading)
         }
-        .frame(width: cardWidth)
-        .padding(.vertical, 2)
     }
 }
 


### PR DESCRIPTION
Follow-up to #346.

## What

Two fixes to the tab switcher that landed in #346:

- The panel's padding was uneven, and drifted further as the window was resized.
- The switcher is now **on by default**.

## Why

The gap from the panel's edge to a card's preview was 18pt at the sides but 20pt at the top. Removing the cause of *that* only fixed one window shape — a second source of drift sat underneath it, which is why resizing moved the padding again.

On the default: the switcher is the better behavior for the shortcut it fronts, and leaving it off meant nobody saw it without going looking.

## How

**Two independent sources of drift.**

1. The card carried a stray `.padding(.vertical, 2)` with no horizontal counterpart — left behind when the uniform padding around it was replaced by a selection fill that hugs the preview.
2. The card's width was `max(minimumWidth, previewWidth)`. A narrow (portrait) pane region produced a card wider than its own picture, and the surplus was distributed by *centering* — growing the side padding while the top stayed put. Resizing changed the aspect, changed the surplus, and moved the padding with it.

The fix for the second is structural rather than another adjustment: **the card is now exactly as wide as its preview at every aspect**, and the readability floor a narrow region needs is met by making the preview *taller* (capped by `maxPreviewHeight`) rather than the card wider. With no surplus, there is nothing to distribute and the padding is uniform by construction — a future change can't reintroduce the drift without first reintroducing a width floor.

**Defaulting on** has two intended consequences: cycling becomes selection-only by default (a press moves the strip's selection; the tab behind it changes on release, not on every press), and the pane snapshots the strip needs are collected by default — a downsampled copy of whatever is on screen, at most every 750ms, off the foreground poll that already runs. Turning the preference off (Settings → Appearance → Tab Switching) restores both.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app and confirmed the behavior
- [ ] Added or updated tests for new model / persistence / palette / hotkey logic

Measured on 8× crops of 2× captures, panel edge → preview:

| window shape | side | top |
|---|---|---|
| tall (before) | 18.1pt | 19.1pt |
| tall (after) | 18.1pt | 18.0pt |
| wide (after) | 17.8pt | 17.5pt |

The "wide" row is the case that used to drift — same window, dragged to a different aspect so the previews go from portrait to landscape.

Default-on was verified with the preference key deleted from the defaults domain, so the new default is what took effect rather than a stored value.

## Notes for reviewers

- **No tests added.** Both changes are view-layer geometry. `TabSwitcherCard.previewHeight(forPaneAspect:)` and `width(forPaneAspect:)` are pure and would be worth pinning (the invariant `width == previewWidth + 2 * selectionHalo` at every aspect is exactly what stops the drift returning), but they're `static` on a `private struct`. Happy to lift them somewhere testable if you'd like that invariant guarded.
