### PR TITLE
Make pane and tab close alerts work from the keyboard

### DIFF
--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -309,9 +309,11 @@ struct CloseConfirmationAlerts: ViewModifier {
                 Button("Cancel", role: .cancel) {
                     appState.cancelPendingClosePane()
                 }
+                .keyboardShortcut(.cancelAction)
                 Button("Close", role: .destructive) {
                     appState.confirmPendingClosePane()
                 }
+                .keyboardShortcut(.defaultAction)
             } message: {
                 Text("A process is still running in this pane. Close it anyway?")
             }
@@ -325,9 +327,11 @@ struct CloseConfirmationAlerts: ViewModifier {
                 Button("Cancel", role: .cancel) {
                     appState.cancelPendingCloseTab()
                 }
+                .keyboardShortcut(.cancelAction)
                 Button("Close", role: .destructive) {
                     appState.confirmPendingCloseTab()
                 }
+                .keyboardShortcut(.defaultAction)
             } message: {
                 Text("A process is still running in this tab. Closing the tab ends it.")
             }


### PR DESCRIPTION
## What

Makes the running-process alerts for panes and tabs work from the keyboard.

## Why

After Cmd+W, the alert takes over the UI but Return does nothing. Closing a busy tab therefore starts on the keyboard and ends with the mouse.

## How

Close now uses SwiftUI's default action and Cancel uses its cancel action. This is the same native pattern already used by MacTerm's quit confirmation and new remote project sheet.

The confirmation still appears, and no close behaviour or process detection changes.

## Verified

- [x] `mise run format`, `mise run lint`, and `mise run test` pass
- [x] Full end-to-end suite passes with 32 tests passed and 1 remote-only test skipped
- [x] Built and ran the change in an isolated app profile
- [x] Confirmed Return closes both a running pane and a running tab
- [x] Confirmed Escape cancels and leaves the process running
- [x] Confirmed the File and tab context-menu actions reach the same keyboard-enabled alert

## Notes for reviewers

The screenshots use temporary local projects and synthetic tab names.

Full window:

![Full MacTerm window showing the running-process tab alert](https://raw.githubusercontent.com/nabilfreeman/macterm/pr-assets/close-running-processes-keyboard-focus/01-close-tab-alert-full.png)

Tab alert:

![Close-up of the running-process tab alert](https://raw.githubusercontent.com/nabilfreeman/macterm/pr-assets/close-running-processes-keyboard-focus/02-close-tab-alert-detail.png)

Pane alert:

![Close-up of the running-process pane alert](https://raw.githubusercontent.com/nabilfreeman/macterm/pr-assets/close-running-processes-keyboard-focus/04-close-pane-alert-detail.png)
