### PR TITLE
Refcount a zmx session so closing one view can't kill another's

### DIFF
--- a/Macterm/App/AppState+PinnedTabs.swift
+++ b/Macterm/App/AppState+PinnedTabs.swift
@@ -298,8 +298,9 @@ extension AppState {
               let tab = ws.tabs.first(where: { $0.id == tabID })
         else { return }
         logger.info("unloadPinnedTab: \(tabID, privacy: .public)")
-        for pane in tab.splitRoot.allPanes() {
-            pane.killPersistentSession(using: zmx)
+        let unloading = tab.splitRoot.allPanes()
+        releaseSessions(unloading)
+        for pane in unloading {
             pane.destroySurface()
         }
         ws.closeTab(tabID)

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -906,11 +906,43 @@ final class AppState {
     /// too (#285), or a sweep would kill the very sessions the materialize
     /// step is about to reattach.
     private func claimedSessionNames() -> Set<String> {
-        Set(workspaces.values
+        Set(allLivePanes().map(\.sessionName))
+            .union(pendingPinnedSessionNames())
+    }
+
+    /// Every pane attached to a session, across ALL workspaces (pinned
+    /// included) — the shared traversal behind `claimedSessionNames` and
+    /// `releaseSessions`.
+    private func allLivePanes() -> [Pane] {
+        workspaces.values
             .flatMap(\.tabs)
             .flatMap { $0.splitRoot.allPanes() }
-            .map(\.sessionName))
-            .union(pendingPinnedSessionNames())
+    }
+
+    /// Give up these panes' claims on their zmx sessions, killing a session
+    /// only when no OTHER pane still attaches it. Several panes may share one
+    /// session (a mirror of the same session shown elsewhere), so a pane going
+    /// away is a *release*, not a kill: the daemon has to outlive it for the
+    /// mirrors that remain, or closing one view of a session would destroy the
+    /// work still on screen in another.
+    ///
+    /// Takes the whole batch at once, because the callers that unload a
+    /// project, close a tab, or drop a layout's panes release many panes
+    /// together — asked one at a time, two mirrors inside one batch would each
+    /// see the other still in the tree, both decline to kill, and leak the
+    /// session as a clients==0 daemon.
+    ///
+    /// Callers still `destroySurface()` themselves; this decides only the kill.
+    func releaseSessions(_ panes: [Pane]) {
+        let releasing = Set(panes.map(\.id))
+        let retained = Set(
+            allLivePanes()
+                .filter { !releasing.contains($0.id) }
+                .map(\.sessionName)
+        ).union(pendingPinnedSessionNames())
+        for pane in panes where !retained.contains(pane.sessionName) {
+            pane.killPersistentSession(using: zmx)
+        }
     }
 
     private func shouldSweep(_ destination: String, now: Date) -> Bool {
@@ -1060,14 +1092,16 @@ final class AppState {
         guard let ws = workspaces[projectID] else { return }
         logger.debug("unloadProject: \(projectID, privacy: .public)")
         let snapshot = WorkspaceSerializer.snapshot([projectID: ws])
-        for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {
-            // Unload KILLS: with quit now a detach, this is the one action
-            // that stops a whole project's shells while keeping its layout
-            // (the group-kill #113 asked for). A detaching unload would be
-            // a trap — "unloaded" shells silently running forever. The
-            // snapshot keeps the layout; reopening spawns fresh shells in
-            // the saved cwds (`zmx attach` upserts over the dead names).
-            pane.killPersistentSession(using: zmx)
+        let unloading = ws.tabs.flatMap { $0.splitRoot.allPanes() }
+        // Unload KILLS: with quit now a detach, this is the one action that
+        // stops a whole project's shells while keeping its layout (the
+        // group-kill #113 asked for). A detaching unload would be a trap —
+        // "unloaded" shells silently running forever. The snapshot keeps the
+        // layout; reopening spawns fresh shells in the saved cwds (`zmx
+        // attach` upserts over the dead names). A session mirrored outside
+        // this project survives, and its pane keeps it.
+        releaseSessions(unloading)
+        for pane in unloading {
             pane.destroySurface()
         }
         if let restored = WorkspaceSerializer.restore(from: snapshot, validIDs: [projectID]).first {
@@ -1093,9 +1127,11 @@ final class AppState {
         guard projectID != PinnedTabs.projectID else { return }
         logger.debug("removeProject: \(projectID, privacy: .public)")
         if let ws = workspaces[projectID] {
-            for pane in ws.tabs.flatMap({ $0.splitRoot.allPanes() }) {
-                // Project removed for good → its sessions die with it.
-                pane.killPersistentSession(using: zmx)
+            // Project removed for good → its sessions die with it, unless a
+            // session is mirrored by a pane outside this project.
+            let removing = ws.tabs.flatMap { $0.splitRoot.allPanes() }
+            releaseSessions(removing)
+            for pane in removing {
                 pane.destroySurface()
             }
         }
@@ -1295,9 +1331,11 @@ final class AppState {
               let tab = ws.tabs.first(where: { $0.id == tabID })
         else { return }
         logger.debug("closeTab: \(tabID, privacy: .public) project=\(projectID, privacy: .public)")
-        for pane in tab.splitRoot.allPanes() {
-            // Tab closed for good → its panes' zmx sessions die with it.
-            pane.killPersistentSession(using: zmx)
+        // Tab closed for good → its panes' zmx sessions die with it, unless a
+        // session is mirrored by a pane in another tab or window.
+        let closing = tab.splitRoot.allPanes()
+        releaseSessions(closing)
+        for pane in closing {
             pane.destroySurface()
         }
         ws.closeTab(tabID)
@@ -1950,10 +1988,14 @@ final class AppState {
             return
         }
         logger.debug("closePane: \(paneID, privacy: .public) project=\(projectID, privacy: .public)")
-        // Pane closed for good → its zmx session dies with it. (The
-        // onlyPaneLeft path below re-kills via closeTab; killSession is a
-        // no-op on a missing session, so the overlap is harmless.)
-        tab.splitRoot.findPane(id: paneID)?.killPersistentSession(using: zmx)
+        // Pane closed for good → its zmx session dies with it, unless another
+        // pane mirrors that session. (The onlyPaneLeft path below re-releases
+        // via closeTab; killSession is a no-op on a missing session, so the
+        // overlap is harmless.) The pane is still in the tree here, which is
+        // why releaseSessions excludes the batch it is given.
+        if let closing = tab.splitRoot.findPane(id: paneID) {
+            releaseSessions([closing])
+        }
         reconnectPolicy.forget(paneID)
         switch tab.removePane(paneID) {
         case .onlyPaneLeft:
@@ -2320,9 +2362,11 @@ final class AppState {
         // Destroy surfaces only AFTER the new trees no longer reference them.
         // A layout-dropped pane is gone for good (no declared node claims it),
         // so its zmx session dies too — otherwise it would linger as a
-        // clients==0 daemon.
+        // clients==0 daemon. Unless a pane elsewhere mirrors that session: a
+        // reconcile that drops one of two identical leaves must not kill the
+        // session the surviving one was just matched to.
+        releaseSessions(plan.panesToDestroy)
         for pane in plan.panesToDestroy {
-            pane.killPersistentSession(using: zmx)
             pane.destroySurface()
         }
 

--- a/Macterm/Views/QuickTerminal.swift
+++ b/Macterm/Views/QuickTerminal.swift
@@ -496,6 +496,14 @@ final class QuickTerminalSplitState {
     func closePane(_ paneID: UUID) {
         // Quick-terminal panes are ephemeral: closing one is permanent, so its
         // zmx session dies with it (transient hide/show never reaches here).
+        //
+        // This is the one kill that does NOT go through
+        // `AppState.releaseSessions`, and it is exempt by construction rather
+        // than by oversight: quick-terminal panes carry
+        // `ZmxSessionName.quickTerminalSlug`, so their session names can never
+        // equal a workspace pane's, and this state owns no AppState reference
+        // to consult. Nothing can mirror one, so there is never another
+        // claimant to refcount against.
         tab.splitRoot.findPane(id: paneID)?.killPersistentSession(using: .live)
         switch tab.removePane(paneID) {
         case .onlyPaneLeft:

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -1707,6 +1707,82 @@ struct AppStateTests {
         #expect(await killed.names == names)
     }
 
+    /// A pane attached to `name`, for building the mirror cases below. Uses
+    /// the same persisted-name init the restore path uses, which is the only
+    /// way two panes can legitimately share a session name today.
+    private func mirrorPane(of name: String, projectID: UUID) -> Pane {
+        Pane(projectPath: "/tmp", projectID: projectID, sessionName: name)
+    }
+
+    @Test
+    func closing_one_of_two_mirrors_spares_the_shared_session() async throws {
+        // Two panes may attach one zmx session (the same session shown in
+        // another window). Closing one is a release, not a kill — the daemon
+        // has to outlive it, or the work still on screen elsewhere dies.
+        let killed = KilledSessions()
+        let state = makeAppState()
+        state.zmx = recordingZmx(into: killed)
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        let tab = try #require(ws.activeTab)
+        let shared = try #require(tab.splitRoot.allPanes().first).sessionName
+
+        let mirrorTab = ws.createTab(projectPath: "/tmp")
+        mirrorTab.splitRoot = .pane(mirrorPane(of: shared, projectID: p.id))
+
+        state.closeTab(mirrorTab.id, projectID: p.id)
+
+        await killed.settleExpectingNone()
+        #expect(await killed.names.isEmpty)
+    }
+
+    @Test
+    func closing_the_last_mirror_kills_the_shared_session() async throws {
+        // The refcount must actually reach zero: with no pane left attached,
+        // the daemon has to die or it lingers as a clients==0 orphan.
+        let killed = KilledSessions()
+        let state = makeAppState()
+        state.zmx = recordingZmx(into: killed)
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        let tab = try #require(ws.activeTab)
+        let shared = try #require(tab.splitRoot.allPanes().first).sessionName
+
+        let mirrorTab = ws.createTab(projectPath: "/tmp")
+        mirrorTab.splitRoot = .pane(mirrorPane(of: shared, projectID: p.id))
+        // A third tab so closing both mirror-holding tabs leaves a valid
+        // workspace behind.
+        _ = ws.createTab(projectPath: "/tmp")
+
+        state.closeTab(mirrorTab.id, projectID: p.id)
+        state.closeTab(tab.id, projectID: p.id)
+
+        await killed.settle(expecting: 1)
+        #expect(await killed.names == [shared])
+    }
+
+    @Test
+    func releasing_two_mirrors_in_one_batch_still_kills_the_session() async throws {
+        // The batch case: asked one at a time, two mirrors inside the SAME
+        // batch would each see the other still in the tree, both decline, and
+        // leak the session. This is why releaseSessions takes the whole batch.
+        let killed = KilledSessions()
+        let state = makeAppState()
+        state.zmx = recordingZmx(into: killed)
+        let p = seedProject(state)
+        let ws = try #require(state.workspaces[p.id])
+        let tab = try #require(ws.activeTab)
+        let shared = try #require(tab.splitRoot.allPanes().first).sessionName
+
+        let mirrorTab = ws.createTab(projectPath: "/tmp")
+        mirrorTab.splitRoot = .pane(mirrorPane(of: shared, projectID: p.id))
+
+        state.unloadProject(p.id)
+
+        await killed.settle(expecting: 1)
+        #expect(await killed.names == [shared])
+    }
+
     @Test
     func closing_remote_pane_routes_kill_over_ssh() async throws {
         // A remote pane's session lives on the remote daemon — a local kill


### PR DESCRIPTION
## What

`AppState.releaseSessions(_:)` replaces the unconditional `killPersistentSession` at six of its seven call sites. A pane going away is now a *release* — the zmx session dies only when no other pane still attaches it.

No behaviour change on its own: nothing creates a second pane on a session yet.

## Why

Groundwork for multi-window (#345), not a fix for a bug reachable today.

Every pane owns its session outright right now — `killPersistentSession` has no notion of another claimant, and seven paths call it (unload/remove project, close tab, close pane, layout apply's `panesToDestroy`, unload pinned tab, quick terminal). That is correct only while a session name maps to exactly one pane.

Multi-window breaks that assumption. Showing the same session in a second window means a second pane attached to it, because a `Pane` owns exactly one `NSView` for its lifetime and one `NSView` cannot live in two view hierarchies — so "the same tab in two windows" is necessarily two panes sharing a `sessionName`. Against the current code, closing either view destroys the session the other is still displaying.

Refs #345.

## How

`releaseSessions` takes the **whole batch** rather than one pane at a time. That is the non-obvious part: the callers that unload a project, close a tab or drop a layout's panes release many panes together, and asked individually two mirrors inside one batch would each see the other still in the tree, both decline to kill, and leak the session as a `clients==0` daemon. Both failure modes — no refcount at all, and a naive per-pane loop — have their own regression test.

`claimedSessionNames()` and `releaseSessions` now share one `allLivePanes()` traversal.

Two things worth a reviewer's eye:

- **`closePane` kills before it removes the pane from the tree**, so the closing pane is still a live pane when the check runs. That is why `releaseSessions` excludes the batch it is given rather than trusting tree membership.
- **The quick terminal's kill stays direct**, and is now documented as exempt by construction rather than by oversight: `QuickTerminalSplitState` holds no `AppState` reference, and its panes carry `ZmxSessionName.quickTerminalSlug`, so their names can never equal a workspace pane's and nothing can mirror one. Threading an `AppState` through for it would buy no behaviour.

Retained names also include `pendingPinnedSessionNames()`, matching what the orphan reapers already spare. That is a no-op today (two panes only share a name by mirroring) and errs toward not killing.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [ ] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

Each new test was checked to **fail** without the specific thing it guards, so none of them pass vacuously:

| Test | Fails when |
|---|---|
| `closing_one_of_two_mirrors_spares_the_shared_session` | the refcount is removed entirely |
| `releasing_two_mirrors_in_one_batch_still_kills_the_session` | `releaseSessions` loops per pane instead of taking the batch |
| `closing_the_last_mirror_kills_the_shared_session` | guards the other direction — an over-eager refcount that spares forever (passes against both sabotages above, by design) |

Not run in the app, deliberately: there is no user-visible behaviour to observe until something creates a mirror.

## Notes for reviewers

First step of the plan for #345. The next one is window-scoped accessors that initially return today's global values; mirrors themselves come after that, with a `pane mirror` CLI verb so the whole layer is testable inside a single window before any window work lands.

The tests build a mirror through `Pane(projectPath:projectID:sessionName:)` — the persisted-name init the restore path uses, and today the only legitimate way two panes can share a session name.