### PR TITLE
Silence the strict-concurrency warnings in the tint cutout and color menu

### DIFF
--- a/Macterm/Views/ProjectColorMenu.swift
+++ b/Macterm/Views/ProjectColorMenu.swift
@@ -10,11 +10,17 @@ import SwiftUI
 /// palette's selection ring is what marks the current color.
 struct ProjectColorMenu: View {
     let selection: ProjectColor?
-    let onSelect: (ProjectColor?) -> Void
+    let onSelect: @MainActor (ProjectColor?) -> Void
 
     var body: some View {
         Menu("Color") {
-            Picker("Color", selection: Binding(get: { selection }, set: onSelect)) {
+            // `Binding.set` is `@isolated(any) @Sendable`, so `onSelect` has to
+            // be main-actor-isolated to reach it without a data-race warning —
+            // but it must be *called* from a closure literal rather than passed
+            // as `set: onSelect`. Handing the function value over directly asks
+            // for a reabstraction thunk into `@isolated(any)`, and IRGen
+            // crashes emitting it (observed on Swift 6.3.3).
+            Picker("Color", selection: Binding(get: { selection }, set: { onSelect($0) })) {
                 ForEach(ProjectColor.allCases, id: \.self) { color in
                     Label(color.displayName, systemImage: "circle.fill")
                         .tint(MactermTheme.color(for: color))

--- a/Macterm/Views/WindowAppearance.swift
+++ b/Macterm/Views/WindowAppearance.swift
@@ -122,6 +122,7 @@ struct TintCutout {
 
     /// Cut `view` (a tinted layer) to the regions, which are in `container`'s
     /// coordinates.
+    @MainActor
     func apply(to view: NSView, in container: NSView) {
         guard let layer = view.layer else { return }
         guard !holes.isEmpty else {


### PR DESCRIPTION
## What

Resolves the five Swift 6 strict-concurrency warnings that had accumulated in the build log — four in `TintCutout`, one in `ProjectColorMenu`. No behavior change.

## Why

They fire on every build of both targets (they showed up twice in the archive log, once under `Macterm` and once under `MactermCLI`), so a real new warning would have had to be spotted in the noise.

## How

Two separate isolation gaps.

**`TintCutout.apply`** is a method on a plain struct, so it's nonisolated, and every `NSView` member it touches — `layer`, `bounds` (×2), `convert(_:from:)` — warned. Both call sites (`MactermTintBackdropView`, `MactermGlassView`) are inside `NSView` subclasses on the main actor, so `apply` gets `@MainActor`, matching how `rendererQuantizedAlpha` directly above it is already annotated. `set` stays nonisolated — it touches nothing isolated and is just a change check.

**`ProjectColorMenu.onSelect`** feeds SwiftUI's `Binding.set`, which now takes `@isolated(any) @Sendable`; converting a non-Sendable function value to it is the warning. Both callers only invoke a main-actor `projectStore.setColor`, so the stored closure is now `@MainActor`.

One wrinkle worth a reviewer's attention: the obvious follow-through — leaving `set: onSelect` alone once the closure is `@MainActor` — **crashes the compiler**. Handing the function value over directly asks IRGen to emit a reabstraction thunk into `@isolated(any)`, and swift-frontend hits `report_fatal_error` emitting `@$s7Macterm12ProjectColorOSgScA_pSgIeAghyg_ADIeAghn_TR` (observed on Swift 6.3.3). Calling it from a closure literal instead — `set: { onSelect($0) }` — forms the closure at the target type with no thunk. There's a comment at the site so nobody collapses it back to the shorter spelling.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Full Debug build is warning-clean (the only line left matching `warning:` is `appintentsmetadataprocessor`'s unrelated "No AppIntents.framework dependency found")

## Notes for reviewers

Not separately exercised in the running app — both changes are isolation annotations with no runtime effect, and the color menu is covered by the fact that it compiles at all (a wrong isolation here would be an error, not a warning).
