### PR TITLE
chore(deps): bump GhosttyKit to build-2026-09-06

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -22,7 +22,7 @@ XCFRAMEWORK_DIR="GhosttyKit.xcframework"
 # including the nightly sync — deletes and recreates it with different bytes,
 # the exact asset-swap-under-a-pin hazard documented in AGENTS.md. The next
 # ordinary bump (a past-day daily tag, immutable by then) retires this one.
-GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-08-31}"
+GHOSTTYKIT_TAG="${GHOSTTYKIT_TAG:-build-2026-09-06}"
 # The zmx release supplying the bundled session multiplexer. Pinned for the same
 # reason GhosttyKit is: thdxg/zmx publishes a build-YYYY-MM-DD release on every
 # push to its main, so tracking `latest` meant two builds of ONE Macterm commit


### PR DESCRIPTION
Moves the pinned `thdxg/ghostty` release (`GHOSTTYKIT_TAG` in `scripts/setup.sh`) from `build-2026-08-31` to `build-2026-09-06`.

**CI on this PR is the gate.** Editing `scripts/setup.sh` changes the GhosttyKit cache key, so this run downloads the new pin from scratch and exercises it through Unit, End-to-end, and the benchmark — rather than a release being the first thing to try it.

Compare upstream: [`build-2026-08-31...build-2026-09-06`](https://github.com/thdxg/ghostty/compare/build-2026-08-31...build-2026-09-06)

---

### GhosttyKit API review — `build-2026-08-31` → `build-2026-09-06`

Filtered to the **171** `ghostty_*`/`GHOSTTY_*` symbols Macterm's own sources reference and the header defines.

#### ✅ No symbol we use was removed

#### No changed hunk touches a symbol we use

<sub>0 changed header lines total; 0 hunk(s) touch symbols we use. A green CI run means it builds and the suites pass — not that no behaviour moved.</sub>
