### PR TITLE
Lead with lightweight and vertical tabs in the project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 
 <p align="center">
-  A macOS terminal with session persistence, smart multiplexing, and native UI. Built on libghostty.
+  A lightweight macOS terminal with vertical tabs, session persistence, and native UI. Built on libghostty
 
 </p>
 

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -114,7 +114,7 @@
     <section class="l-wrap l-hero">
       <h1>
         Macterm
-        <span class="l-lede">A beautiful macOS terminal with vertical tabs, session persistence, and native UI. Built on libghostty</span>
+        <span class="l-lede">A lightweight macOS terminal with vertical tabs, session persistence, and native UI. Built on libghostty</span>
       </h1>
 
       <div class="l-cta-row">


### PR DESCRIPTION
Aligns the one-line project description across the README and the website hero on a single wording:

> A lightweight macOS terminal with vertical tabs, session persistence, and native UI. Built on libghostty

Previously the two disagreed — the README said "session persistence, smart multiplexing" while the site's hero lede said "A beautiful macOS terminal with vertical tabs". The new line leads with *lightweight* and names *vertical tabs*, which is the first thing a reader sees in a screenshot.

## Changed

- `README.md` — the tagline under the title
- `website/public/index.html` — the hero lede

## Notes for a reviewer

The longer SEO `<meta>` descriptions and the JSON-LD blocks in `index.html` are deliberately untouched — they are prose written for search results, not the tagline. The GitHub repo description is set outside the repo and isn't updated here.