### PR TITLE
Take over a mirrored session's size by clicking the pane

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -140,6 +140,7 @@ jobs:
             Macterm/Resources/ghostty
             Macterm/Resources/terminfo
             Macterm/Resources/zmx
+            .zmx-tag
             .ghosttykit-tag
           # The tag stamp is cached with the artifacts it describes (test.yml).
           #

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -219,6 +219,7 @@ jobs:
             Macterm/Resources/ghostty
             Macterm/Resources/terminfo
             Macterm/Resources/zmx
+            .zmx-tag
             .ghosttykit-tag
           # No restore-keys fallback — see test.yml for why a time-rolling key
           # and a prefix restore-key must never be paired.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
             Macterm/Resources/ghostty
             Macterm/Resources/terminfo
             Macterm/Resources/zmx
+            .zmx-tag
             .ghosttykit-tag
           # The tag stamp is cached with the artifacts it describes (test.yml).
           #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
             Macterm/Resources/ghostty
             Macterm/Resources/terminfo
             Macterm/Resources/zmx
+            .zmx-tag
             .ghosttykit-tag
           # The tag stamp is cached WITH the artifacts it describes. setup.sh
           # reads a missing stamp as "provenance unknown" and warns, which a
@@ -207,6 +208,7 @@ jobs:
             Macterm/Resources/ghostty
             Macterm/Resources/terminfo
             Macterm/Resources/zmx
+            .zmx-tag
             .ghosttykit-tag
           key: ghosttykit-${{ hashFiles('scripts/setup.sh') }}-${{ steps.epoch.outputs.week }}
       # Runs BEFORE the DerivedData cache, which keys on what this installs.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Macterm/Resources/*
 # GHOSTTYKIT_TAG in setup.sh refreshes them instead of the presence checks
 # silently keeping the old copy. Per-checkout state, not source.
 .ghosttykit-tag
+.zmx-tag
 
 build/
 __pycache__/

--- a/Macterm/App/AppState.swift
+++ b/Macterm/App/AppState.swift
@@ -1002,6 +1002,47 @@ final class AppState {
         sessionLeaders[pane.sessionName] = pane.id
     }
 
+    /// Hand this pane's session leadership over because the user moved to it —
+    /// updating our model AND telling zmx, which otherwise only switches leader
+    /// on real keystrokes and so would leave the pty sized for the pane the
+    /// user just left.
+    ///
+    /// The claim is sent unconditionally for a mirrored local pane, not only
+    /// when we believe leadership needs to move. zmx's `handleClaim` is a
+    /// no-op for a client that already leads, so the redundant case is free —
+    /// and sending anyway is what re-synchronises us whenever our model and
+    /// the daemon have drifted (an inferred leader after restore, or a foreign
+    /// `zmx attach` that took leadership without telling us).
+    ///
+    /// Debounced: a claim costs a pty resize, a SIGWINCH and a full TUI
+    /// redraw, and focus is noisy — `mouseDown` reports it twice per click
+    /// (directly and again via `becomeFirstResponder`) and `FocusRestoration`
+    /// retries across run-loop ticks. Cmd-tabbing past a window must not
+    /// reflow the program twice.
+    ///
+    /// **Remote panes are excluded.** Their zmx lives on the host and may
+    /// predate the Claim tag, in which case the client forwards the APC to the
+    /// shell and the user gets garbage on their prompt. Knowing otherwise
+    /// needs a per-host version probe; until then a remote mirror falls back
+    /// to zmx's own behaviour, where typing into it transfers leadership.
+    func claimSessionLeadership(_ pane: Pane) {
+        guard isMirrored(pane) else { return }
+        // Record first so the dim moves with the click rather than after the
+        // debounce — the model is ours to change immediately.
+        noteSessionLeader(pane)
+        guard !pane.isRemote else { return }
+        pendingLeadershipClaim?.cancel()
+        let work = DispatchWorkItem { [weak self, weak pane] in
+            guard let self, let pane, self.isLeader(pane) else { return }
+            pane.nsView?.sendLeadershipClaim()
+        }
+        pendingLeadershipClaim = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.leadershipClaimDebounce, execute: work)
+    }
+
+    private static let leadershipClaimDebounce: TimeInterval = 0.15
+    private var pendingLeadershipClaim: DispatchWorkItem?
+
     /// The panes in `tab` that are mirrors NOT currently driving their
     /// session's size — the ones the UI dims.
     func nonLeaderPaneIDs(in tab: TerminalTab) -> Set<UUID> {
@@ -2525,12 +2566,11 @@ final class AppState {
     func focusPane(_ paneID: UUID, projectID: UUID) {
         guard let tab = workspaces[projectID]?.activeTab else { return }
         tab.focusPane(paneID)
-        // Focusing a mirror is how the user says "drive the size from here".
-        // Keystrokes require focus, and any real keystroke makes zmx's daemon
-        // hand leadership over anyway (its `isUserInput` rule), so recording
-        // it here tracks what the daemon is about to do rather than diverging.
+        // Focusing a mirror is how the user says "drive the size from here",
+        // so tell zmx as well as ourselves — its daemon only switches leader
+        // on real keystrokes, and the user has not typed anything yet.
         if let pane = tab.splitRoot.findPane(id: paneID) {
-            noteSessionLeader(pane)
+            claimSessionLeadership(pane)
         }
     }
 

--- a/Macterm/System/ZmxClient.swift
+++ b/Macterm/System/ZmxClient.swift
@@ -683,6 +683,25 @@ enum ZmxEnvironment {
     }
 }
 
+/// zmx's leadership protocol (#345).
+///
+/// A session may have several attached clients but only one **leader**, whose
+/// window size drives the pty; zmx drops a non-leader's resize outright. The
+/// daemon hands leadership to any client that sends real user input, which
+/// suits a human at a keyboard but gives Macterm no way to say "size the pty
+/// from this pane" when the user merely clicks it — typing would reach their
+/// running program.
+///
+/// So the client watches its stdin for this APC string and turns it into an
+/// IPC Claim instead of forwarding it (zmx's `util.ClaimFilter`). APC because
+/// no keyboard produces one and terminals discard unknown APC, so a stray
+/// sequence reaching a program is inert.
+enum ZmxLeadership {
+    /// Must match `ClaimFilter.sequence` in the zmx fork exactly — it is a wire
+    /// contract between the two, not a local constant.
+    static let claimSequence = "\u{1b}_zmx;claim\u{1b}\\"
+}
+
 /// Resolves how a surface launches under zmx.
 enum ZmxAttach {
     /// The `command-wrapper` argv that wraps a surface's shell in zmx:

--- a/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Macterm/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1709,6 +1709,48 @@ extension GhosttyTerminalNSView {
 extension GhosttyTerminalNSView {
     /// The live terminal grid + cell/surface pixel dimensions
     /// (`ghostty_surface_size`), or nil when the surface isn't created yet.
+    /// Ask zmx to make this pane's client the session leader (#345), so the
+    /// pty follows THIS pane's size rather than another mirror's.
+    ///
+    /// Refuses before the surface has a real size: `setLeader` answers a claim
+    /// by asking the client for its window size, and a surface that has not
+    /// laid out yet (an off-screen tab, the incubator) would resize the shared
+    /// pty to a placeholder for every mirror at once.
+    ///
+    /// Idempotent by design — zmx's `handleClaim` returns early when the
+    /// client is already leader, sending no size request — so callers may
+    /// claim freely rather than tracking whether it is needed.
+    @discardableResult
+    func sendLeadershipClaim() -> Bool {
+        guard let size = surfaceSize, size.columns > 0, size.rows > 0 else { return false }
+        return sendControlSequence(ZmxLeadership.claimSequence)
+    }
+
+    /// Write raw bytes straight to the pty, recording NONE of the
+    /// command-submission evidence `sendText` does.
+    ///
+    /// That evidence drives `TerminalExecutionTracker` — execution state, the
+    /// tab status glyph, and tab naming via `shellIsAtPrompt` — so a control
+    /// sequence the user never typed must leave it untouched, or a following
+    /// Return would read as submitting content that does not exist.
+    ///
+    /// Rides the key path with only `.text` set: libghostty writes such an
+    /// event's bytes verbatim under both its legacy and kitty encoders (no
+    /// keycode, so no CSI-u translation). NOT `ghostty_surface_text`, which
+    /// routes through the clipboard-paste path and would wrap this in
+    /// bracketed paste and run it past the unsafe-paste check.
+    @discardableResult
+    private func sendControlSequence(_ sequence: String) -> Bool {
+        guard let surface, !sequence.isEmpty else { return false }
+        sequence.withCString { ptr in
+            var ke = ghostty_input_key_s()
+            ke.action = GHOSTTY_ACTION_PRESS
+            ke.text = ptr
+            _ = ghostty_surface_key(surface, ke)
+        }
+        return true
+    }
+
     var surfaceSize: ghostty_surface_size_s? {
         guard let surface else { return nil }
         return ghostty_surface_size(surface)

--- a/MactermTests/App/AppStateTests.swift
+++ b/MactermTests/App/AppStateTests.swift
@@ -279,6 +279,39 @@ struct AppStateTests {
     }
 
     @Test
+    func claiming_leadership_is_a_noop_for_an_unmirrored_pane() throws {
+        // Nothing to claim: the pane is its session's only client, so the
+        // whole mechanism must stay off the hot path of an ordinary focus.
+        let state = makeAppState()
+        let p = seedProject(state)
+        let tab = try #require(state.workspaces[p.id]?.activeTab)
+        let pane = try #require(tab.splitRoot.allPanes().first)
+
+        state.claimSessionLeadership(pane)
+
+        #expect(state.isLeader(pane))
+        #expect(!state.isMirrored(pane))
+    }
+
+    @Test
+    func claiming_leadership_records_it_immediately() throws {
+        // The model updates now, not after the debounce, so the dim moves with
+        // the click. Only the wire message to zmx is deferred.
+        let state = makeAppState()
+        let p = seedProject(state)
+        let tab = try #require(state.workspaces[p.id]?.activeTab)
+        let source = try #require(tab.splitRoot.allPanes().first)
+        let mirrorID = try #require(state.mirrorPane(source.id, direction: .horizontal, projectID: p.id))
+        let mirrored = try #require(tab.splitRoot.findPane(id: mirrorID))
+        #expect(state.isLeader(source))
+
+        state.claimSessionLeadership(mirrored)
+
+        #expect(state.isLeader(mirrored))
+        #expect(!state.isLeader(source))
+    }
+
+    @Test
     func closeNeedsConfirmation_is_false_for_a_pane_whose_session_survives() throws {
         // The busy-close guard says "closing kills its session". For a mirror
         // that is simply false — the other view keeps the program running —

--- a/MactermTests/System/ZmxClientTests.swift
+++ b/MactermTests/System/ZmxClientTests.swift
@@ -308,3 +308,18 @@ struct ZmxReapOrphansDriverTests {
         #expect(killed.value.isEmpty)
     }
 }
+
+@MainActor
+struct ZmxLeadershipTests {
+    @Test
+    func claimSequenceMatchesTheZmxWireContract() {
+        // A wire contract with the zmx fork's `util.ClaimFilter.sequence`, not
+        // a local constant: the client scans stdin for these exact bytes, so a
+        // drift here means claims are silently typed into the user's shell
+        // instead of switching leadership.
+        #expect(ZmxLeadership.claimSequence == "\u{1b}_zmx;claim\u{1b}\\")
+        // APC, so no keyboard can produce it and terminals discard it unknown.
+        #expect(ZmxLeadership.claimSequence.hasPrefix("\u{1b}_"))
+        #expect(ZmxLeadership.claimSequence.hasSuffix("\u{1b}\\"))
+    }
+}

--- a/e2e/test_pane_mirror.py
+++ b/e2e/test_pane_mirror.py
@@ -154,3 +154,72 @@ def test_closing_a_mirror_leaves_the_session_running(app, fresh_tab, live_pane):
         timeout=60,
         message=f"marker {marker} after closing the mirror",
     )
+
+
+def _cols(app, pane_id):
+    return app.pane_inspect(pane=pane_id)["cols"]
+
+
+def test_focusing_a_mirror_resizes_the_shared_pty_to_it(app, fresh_tab, live_pane):
+    """The whole chain, end to end: focus -> Macterm claim -> zmx ClaimFilter
+    -> Daemon.handleClaim -> setLeader -> size request -> TIOCSWINSZ.
+
+    zmx sizes the pty from the LEADER's client only, so this asserts what the
+    session's shell itself believes its width is and requires it to follow
+    whichever mirror has focus.
+
+    Two things make the measurement honest.
+
+    The split is deliberately skewed: at 50/50 the two mirrors are the same
+    width, and a working claim would be indistinguishable from a broken one.
+
+    And the size is read from a loop already running in the session rather than
+    by typing a command when we want to know. Typing is precisely what zmx's
+    OWN leadership rule reacts to, so a `pane run` to measure would hand
+    leadership to the pane it was run in and always report that pane's width —
+    the observation would create the result it claims to find.
+    """
+    app.cli("pane", "mirror", "--direction", "right", "--pane", live_pane["id"])
+    panes = wait_for(
+        lambda: (lambda p: p if len(p) == 2 else None)(app.panes(tab=fresh_tab["id"])),
+        message="the mirror",
+    )
+    mirror = next(p for p in panes if p["id"] != live_pane["id"])
+    wait_for(lambda: app.pane_text(pane=mirror["id"]), timeout=60, message="mirror surface")
+
+    app.cli("pane", "resize-split", "--axis", "horizontal", "--ratio", "0.72",
+            "--pane", live_pane["id"])
+    widths = wait_for(
+        lambda: (lambda a, b: (a, b) if a - b > 8 else None)(
+            _cols(app, live_pane["id"]), _cols(app, mirror["id"])
+        ),
+        message="the split to skew so the two mirrors differ in width",
+    )
+    wide, narrow = widths
+
+    # Print the pty size once a second, forever. No `$` and no single quotes,
+    # so every login shell tokenizes it identically.
+    app.pane_run('/bin/sh -c "while true; do stty size; sleep 1; done"', pane=live_pane["id"])
+
+    def latest_pty_cols():
+        text = app.pane_text(pane=live_pane["id"], scrollback=True) or ""
+        for line in reversed(text.splitlines()):
+            parts = line.split()
+            if len(parts) == 2 and all(p.isdigit() for p in parts):
+                return int(parts[1])
+        return None
+
+    def settles_on(expected, why):
+        wait_for(
+            lambda: latest_pty_cols() == expected,
+            timeout=30,
+            message=f"the pty to report {expected} columns ({why})",
+        )
+
+    settles_on(wide, "the loop was started in the wide pane, so it leads")
+
+    app.cli("pane", "focus", "--pane", mirror["id"])
+    settles_on(narrow, "focusing the narrow mirror claims leadership")
+
+    app.cli("pane", "focus", "--pane", live_pane["id"])
+    settles_on(wide, "and focusing back claims it again")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,6 +23,19 @@ XCFRAMEWORK_DIR="GhosttyKit.xcframework"
 # the exact asset-swap-under-a-pin hazard documented in AGENTS.md. The next
 # ordinary bump (a past-day daily tag, immutable by then) retires this one.
 GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-31}"
+# The zmx release supplying the bundled session multiplexer. Pinned for the same
+# reason GhosttyKit is: thdxg/zmx publishes a build-YYYY-MM-DD release on every
+# push to its main, so tracking `latest` meant two builds of ONE Macterm commit
+# could ship different zmx binaries — including a tagged release picking up
+# whatever landed that morning. Bumping the multiplexer is now its own
+# reviewable commit.
+#
+# It is a wire dependency, not just a binary: Macterm sends zmx's leadership
+# claim (ZmxLeadership.claimSequence) and a zmx predating that tag forwards the
+# APC to the user's shell as literal garbage instead of switching leader. That
+# is exactly what a stale CI cache did once — `Macterm/Resources/zmx` rides the
+# GhosttyKit cache, whose key hashes THIS file, so a zmx bump must change it.
+ZMX_TAG="${ZMX_TAG:-build-2026-09-06}"
 # Which tag the on-disk fork artifacts actually came from. Without this the
 # presence checks below would keep a stale copy forever after a pin bump — the
 # same silent-staleness trap that makes symlinking these artifacts a bad idea.
@@ -43,6 +56,8 @@ GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-31}"
 # compare against, so an unstamped tree never adopts a bumped pin on its own.
 # That is what the warning is for.
 TAG_STAMP=".ghosttykit-tag"
+# Same idea for zmx, kept separate because the two move independently.
+ZMX_TAG_STAMP=".zmx-tag"
 # Marker for the downloaded upstream resources. The tarball mirrors a real
 # Ghostty.app Resources layout: ghostty/{themes,shell-integration} plus a
 # sibling terminfo/. All come from the tarball — nothing is committed — so its
@@ -191,7 +206,23 @@ fi
 if [[ -d "$RESOURCES_MARKER" ]] && ! $tag_changed; then
   need_resources=false
 fi
-[[ -x "$ZMX_BIN" ]] && need_zmx=false
+# Presence alone is not enough: a checkout (or a restored CI cache) can hold a
+# zmx from before the pin moved, and that binary is wrong in a way nothing else
+# notices — it silently lacks wire features Macterm depends on.
+zmx_stamped_tag=""
+[[ -f "$ZMX_TAG_STAMP" ]] && zmx_stamped_tag=$(cat "$ZMX_TAG_STAMP")
+if [[ -x "$ZMX_BIN" ]]; then
+  if [[ -z "$zmx_stamped_tag" ]]; then
+    # Unstamped: provenance unknown, and every checkout predating the pin looks
+    # like this. Refresh once so it becomes knowable, rather than warning
+    # forever about a binary nobody can identify.
+    echo "Bundled zmx is unstamped (provenance unknown); installing $ZMX_TAG"
+  elif [[ "$zmx_stamped_tag" != "$ZMX_TAG" ]]; then
+    echo "Pinned zmx release changed ($zmx_stamped_tag -> $ZMX_TAG); refreshing"
+  else
+    need_zmx=false
+  fi
+fi
 
 if ! $need_xcframework && ! $need_resources && ! $need_zmx; then
   echo "GhosttyKit, resources, and zmx already present"
@@ -277,15 +308,22 @@ if $need_zmx; then
   # universal app build. Shipped as a tarball (preserves the executable bit
   # through the GitHub asset round-trip) holding a single `zmx` binary;
   # extracted to Macterm/Resources/zmx/zmx (gitignored).
-  ZMX_TAG=$(gh release list --repo "$ZMX_REPO" --limit 1 --json tagName -q ".[0].tagName")
-  if [[ -z "$ZMX_TAG" ]]; then
-    echo "Error: No zmx releases found in $ZMX_REPO" >&2
-    exit 1
+  if [[ "$ZMX_TAG" == "latest" ]]; then
+    resolved_zmx_tag=$(gh release list --repo "$ZMX_REPO" --limit 1 --json tagName -q ".[0].tagName")
+    if [[ -z "$resolved_zmx_tag" ]]; then
+      echo "Error: No zmx releases found in $ZMX_REPO" >&2
+      exit 1
+    fi
+    echo "ZMX_TAG=latest resolved to $resolved_zmx_tag"
+  else
+    resolved_zmx_tag="$ZMX_TAG"
   fi
-  gh release download "$ZMX_TAG" --pattern "zmx-universal-macos.tar.gz" --repo "$ZMX_REPO"
+  gh release download "$resolved_zmx_tag" --pattern "zmx-universal-macos.tar.gz" --repo "$ZMX_REPO"
   rm -rf Macterm/Resources/zmx
   mkdir -p Macterm/Resources/zmx
   tar xzf zmx-universal-macos.tar.gz -C Macterm/Resources/zmx
   chmod +x Macterm/Resources/zmx/zmx
   rm zmx-universal-macos.tar.gz
+  # Stamp only what this run actually installed, mirroring $TAG_STAMP.
+  printf '%s\n' "$resolved_zmx_tag" > "$ZMX_TAG_STAMP"
 fi


### PR DESCRIPTION
## What

Focusing a mirrored pane now sends zmx's leadership claim, so the pty resizes to the pane the user just moved to.

## Why

#349 and #350 landed mirroring and the dim, but without the last link: zmx hands leadership only to a client that sends **real user input**, so a dimmed mirror stayed dimmed until you typed into it. Clicking one did nothing — which is the interaction the feature exists for.

Needs thdxg/zmx#4, released as `build-2026-09-06`. **Anyone with an existing checkout must `rm -rf Macterm/Resources/zmx && mise run setup`** — `setup.sh` guards that download with a presence check, so a stale binary is never refreshed and claim-on-focus will silently do nothing against it.

Closes the interactive half of #345.

## How

**The claim goes out unconditionally for a mirrored local pane**, not only when we believe leadership needs to move. `handleClaim` is a no-op for a client that already leads (it sends no size request), so the redundant case costs nothing — and sending anyway is what re-synchronises us whenever our model and the daemon have drifted: an inferred leader after restore, or a foreign `zmx attach` that took leadership silently. That turns #350's documented known-gap into a self-healing one for any pane the user actually clicks.

**Debounced by 150ms.** A claim costs a pty resize, a SIGWINCH and a full TUI redraw, and focus is noisy: `mouseDown` reports it twice per click (directly, then again via `becomeFirstResponder`), and `FocusRestoration` retries across run-loop ticks. Cmd-tabbing past a window must not reflow the program twice. The *model* still updates immediately, so the dim moves with the click and only the wire message waits.

**The write bypasses `sendText`.** That path records command-submission evidence driving `TerminalExecutionTracker` — execution state, the tab status glyph, tab naming via `shellIsAtPrompt` — and a sequence the user never typed must leave it untouched, or a following Return would read as submitting content that does not exist. `sendControlSequence` rides the key path with only `.text` set, which libghostty writes verbatim under both its legacy and kitty encoders (no keycode, so no CSI-u translation). Deliberately **not** `ghostty_surface_text`: that routes to `completeClipboardPaste`, which would wrap the sequence in bracketed paste and run it past the unsafe-paste check.

**It refuses before the surface has a real size.** `setLeader` answers a claim by asking the client for its window size, so claiming from a surface that has not laid out yet (an off-screen tab, the incubator) would resize the *shared* pty to a placeholder for every mirror at once.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run e2e`, 25 passed)
- [x] Added or updated tests for new model / persistence / palette / hotkey logic

`test_focusing_a_mirror_resizes_the_shared_pty_to_it` walks the entire chain — focus → Macterm claim → zmx `ClaimFilter` → `handleClaim` → `setLeader` → size request → `TIOCSWINSZ` — and **fails when the claim send is removed**, so it is not vacuous.

Two things make that measurement honest, and the first cost me a wrong result before I noticed:

- **The size is read from a loop already running in the session, never by typing.** Typing is exactly what zmx's own leadership rule reacts to, so a `pane run` issued *to measure* hands leadership to the pane it ran in and always reports that pane's width. The observation would create the result it claims to find. My first draft did this and "passed" the first assertion for entirely the wrong reason.
- **The split is skewed to 0.72.** At 50/50 the two mirrors are the same width and a working claim is indistinguishable from a broken one.

Also verified the shipped artifact rather than just my local build: downloaded `build-2026-09-06`, confirmed it is universal, and ran the two-PTY harness against the release binary *and* against the copy inside the built app bundle.

## Notes for reviewers

**Remote panes are excluded, deliberately.** Their zmx lives on the host and may predate the `Claim` tag, in which case the client forwards the APC to the shell and the user gets visible garbage on their prompt. Knowing otherwise needs a per-host `zmx --version` probe, cached and gated behind `backgroundSSHConnections` like every other background ssh op (#272). Until then a remote mirror keeps zmx's own behaviour, where typing into it transfers leadership — so the feature degrades rather than misbehaves.

`ZmxLeadership.claimSequence` is a **wire contract** with `util.ClaimFilter.sequence` in the zmx fork, not a local constant; a unit test pins it. Drift means claims get typed into the user's shell instead of switching leadership.