### PR TITLE
Make the remaining confirmation alerts work from the keyboard

### DIFF
--- a/Macterm/App/MactermApp.swift
+++ b/Macterm/App/MactermApp.swift
@@ -221,9 +221,11 @@ struct MactermApp: App {
                     Button("Cancel", role: .cancel) {
                         appState.cancelPendingUnloadProject()
                     }
+                    .keyboardShortcut(.cancelAction)
                     Button("Unload", role: .destructive) {
                         appState.confirmPendingUnloadProject()
                     }
+                    .keyboardShortcut(.defaultAction)
                 } message: {
                     Text("A process is still running in this project. Unloading stops every process in its tabs; the layout is kept.")
                 }
@@ -237,9 +239,11 @@ struct MactermApp: App {
                     Button("Cancel", role: .cancel) {
                         appState.cancelPendingRemoveProject()
                     }
+                    .keyboardShortcut(.cancelAction)
                     Button("Remove", role: .destructive) {
                         appState.confirmPendingRemoveProject()
                     }
+                    .keyboardShortcut(.defaultAction)
                 } message: {
                     Text("A process is still running in this project. Removing it ends every process in its tabs.")
                 }
@@ -253,9 +257,11 @@ struct MactermApp: App {
                     Button("Cancel", role: .cancel) {
                         appState.cancelPendingLayoutApply()
                     }
+                    .keyboardShortcut(.cancelAction)
                     Button("Apply", role: .destructive) {
                         appState.confirmPendingLayoutApply()
                     }
+                    .keyboardShortcut(.defaultAction)
                 } message: {
                     if let pending = appState.pendingLayoutApply {
                         Text(pending.confirmationMessage)
@@ -359,9 +365,11 @@ struct ProjectConfirmationAlerts: ViewModifier {
                 Button("Cancel", role: .cancel) {
                     appState.cancelPendingUnloadProject()
                 }
+                .keyboardShortcut(.cancelAction)
                 Button("Unload", role: .destructive) {
                     appState.confirmPendingUnloadProject()
                 }
+                .keyboardShortcut(.defaultAction)
             } message: {
                 Text("A process is still running in this project. Unloading stops every process in its tabs; the layout is kept.")
             }
@@ -375,9 +383,11 @@ struct ProjectConfirmationAlerts: ViewModifier {
                 Button("Cancel", role: .cancel) {
                     appState.cancelPendingRemoveProject()
                 }
+                .keyboardShortcut(.cancelAction)
                 Button("Remove", role: .destructive) {
                     appState.confirmPendingRemoveProject()
                 }
+                .keyboardShortcut(.defaultAction)
             } message: {
                 Text("A process is still running in this project. Removing it ends every process in its tabs.")
             }
@@ -391,9 +401,11 @@ struct ProjectConfirmationAlerts: ViewModifier {
                 Button("Cancel", role: .cancel) {
                     appState.cancelPendingBulkRemove()
                 }
+                .keyboardShortcut(.cancelAction)
                 Button("Remove", role: .destructive) {
                     appState.confirmPendingBulkRemove()
                 }
+                .keyboardShortcut(.defaultAction)
             } message: {
                 Text("A process is still running in one of the selected items. Removing them ends every process in their tabs.")
             }
@@ -421,9 +433,11 @@ struct LayoutAlerts: ViewModifier {
                 Button("Cancel", role: .cancel) {
                     appState.cancelPendingLayoutApply()
                 }
+                .keyboardShortcut(.cancelAction)
                 Button("Apply", role: .destructive) {
                     appState.confirmPendingLayoutApply()
                 }
+                .keyboardShortcut(.defaultAction)
             } message: {
                 if let pending = appState.pendingLayoutApply {
                     Text(pending.confirmationMessage)

--- a/Macterm/Settings/ProjectsSettings.swift
+++ b/Macterm/Settings/ProjectsSettings.swift
@@ -112,7 +112,9 @@ struct ProjectsSettings: View {
             )
         ) {
             Button("Cancel", role: .cancel) { layoutPendingDeletion = nil }
+                .keyboardShortcut(.cancelAction)
             Button("Remove", role: .destructive) { confirmDeletion() }
+                .keyboardShortcut(.defaultAction)
         } message: {
             Text("“\(layoutPendingDeletion?.filename ?? "")” will be deleted. Projects using it are kept, but lose their saved layout.")
         }


### PR DESCRIPTION
## What

Finishes what #388 started: the other seven confirmation alerts now answer Return and Escape too.

## Why

SwiftUI's `.alert` does not promote a `role: .destructive` button to the default button, so the confirm button has no key equivalent unless one is spelled out. #388 fixed the two busy-close alerts that way, which left the app in the worse of the two states — Return closes a busy pane, but does nothing in "Unload project with running processes?" two modifiers down in the same file. A rule that holds for one dialog and not its neighbours is harder to learn than one that holds nowhere.

## How

The same two lines #388 added, applied to every remaining two-button alert:

| Alert | Where |
|---|---|
| Unload project with running processes? | main window + Settings |
| Remove project with running processes? | main window + Settings |
| Apply layout? | main window + Settings |
| Remove items with running processes? | main window |
| Remove layout file? | Settings |

Deliberately untouched:

- **Single-button "OK" alerts** (layout error, delete failure) — a lone button is already the default; adding `.defaultAction` to a `role: .cancel` button would be contradictory.
- **`Menu` items** (`SettingsView.swift:980`, `ProjectsSettings.swift:288`/`:362`) — those are menus, not alerts, and take no key equivalents.

No behaviour changes beyond the key equivalents: the same confirmations appear, staged through the same `DialogHost` gating, and the destructive action stays destructive.

## Verified

- [x] `mise run format` (no reformatting needed), `mise run lint`, `mise run test` all pass
- [x] Compiles clean — the test run builds the app target

Behavioural verification rides on #388: this is the identical construct (`.alert` with a `role: .cancel` and a `role: .destructive` button) getting the identical modifiers, and that PR was manually confirmed to make Return confirm and Escape cancel. I did not repeat the click-through on each of the seven.