### PR TITLE
Let the backdrop show through a preview card's split dividers

### DIFF
--- a/Macterm/Views/TabSwitcherOverlay.swift
+++ b/Macterm/Views/TabSwitcherOverlay.swift
@@ -315,12 +315,13 @@ private struct TabSwitcherCard: View {
                 // captured frames drop in uncropped.
                 .aspectRatio(Self.safeAspect(paneAspect), contentMode: .fit)
                 .frame(height: Self.previewHeight(forPaneAspect: paneAspect))
-                // The gaps between leaves are the miniature split dividers, so
-                // they need a color of their own. Left transparent they showed
-                // whatever sat behind the card — the selection fill on the
-                // selected one, the glass panel on the rest — which made two
-                // cards of the same layout read as different things.
-                .background(MactermTheme.border)
+                // The gaps between leaves are the miniature split dividers,
+                // and they are deliberately untinted: whatever sits behind the
+                // card shows through them — the selection fill on the selected
+                // one, the glass panel on the rest — so a divider reads as a
+                // gap in the picture rather than as a drawn line. That does
+                // mean two cards of the same layout differ by their backdrop,
+                // which is the intent, not a regression to fix with a fill.
                 .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)


### PR DESCRIPTION
## What

The gaps between leaves in a Tab Switcher preview card — the miniature of the split divider — are no longer tinted. Whatever sits behind the card now shows through them.

## Why

Those gaps were filled with `MactermTheme.border`, which made a divider read as a drawn line rather than as a gap in the picture. The tint was there so every card's dividers looked identical regardless of backdrop; the show-through is what's wanted instead.

## How

Dropped the `.background(MactermTheme.border)` on the `PaneMosaic` in `TabSwitcherCard`. The backdrop now reaches through: the selection fill on the selected card, the glass panel on the rest.

The comment that previously justified the fill is rewritten to record that the difference between two same-layout cards is now the intent — otherwise the next reader has a standing argument for putting the fill back.

One knock-on: the mosaic's `clipShape` corners have no fill behind them either, so the corner slivers outside each leaf's rectangle show the backdrop for the same reason. The card's 1pt `strokeBorder` is untouched.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` all pass
- [x] Built and ran the change in the app (`mise run run`) and confirmed the behavior
- [ ] Added or updated tests for new model / persistence / palette / hotkey logic

Debug build succeeds. **Not visually confirmed** — the overlay only appears while the Recent Tab chord is physically held, and synthetic keys would need an Accessibility grant, so this needs a reviewer's eyes in the running app. No tests: the change is one view modifier, and this file's layer isn't unit-tested by convention.

## Notes for reviewers

Worth a look at both states side by side — a selected card (gaps carry the `fg.opacity(0.14)` selection fill) and an unselected one (gaps carry the glass panel) — since making those two differ is exactly the behavior change.
