### PR TITLE
feat: give the sidebar more room by default

### DIFF
--- a/Macterm/App/Preferences.swift
+++ b/Macterm/App/Preferences.swift
@@ -407,7 +407,7 @@ final class Preferences {
     /// `MainWindow`'s `navigationSplitViewColumnWidth` so a stored value can
     /// never fall outside what the column accepts.
     static let sidebarWidthRange: ClosedRange<Double> = 140 ... 400
-    static let defaultSidebarWidth: Double = 180
+    static let defaultSidebarWidth: Double = 220
 
     /// Which appcast channel auto-updates come from. Read by `Updater`'s
     /// `allowedChannels(for:)`, so `.beta`/`.tip` make the matching prerelease

--- a/MactermTests/App/PreferencesTests.swift
+++ b/MactermTests/App/PreferencesTests.swift
@@ -94,6 +94,7 @@ struct PreferencesTests {
     @Test
     func sidebar_width_is_clamped_to_the_column_bounds() {
         let range = Preferences.sidebarWidthRange
+        #expect(Preferences.defaultSidebarWidth == 220)
         #expect(Preferences.clampSidebarWidth(nil) == Preferences.defaultSidebarWidth)
         #expect(Preferences.clampSidebarWidth(0) == Preferences.defaultSidebarWidth)
         #expect(Preferences.clampSidebarWidth(range.lowerBound - 40) == range.lowerBound)


### PR DESCRIPTION
## What

Makes the default sidebar 220 points wide instead of 180.

## Why

The current default is tight enough that ordinary project and tab names start fading early. A little more room keeps the sidebar readable without taking much away from the terminal.

Apple does not prescribe a fixed sidebar width. Its [sidebar](https://developer.apple.com/design/human-interface-guidelines/sidebars) and [split view](https://developer.apple.com/design/human-interface-guidelines/split-views) guidance focuses on reasonable pane sizes while keeping sidebars resizable and hideable. This keeps MacTerm's existing 140 to 400 point range, resizing, hiding, and width restoration unchanged.

## How

Only the fallback width changes. Fresh installs, or profiles without a saved width, start at 220 points.

An existing saved width remains authoritative, including 180 points if that is what someone chose.

## Verified

- [x] `mise run setup`, `mise run format`, `mise run lint`, and `mise run test` pass
- [x] Added a regression assertion for the 220 point default
- [x] Launched an isolated profile with synthetic projects and confirmed the sidebar restored to 220 points
- [x] Compared the same labels at 180 and 220 points
- [x] Confirmed existing saved widths still pass through unchanged

## Notes for reviewers

The screenshots use temporary local projects and synthetic tab names.

Current 180 point default:

<img src="https://github.com/user-attachments/assets/de1fc8b0-2e47-494f-a75d-91a09bf39b68" width="180" alt="Current 180 point sidebar with several ordinary names fading">

Proposed 220 point default:

<img src="https://github.com/user-attachments/assets/b83929b1-e037-42a5-8c61-e8ffc3e7b35a" width="220" alt="Proposed 220 point sidebar with ordinary names shown in full">

Full window at 220 points:

![MacTerm with the proposed 220 point sidebar](https://github.com/user-attachments/assets/00e7aea6-4f4b-4ef1-bfde-fde10ed379a9)
