### PR TITLE
Show live star and download counts in the website navbar

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -105,8 +105,8 @@
     </a>
     <nav class="l-nav">
       <a href="/docs/">Docs</a>
-      <a href="https://github.com/thdxg/macterm">GitHub</a>
-      <a data-download-latest class="l-cta" href="https://github.com/thdxg/macterm/releases/latest">Download</a>
+      <a href="https://github.com/thdxg/macterm">GitHub<span data-stat-stars hidden class="l-count" title="GitHub stars"><svg class="l-count-icon" width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .587l3.668 7.431 8.2 1.192-5.934 5.786 1.401 8.169L12 18.896l-7.335 3.869 1.401-8.169L.132 9.21l8.2-1.192z"/></svg><span data-stat-stars-num>0</span><span class="sr-only"> stars</span></span></a>
+      <a data-download-latest class="l-cta" href="https://github.com/thdxg/macterm/releases/latest">Download<span data-stat-downloads hidden class="l-count" title="Total downloads across every release"><svg class="l-count-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg><span data-stat-downloads-num>0</span><span class="sr-only"> downloads</span></span></a>
     </nav>
   </header>
 

--- a/website/public/site.js
+++ b/website/public/site.js
@@ -101,9 +101,12 @@
 // unauthenticated budget is 60 requests/hour per *visitor* IP, and the site
 // spends at most three of them (one per figure below), so the ceiling that
 // matters is a single reader browsing the docs. Two things keep that in
-// bounds: every figure is fetched only when the page actually displays it (a
-// docs page shows only the Download button, so it spends one), and each is
-// cached in localStorage for an hour. Anything that fails — offline, rate
+// bounds: every figure is fetched only when the page actually displays it
+// (both headers now show all three — stars beside GitHub, the download total
+// beside Download — so a cold page spends a handful: one for stars, one for
+// the latest release, and one per hundred releases for the total), and each
+// is cached in localStorage for an hour, so a docs reader clicking between
+// pages pays once. Anything that fails — offline, rate
 // limited, storage blocked — leaves the stat hidden and the button on its
 // static /releases/latest href, which is how this already degrades. ---
 (function loadStats() {

--- a/website/src/docs-template.html
+++ b/website/src/docs-template.html
@@ -46,8 +46,8 @@
     </a>
     <nav class="l-nav">
       <a href="/docs/">Docs</a>
-      <a href="https://github.com/thdxg/macterm">GitHub</a>
-      <a data-download-latest class="l-cta" href="https://github.com/thdxg/macterm/releases/latest">Download</a>
+      <a href="https://github.com/thdxg/macterm">GitHub<span data-stat-stars hidden class="l-count" title="GitHub stars"><svg class="l-count-icon" width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .587l3.668 7.431 8.2 1.192-5.934 5.786 1.401 8.169L12 18.896l-7.335 3.869 1.401-8.169L.132 9.21l8.2-1.192z"/></svg><span data-stat-stars-num>0</span><span class="sr-only"> stars</span></span></a>
+      <a data-download-latest class="l-cta" href="https://github.com/thdxg/macterm/releases/latest">Download<span data-stat-downloads hidden class="l-count" title="Total downloads across every release"><svg class="l-count-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg><span data-stat-downloads-num>0</span><span class="sr-only"> downloads</span></span></a>
     </nav>
   </header>
 

--- a/website/src/tailwind.css
+++ b/website/src/tailwind.css
@@ -170,6 +170,39 @@
     border-color: var(--l-rose);
     background: rgba(235, 188, 186, 0.08);
   }
+  /* A live figure riding beside a nav label — the star count on GitHub, the
+     all-releases download total on Download — filled by site.js's loadStats
+     and revealed only once a number has landed (`hidden` until then, so a
+     failed or rate-limited fetch leaves the label exactly as it was). Set in
+     the mono at a step down and one ink step fainter than the label, behind a
+     hairline, so it reads as data attached to the word rather than as a
+     second word; `.l-nav`'s tabular-nums is what keeps the header from
+     shifting when a cached figure is replaced by a fresh one. It is inline —
+     no `display` of its own — so the [hidden] reset stays in charge. */
+  .l-nav .l-count {
+    margin-left: 9px;
+    padding-left: 9px;
+    border-left: 1px solid var(--l-edge);
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    letter-spacing: 0.02em;
+    color: var(--l-soft);
+    transition: color 0.18s;
+  }
+  .l-nav a:hover .l-count {
+    color: inherit;
+  }
+  /* The glyph sits on the text baseline rather than the box's middle, so it
+     lines up with the digits' x-height instead of floating above them. */
+  .l-count-icon {
+    display: inline-block;
+    vertical-align: -1px;
+    margin-right: 5px;
+  }
+  .l-nav .l-cta .l-count {
+    border-left-color: rgba(235, 188, 186, 0.35);
+    color: rgba(235, 188, 186, 0.78);
+  }
 
   /* — hero — */
   .l-hero {
@@ -470,6 +503,13 @@
     }
     .l-nav {
       gap: 16px;
+    }
+    /* The header has no room to spare on a phone: measured at 375px, brand +
+       three links fill the row to the gutter with nothing left, and the two
+       counts add ~90px, so they overflowed the viewport and squeezed the
+       wordmark into "Docs". Below this breakpoint the labels stand alone. */
+    .l-nav .l-count {
+      display: none;
     }
     .l-thumbs {
       grid-template-columns: repeat(5, 128px);


### PR DESCRIPTION
## What

The navbar on the landing page and every docs page now shows the GitHub star count beside **GitHub** and the all-releases download total beside **Download**, each with a glyph in front (★ 436 · ⤓ 6.3K at the time of writing).

## Why

`site.js` has fetched these figures from api.github.com since the first redesign (#143), but the dark redesign (#343) dropped the hero markup they filled, so the stats module has been running with nothing to show. This puts the hooks back where they read best now: beside the labels they describe.

## How

- `[data-stat-stars]` / `[data-stat-downloads]` spans inside the two nav links, `hidden` until a number lands, so a failed or rate-limited fetch leaves the label exactly as it was. Icons are `aria-hidden` and a `sr-only` suffix keeps the link reading as "GitHub 436 stars".
- New `.l-count` style: mono, a step smaller and one ink step fainter than the label, behind a hairline; rose-tinted inside the Download button. `.l-nav`'s existing `tabular-nums` keeps the header from shifting when a cached figure is refreshed.
- **Phone**: measured at 375px the brand and three links already fill the row to the gutter, and the counts add ~90px — the wordmark got squeezed into "Docs" and the Download button clipped. The counts hide under the existing 640px breakpoint.
- Requests stay **unauthenticated** (no token to hide on a static site). A cold page now spends four requests — stars, latest release, one per hundred releases for the total — against the 60/hour per-visitor budget, cached in localStorage for an hour, so a docs reader clicking between pages pays once. The budget comment in `site.js` is updated to match.

## Verified

`bun run build` clean (incl. `check-seo`); previewed locally at desktop (both counts filled from the live API) and at 375px (counts hidden, header `scrollWidth == clientWidth`).
